### PR TITLE
Fix floating point exception in effectiveViscosity calculation

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -980,7 +980,7 @@ contains
       ! calculate effective viscosity from strain rate and flow param.
       do iCell = 1, nCells
          eEff = sqrt(exx(iCell)**2 + eyy(iCell)**2 + exx(iCell)*eyy(iCell) + exy(iCell)**2) ! effective strain rate
-         if (eEff == 0.0_RKIND) then
+         if ( (eEff == 0.0_RKIND) .or. (meanFlowParamA(iCell) == 0.0_RKIND) ) then
             effectiveViscosity(iCell) = 0.0_RKIND
          else
             effectiveViscosity(iCell) = &


### PR DESCRIPTION
If meanFlowParamA == 0.0, but eEff != 0.0, 0.0 was raised to a negative power, causing a floating point exception.