### PR TITLE
Minor fixes related to effective pressure and mu fields

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -750,9 +750,10 @@
 			<!-- uReconstructX/Y are only needed for exact restarts of HO iterative solvers -->
 			<var name="uReconstructX" packages="higherOrderVelocity"/>
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
-                        <!-- beta and efffectivePressure are only used for HO solvers -->
+                        <!-- beta, effectivePressure and muFriction are only used for HO solvers -->
 			<var name="beta" packages="higherOrderVelocity"/>
 			<var name="effectivePressure" packages="higherOrderVelocity"/>
+                        <var name="muFriction" packages="higherOrderVelocity"/>      
                         <!-- dirichletVelocityMask is only used for HO solvers -->
                         <var name="dirichletVelocityMask" packages="higherOrderVelocity"/>
                         <!-- fields only needed by SGH -->

--- a/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.cpp
+++ b/components/mpas-albany-landice/src/mode_forward/Interface_velocity_solver.cpp
@@ -1251,9 +1251,6 @@ void importFields(std::vector<std::pair<int, int> >& marineBdyExtensionMap,  dou
       elevationData[iv] = elev;
     }
 
-    bool floating = rho_ice * thicknessData[iv] + rho_ocean * bedTopographyData[iv] < 0;
-    if (floating && (effecPress_F != 0))
-      effecPressData[iv] = 0.0;
   }
 }
 


### PR DESCRIPTION
Added muFriction to the restart stream of the Registry.

Removed code in the velocity interface setting the effective pressure to zero on floating ice.