### PR TITLE
Add flood fill subroutine to mpas_li_calving.F

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1167,14 +1167,6 @@ is the value of that variable from the *previous* time level!
                 <var name="restoreThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="thickness of ice added when the config_restore_calving_front option is set to .true. (in order to maintain the calving front at its initial position)"
                 />
-                <var name="contiguousDynamicIce" type="integer" dimensions="nCells Time" units="none" time_levs="1"
-                        description="mask of contiguous dynamic ice determined from flood fill.  Used for finding icebergs."
-                        persistence="persistent"
-                />
-                <var name="contiguousDynamicIceOld" type="integer" dimensions="nCells Time" units="none" time_levs="1"
-                        description="mask from the previous iteration of contiguous dynamic ice as the algorithm advances"
-                        persistence="persistent"
-                />
                 <!-- Variables only needed for calculating diffusivity at cell centers - this is always done now so no package is attached here -->
                 <var name="normalSlopeEdge"            type="real"     dimensions="nEdges Time"
                      units="m m^{-1}"  description="normal surface slope on edges"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3392,7 +3392,7 @@ module li_calving
       allocate(seedMaskOld(nCells+1))
       seedMaskOld(:) = 0
 
-      call mpas_log_write("Flood-fill: allocated.")
+      !call mpas_log_write("Flood-fill: allocated.")
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       ! First mark grounded ice to initialize flood fill mask
@@ -3411,14 +3411,14 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
-         call mpas_log_write("Iceberg-detection flood-fill: updated masks.")
+         !call mpas_log_write("Flood-fill: updated masks.")
          newMaskCountLocal = sum(seedMask)
-         call mpas_log_write("Initialized $i cells to local mask", intArgs=(/newMaskCountLocal/))
+         !call mpas_log_write("Initialized $i cells to local mask", intArgs=(/newMaskCountLocal/))
 
          block => block % next
       end do
 
-      call mpas_log_write("Iceberg-detection flood-fill initialization complete.")
+      !call mpas_log_write("Flood-fill initialization complete.")
 
       ! Outer loop over processors (should also have a loop over blocks)
       ! Inner loop over cells on that processor
@@ -3427,11 +3427,11 @@ module li_calving
       call mpas_dmpar_sum_int(domain % dminfo, newMaskCountLocal, newMaskCountGlobal)
       globalLoopCount = 0
 
-      call mpas_log_write("Initialized $i cells to global mask", intArgs=(/newMaskCountGlobal/))
+      call mpas_log_write("Flood fill initialized $i cells to global seedMask", intArgs=(/newMaskCountGlobal/))
 
       do while (newMaskCountGlobal > 0)
          globalLoopCount = globalLoopCount + 1
-         call mpas_log_write("  Starting global processor loop $i", intArgs=(/globalLoopCount/))
+         !call mpas_log_write("  Starting global processor loop $i", intArgs=(/globalLoopCount/))
          ! First Update halos
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'growMask')
@@ -3455,14 +3455,14 @@ module li_calving
             newMaskCountLocal = 1  ! need to make sure we enter the loop
             do while (newMaskCountLocal > 0)
                localLoopCount = localLoopCount + 1
-               call mpas_log_write("    Starting local cell loop $i", intArgs=(/localLoopCount/))
+               !call mpas_log_write("    Starting local cell loop $i", intArgs=(/localLoopCount/))
 
                ! initialize
                newMaskCountLocal = 0
                seedMaskOld(:) = seedMask(:)
 
                do iCell = 1, nCellsSolve ! this gives owned cells only
-                  if ( growMask(iCell)>0 ) then  
+                  if ( growMask(iCell)>0 ) then
                      ! If it has a marked neighbor, then add it to the mask
                      do n = 1, nEdgesOnCell(iCell)
                         jCell = cellsOnCell(n, iCell)
@@ -3478,7 +3478,7 @@ module li_calving
                ! Accumulate cells added locally until we do the next global
                ! reduce
                newMaskCountLocalAccum = newMaskCountLocalAccum + newMaskCountLocal
-               call mpas_log_write("    Added $i new cells to local mask", intArgs=(/newMaskCountLocal/))
+               !call mpas_log_write("    Added $i new cells to local mask", intArgs=(/newMaskCountLocal/))
             enddo ! local mask loop
 
             block => block % next
@@ -3493,6 +3493,8 @@ module li_calving
          endif
       end do ! global loop
       deallocate(seedMaskOld)
+
+      call mpas_log_write("Flood fill complete.")
 
    end subroutine flood_fill
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -144,6 +144,7 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_data_calving', config_data_calving)
       call mpas_pool_get_config(liConfigs, 'config_number_of_blocks', config_number_of_blocks)
+
       if (trim(config_calving) == 'none') then
          return ! do nothing
       endif
@@ -214,11 +215,11 @@ module li_calving
          err = ior(err, err_tmp)
 
       elseif (trim(config_calving) == 'damagecalving') then
-          ! Does not currently support multiple blocks per processor.
-          if (config_number_of_blocks /= 0) then
-             call mpas_log_write("External velocity solvers require that config_number_of_blocks=0", MPAS_LOG_ERR)
-             err_tmp = 1
-          endif
+         ! Does not currently support multiple blocks per processor.
+         if (config_number_of_blocks /= 0) then
+            call mpas_log_write("External velocity solvers require that config_number_of_blocks=0", MPAS_LOG_ERR)
+            err_tmp = 1
+         endif
          err = ior(err,err_tmp)
          call damage_calving(domain, err_tmp)
          err = ior(err, err_tmp)
@@ -3250,8 +3251,8 @@ module li_calving
 
       call mpas_timer_start("iceberg detection")
       call mpas_log_write("Iceberg-detection flood-fill begin.")
-            ! Allocate needed scratch fields
-
+      
+      ! Allocate needed scratch fields
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3220,11 +3220,10 @@ module li_calving
       type (mpas_pool_type), pointer :: velocityPool
       type (mpas_pool_type), pointer :: scratchPool
 
-      type (field1dInteger), pointer :: contiguousDynamicIceField
-      type (field1dInteger), pointer :: contiguousDynamicIceOldField
       type (field1dInteger), pointer :: seedMaskField
       type (field1dInteger), pointer :: growMaskField
       integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
+      !integer, dimension(:), allocatable :: seedMaskOld !mask of where icebergs are removed, for debugging
 
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: thickness
@@ -3232,9 +3231,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
 
-      integer, dimension(:), pointer :: contiguousDynamicIce, contiguousDynamicIceOld
       integer, pointer :: nCells, nCellsSolve
-      integer, dimension(:), pointer :: nCellsArray
       integer :: iCell, jCell, n
       integer :: newMaskCountLocal, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: err_tmp, err
@@ -3278,7 +3275,6 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -3290,11 +3286,10 @@ module li_calving
          err = ior(err, err_tmp)
 
          call mpas_log_write("Iceberg-detection flood-fill: updated masks.")
-         contiguousDynamicIce(:) = 0  ! initialize
          newMaskCountLocal = 0
          do iCell = 1, nCellsSolve
             if (li_mask_is_grounded_ice(cellMask(iCell)) .and. li_mask_is_dynamic_ice(cellMask(iCell))) then
-               contiguousDynamicIce(iCell) = 1
+               seedMask(iCell) = 1
                newMaskCountLocal = newMaskCountLocal + 1
             endif
          enddo
@@ -3305,13 +3300,11 @@ module li_calving
 
       call mpas_log_write("Iceberg-detection flood-fill initialization complete.")
       
-      seedMask(:) = contiguousDynamicIce(:)
       where ( seedMask == 0 .and. li_mask_is_floating_ice(cellMask(:)) )
              growMask = 1
       endwhere
       call flood_fill(seedMask, growMask, domain)
       
-      contiguousDynamicIce(:) = seedMask(:)
       ! Now remove any ice that was not flood-filled - these are icebergs
       block => domain % blocklist
       do while (associated(block))
@@ -3319,20 +3312,20 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-         call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
-         call mpas_pool_get_array(geometryPool, 'contiguousDynamicIceOld', contiguousDynamicIceOld)
          call mpas_pool_get_dimension(geometryPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
+         !allocate(seedMaskOld(nCells+1)) ! debug: make this a mask of where icebergs were removed
+         !seedMaskOld(:) = 0
 
-         contiguousDynamicIceOld(:) = 0
+         localIcebergCellCount = 0
          do iCell = 1, nCellsSolve
-            if (contiguousDynamicIce(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
+            if (seedMask(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
-               !contiguousDynamicIceOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
+               localIcebergCellCount = localIcebergCellCount + 1
+               !seedMaskOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
             endif
          enddo
-         localIcebergCellCount = sum(contiguousDynamicIceOld)
 
          block => block % next
       end do
@@ -3346,6 +3339,7 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       ! clean up
+      !deallocate(seedMaskOld) !un-comment for debugging
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.false.)
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.false.)
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
@@ -3359,8 +3353,9 @@ module li_calving
 !> \brief  Flood fill routine to differentiate ice sheet from icebergs, critically damaged regions, etc. 
 !> The calling routine defines the seedMask to specify the initial masked region, and the growMask 
 !> to specify the potential region to be filled by the flood-fill routine. The flood-fill routine
-!> then adds the contiguous areas of the growMask to the seedMask to produce the final mask, which
-!> is passed back to the calling routine for application.
+!> then adds the contiguous areas of the growMask to the seedMask, which is passed back to the 
+!> calling routine for application. Any integer fields in Registry can be used for seedMask and
+!> growMask, but there are existing variables with those names that can be used.
 !> \author Trevor Hillebrand and Matthew Hoffman
 !> \date   March 2021
 !> \details 
@@ -3382,9 +3377,7 @@ module li_calving
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), allocatable :: seedMaskOld
 
-      integer, dimension(:), pointer :: contiguousDynamicIce, contiguousDynamicIceOld
       integer, pointer :: nCells, nCellsSolve
-      integer, dimension(:), pointer :: nCellsArray
       integer :: iCell, jCell, n
       integer :: newMaskCountLocal, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: err_tmp, err
@@ -3408,7 +3401,6 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
-         call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -3420,14 +3412,7 @@ module li_calving
          err = ior(err, err_tmp)
 
          call mpas_log_write("Iceberg-detection flood-fill: updated masks.")
-         contiguousDynamicIce(:) = 0  ! initialize
-         newMaskCountLocal = 0
-         do iCell = 1, nCellsSolve
-            if ( seedMask(iCell) > 0 ) then
-               contiguousDynamicIce(iCell) = 1
-               newMaskCountLocal = newMaskCountLocal + 1
-            endif
-         enddo
+         newMaskCountLocal = sum(seedMask)
          call mpas_log_write("Initialized $i cells to local mask", intArgs=(/newMaskCountLocal/))
 
          block => block % next
@@ -3449,7 +3434,6 @@ module li_calving
          call mpas_log_write("  Starting global processor loop $i", intArgs=(/globalLoopCount/))
          ! First Update halos
          call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'contiguousDynamicIce')
          call mpas_dmpar_field_halo_exch(domain, 'growMask')
          call mpas_dmpar_field_halo_exch(domain, 'seedMask')
          call mpas_timer_stop("halo updates")
@@ -3464,10 +3448,7 @@ module li_calving
             call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
-            call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
-            call mpas_pool_get_array(geometryPool, 'contiguousDynamicIceOld', contiguousDynamicIceOld)
             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-            call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
             ! initialize local loop
             localLoopCount = 0
@@ -3480,7 +3461,7 @@ module li_calving
                newMaskCountLocal = 0
                seedMaskOld(:) = seedMask(:)
 
-               do iCell = 1, nCellsArray(1) ! this gives owned cells only
+               do iCell = 1, nCellsSolve ! this gives owned cells only
                   if ( growMask(iCell)>0 ) then  
                      ! If it has a marked neighbor, then add it to the mask
                      do n = 1, nEdgesOnCell(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -217,7 +217,7 @@ module li_calving
       elseif (trim(config_calving) == 'damagecalving') then
          ! Does not currently support multiple blocks per processor.
          if (config_number_of_blocks /= 0) then
-            call mpas_log_write("External velocity solvers require that config_number_of_blocks=0", MPAS_LOG_ERR)
+            call mpas_log_write("damagecalving requires that config_number_of_blocks=0", MPAS_LOG_ERR)
             err_tmp = 1
          endif
          err = ior(err,err_tmp)
@@ -3265,14 +3265,8 @@ module li_calving
       call mpas_allocate_scratch_field(growMaskField, single_block_in = .false.)
       growMask => growMaskField % array
 
-      call mpas_pool_get_field(geometryPool, 'contiguousDynamicIce', contiguousDynamicIceField)
-      call mpas_allocate_scratch_field(contiguousDynamicIceField, single_block_in = .false.)
-
-      call mpas_pool_get_field(geometryPool, 'contiguousDynamicIceOld', contiguousDynamicIceOldField)
-      call mpas_allocate_scratch_field(contiguousDynamicIceOldField, single_block_in = .false.)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      !allocate(seedMask(nCells+1))
-      !allocate(growMask(nCells+1))
+      
       seedMask(:) = 0
       growMask(:) = 0
 
@@ -3335,15 +3329,10 @@ module li_calving
             if (contiguousDynamicIce(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
-               contiguousDynamicIceOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
+               !contiguousDynamicIceOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
             endif
          enddo
          localIcebergCellCount = sum(contiguousDynamicIceOld)
-
-!         where(contiguousDynamicIce == 0 .and. li_mask_is_dynamic_ice(cellMask))
-!            calvingThickness = calvingThickness + thickness  ! remove any remaining ice here
-!            thickness = 0.0_RKIND
-!         end where
 
          block => block % next
       end do
@@ -3357,12 +3346,8 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       ! clean up
-      call mpas_deallocate_scratch_field(contiguousDynamicIceField, single_block_in=.false.)
-      call mpas_deallocate_scratch_field(contiguousDynamicIceOldField, single_block_in=.false.)
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.false.)
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.false.)
-      !deallocate(seedMask)
-      !deallocate(growMask)
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
       call mpas_timer_stop("iceberg detection")
    end subroutine remove_icebergs
@@ -3371,7 +3356,11 @@ module li_calving
 !
 !    routine flood_fill
 !
-!> \brief  Flood fill routine to differentiate ice sheet from icebergs
+!> \brief  Flood fill routine to differentiate ice sheet from icebergs, critically damaged regions, etc. 
+!> The calling routine defines the seedMask to specify the initial masked region, and the growMask 
+!> to specify the potential region to be filled by the flood-fill routine. The flood-fill routine
+!> then adds the contiguous areas of the growMask to the seedMask to produce the final mask, which
+!> is passed back to the calling routine for application.
 !> \author Trevor Hillebrand and Matthew Hoffman
 !> \date   March 2021
 !> \details 
@@ -3389,12 +3378,6 @@ module li_calving
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: velocityPool
 
-      type (field1dInteger), pointer :: contiguousDynamicIceField
-      type (field1dInteger), pointer :: contiguousDynamicIceOldField
-
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness    !thickness of ice that calves (computed in this subroutine)
-      real (kind=RKIND), dimension(:), pointer :: thickness
-      integer, dimension(:), pointer :: cellMask
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), allocatable :: seedMaskOld
@@ -3406,7 +3389,6 @@ module li_calving
       integer :: newMaskCountLocal, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: err_tmp, err
       integer :: globalLoopCount, localLoopCount
-      integer :: localIcebergCellCount, globalIcebergCellCount
 
       err = 0
 
@@ -3416,11 +3398,6 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       allocate(seedMaskOld(nCells+1))
       seedMaskOld(:) = 0
-      call mpas_pool_get_field(geometryPool, 'contiguousDynamicIce', contiguousDynamicIceField)
-      call mpas_allocate_scratch_field(contiguousDynamicIceField, single_block_in = .false.)
-
-      call mpas_pool_get_field(geometryPool, 'contiguousDynamicIceOld', contiguousDynamicIceOldField)
-      call mpas_allocate_scratch_field(contiguousDynamicIceOldField, single_block_in = .false.)
 
       call mpas_log_write("Flood-fill: allocated.")
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -3431,7 +3408,6 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
-         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
@@ -3488,13 +3464,11 @@ module li_calving
             call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
-            call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
             call mpas_pool_get_array(geometryPool, 'contiguousDynamicIce', contiguousDynamicIce)
             call mpas_pool_get_array(geometryPool, 'contiguousDynamicIceOld', contiguousDynamicIceOld)
             call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
             call mpas_pool_get_dimension(meshPool, 'nCellsArray', nCellsArray)
 
-            !allocate(seedMaskOld(nCells+1))
             ! initialize local loop
             localLoopCount = 0
             newMaskCountLocal = 1  ! need to make sure we enter the loop
@@ -3538,8 +3512,6 @@ module li_calving
          endif
       end do ! global loop
       deallocate(seedMaskOld)
-      call mpas_deallocate_scratch_field(contiguousDynamicIceField, single_block_in=.false.)
-      call mpas_deallocate_scratch_field(contiguousDynamicIceOldField, single_block_in=.false.)
 
    end subroutine flood_fill
 


### PR DESCRIPTION
This PR moves the flood-fill code from remove_icebergs into its own generalized subroutine called flood_fill. The seed and grow masks are defined in the calling routine and passed to the flood fill routine. It is currently called by remove_icebergs and apply_calving_damage_threshold. In the future, it should be called by von Mises and float-kill calving routines in order to avoid calving over subglacial lakes.