### PR TITLE
Add speed limit option on von Mises calving

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -184,6 +184,10 @@
                         description="If true, then ice from small grounded islands is removed.  Specifically, this finds one- and two-cell masses of ice that are surrounded by open ocean and eliminates them by sending them to the calving flux.  Grounded such ice masses would be islands, floating would be icebergs.  The ice removed is added to the calvingThickness field."
 	                possible_values=".true. or .false."
 		/>
+		<nml_option name="config_calving_speed_limit" type="real" default_value="100.0" units="m s^{-1}"
+			description="Limit calvingVelocity to this value. Currently only supported for von Mises calving."
+			possible_values="Any positive real value"
+		/>
 		<nml_option name="config_grounded_von_Mises_threshold_stress" type="real" default_value="1.0e6" units="Pa"
 			    description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on grounded ice. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
 			    possible_values="Any positive real value"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1505,7 +1505,7 @@ module li_calving
                                         velocityPool, scratchPool, thermalPool
       real (kind=RKIND), pointer :: config_grounded_von_Mises_threshold_stress, &
                                     config_floating_von_Mises_threshold_stress, &
-                                    config_flowLawExponent
+                                    config_flowLawExponent, config_calving_speed_limit
       logical, pointer :: config_use_Albany_flowA_eqn_for_vM
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin, &
                                         calvingVelocity, thickness, &
@@ -1525,10 +1525,9 @@ module li_calving
       applyToFloating = .true.
       applyToGroundingLine = .false.
 
-      call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', &
-              config_grounded_von_Mises_threshold_stress)
-      call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', &
-              config_floating_von_Mises_threshold_stress)
+      call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
+      call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
+      call mpas_pool_get_config(liConfigs, 'config_calving_speed_limit', config_calving_speed_limit)
 
       if ( config_grounded_von_Mises_threshold_stress <=  0.0_RKIND ) then
          call mpas_log_write("config_grounded_von_Mises_threshold_stress must be >0.0", MPAS_LOG_ERR)
@@ -1594,16 +1593,17 @@ module li_calving
 
              ! Calculate calving velocity for grounded cells at marine margin
              if ( .not. li_mask_is_floating_ice(cellMask(iCell)) ) then
-                calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
-                                         vonMisesStress(iCell) / config_grounded_von_Mises_threshold_stress
+                calvingVelocity(iCell) = min(sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
+                                         vonMisesStress(iCell) / config_grounded_von_Mises_threshold_stress, config_calving_speed_limit)
              ! If config_floating_von_Mises_threshold_stress is not 0.0, calculate
              ! calvingVelocity. If config_floating_von_Mises_threshold_stress is
              ! 0.0, remove floating ice in loop below.
-             elseif (li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
-                calvingVelocity(iCell) = sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
-                                         vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress
+             elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
+                calvingVelocity(iCell) = min(sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
+                                         vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress, config_calving_speed_limit)
              endif
           enddo
+
 
           call mpas_log_write("calling li_apply_front_ablation_velocity from von Mises stress calving routine")
          ! Convert calvingVelocity to calvingThickness


### PR DESCRIPTION
It is necessary to set an upper limit on calving velocity when using the von Mises calving parameterization to avoid a positive feedback between ice velocity and calving rates. Testing on the Humboldt_1to10km_r04_20210615 mesh using the following namelist settings gave the desired results:
    config_calving = 'von_Mises_stress'
    config_grounded_von_Mises_threshold_stress = 100.0 ! set very low to ensure speed limit is applied
    config_floating_von_Mises_threshold_stress = 100.0
    config_calving_speed_limit = 9.51e-05 !3km/yr

![image](https://user-images.githubusercontent.com/17446278/125120025-1b7ce280-e0af-11eb-9140-ff44d728507e.png)

Areas with calvingVelocity == 0.0 either have no ice or tensile von Mises stress is 0.0.