### PR TITLE
Zero calvingThickness in li_calve_ice

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -192,7 +192,18 @@ module li_calving
             block => block % next
          end do
       endif
-
+      
+      ! Zero calvingThickness here instead of in individual subroutines.
+      ! This is necessary when using damage threshold calving with other      
+      ! calving routines
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         calvingThickness(:) = 0.0_RKIND
+   
+         block => block % next
+      end do
       ! compute calvingThickness based on the calving_config option
       if (trim(config_calving) == 'thickness_threshold') then
 
@@ -3005,8 +3016,6 @@ module li_calving
       call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
       growMask => growMaskField % array
       growMask(:) = 0
-
-      calvingThickness(:) = 0.0_RKIND
 
       ! define seed and grow masks for flood fill.
       where ( li_mask_is_dynamic_margin(cellMask) .and. (damage .ge. config_damage_calving_threshold) )


### PR DESCRIPTION
Zero calvingThickness in calving driver routine before calling individual calving routines. This is necessary
for combining von Mises or eigencalving with damage threshold calving. I tested this with the Humboldt_1to10km_r04_20210615 mesh, using q=1/5 basal friction law exponent, ISMIP6 grounded front ablation, MIROC5 climate forcing, 20 m/yr sub-shelf melt tuning, von Mises threshold stress of 170 kPa and got the same results as with an executable compiled on MALI-Dev/develop commit d0c28677
Orange curve is with this branch, blue is MALI-Dev/develop (from Humboldt Glacier ensemble).
![image](https://user-images.githubusercontent.com/17446278/132951838-7dbd44d1-eefb-46b3-9800-2e738cd08cff.png)
