### PR TITLE
Add damage to advection scheme

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -42,7 +42,7 @@
 		<dim name="nISMIP6OceanLayers" units="unitless"
 		     description="The number of layers in the ISMIP6 ocean temperature dataset."
 		/>
-		<dim name="maxTracersAdvect" definition="1" units="unitless"
+		<dim name="maxTracersAdvect" definition="2" units="unitless"
 		     description="The maximum number of tracers to be advected."
 		/>
 		<dim name="nRegions" definition="1" units="unitless"
@@ -195,6 +195,10 @@
                 <nml_option name="config_floating_von_Mises_threshold_stress" type="real" default_value="1.0e6" units="Pa"
                             description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on floating ice. Generally seems to need to be low (1e5 to 2e5 for Humboldt Glacier) to allow floating ice to retreat. If set to 0.0, floating ice will be removed from dynamic cells each timestep; calvingThickness will be correct, but calvingVelocity will not be correct for those cells. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
                             possible_values="Any positive real value"
+                />
+		<nml_option name="config_damage_advection" type="logical" default_value=".false." units="unitless"
+                        description="If true, then damage will be advected."
+		            possible_values=".true. or .false."
                 />
 		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".true." units="unitless"
                         description="If true, then the 'li_finalize_damage_after_advection' subroutine is applied, doing the following: 1) set the value of damage at the grounding line based on the choice of 'config_damage_gl_setting', 2) reset the value of damage to its initial value (to avoid healing), based on choice of 'config_preserve_damage', 3) couple the updated damage value to the rheology if 'config_damage_rheology_coupling' is true."

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -937,8 +937,14 @@ module li_advection
       character (len=StrKIND), pointer :: &
            config_thermal_solver
 
+      logical, pointer :: &
+           config_damage_advection
+
       integer, pointer :: &
            nCells                     ! number of cells
+
+      integer, pointer :: &
+           nVertLevels      ! number of vertical layers
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
@@ -955,19 +961,24 @@ module li_advection
       real (kind=RKIND), dimension(:), pointer :: &
            thickness                  ! ice thickness
 
+      real (kind=RKIND), dimension(:), pointer :: &
+           damage ! damage
+
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
 
-      integer :: iCell, iTracer
+      integer :: iCell, iTracer, k
 
       ! get dimensions
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       ! get arrays from mesh pool
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
 
       ! get arrays from geometry pool
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'damage', damage)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -978,6 +989,7 @@ module li_advection
 
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(liConfigs, 'config_damage_advection', config_damage_advection)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
 
       ! initialize
@@ -1037,7 +1049,23 @@ module li_advection
 
       endif
 
-      ! Note: Other tracers (e.g., ice age or damage) can be added here as needed.
+      if (config_damage_advection) then
+
+         ! increment the tracer index
+         iTracer = iTracer + 1
+
+         ! copy 2d damage to all vertical levels in the tracer array
+         do k = 1, nVertLevels
+            advectedTracers(iTracer,k,:) = damage(:)
+         enddo
+
+         ! set damage of new ice at upper and lower surfaces to 0
+         surfaceTracers(iTracer,:) = 0.0_RKIND
+         basalTracers(iTracer,:) = 0.0_RKIND
+
+      endif
+
+      ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
 
     end subroutine tracer_setup
@@ -1097,6 +1125,9 @@ module li_advection
       character (len=StrKIND), pointer :: &
            config_thermal_solver
 
+      logical, pointer :: &
+           config_damage_advection
+
       integer, pointer :: &
            nCellsSolve                ! number of locally owned cells
 
@@ -1106,10 +1137,15 @@ module li_advection
       real (kind=RKIND), dimension(:), pointer :: &
            thickness                  ! ice thickness
 
+      real (kind=RKIND), dimension(:), pointer :: &
+           damage ! damage
+
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
            waterFrac,               & ! water fraction
            enthalpy                   ! interior ice enthalpy
+
+      real (kind=RKIND), dimension(:), pointer :: layerThicknessFractions
 
       integer :: iCell, iTracer
 
@@ -1118,9 +1154,11 @@ module li_advection
 
       ! get arrays from mesh pool
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
+      call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
 
       ! get arrays from geometry pool
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'damage', damage)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -1129,6 +1167,7 @@ module li_advection
 
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(liConfigs, 'config_damage_advection', config_damage_advection)
 
       iTracer = 1
 
@@ -1157,7 +1196,14 @@ module li_advection
 
       endif
 
-      ! Note: Other tracers (e.g., ice age or damage) can be added here as needed.
+      if (config_damage_advection) then
+         iTracer = iTracer + 1
+         do iCell = 1, nCellsSolve
+            damage(iCell) = sum(advectedTracers(iTracer,:,iCell) * layerThicknessFractions)  ! thickness-weighted average
+         enddo
+      endif
+
+      ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
 
     end subroutine tracer_finish


### PR DESCRIPTION
This merge adds damage to the advection scheme.  It only occurs if
config_damage_advection is .true., and it is .false. by default.  We may
want to change the namelist controls in the future, perhaps having
damage always advected when the damage calving scheme is on.  But this
makes it simpler for testing.

The advection scheme is 3d but damage is a 2d field.  When damage is
added to the tracer array, the 2d value is assigned at all vertical
levels.  After advection, the tracer array result is converted back to a
2d field by a layerThickness-weighted average.

Any accumulation at the ice surface or bottom is accumulated with a
damage value of 0.