### PR TITLE
Add config_restore_thickness_after_advection

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -115,7 +115,11 @@
 		<nml_option name="config_tracer_advection" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for advecting tracers."
 		            possible_values="'fo', 'none'"
-		/>
+                />
+		<nml_option name="config_restore_thickness_after_advection" type="logical" default_value=".false." units="unitless"
+			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage."
+			    possible_values=".true. or .false."
+                />
 <!-- This option to be implemented in the future.
 		<nml_option name="config_allow_additional_advance" type="logical" default_value=".true." units="none"
 		            description="Determines whether ice can advance beyond its initial extent"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -117,7 +117,7 @@
 		            possible_values="'fo', 'none'"
                 />
 		<nml_option name="config_restore_thickness_after_advection" type="logical" default_value=".false." units="unitless"
-			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage."
+			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage.  When this is true, geometry changes from surface and basal mass balance (grounded or floating) and facemelting are not retained, but changes from calving are."
 			    possible_values=".true. or .false."
                 />
 <!-- This option to be implemented in the future.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -626,6 +626,7 @@ module li_time_integration_fe
       integer, pointer :: nCells
 
       character (len=StrKIND), pointer :: config_thickness_advection
+      logical, pointer :: config_restore_thickness_after_advection
       character (len=StrKIND), pointer :: config_tracer_advection
 
       logical, pointer :: config_print_thickness_advection_info
@@ -641,6 +642,7 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_tracer_advection', config_tracer_advection)
       call mpas_pool_get_config(liConfigs, 'config_print_thickness_advection_info', config_print_thickness_advection_info)
+      call mpas_pool_get_config(liConfigs, 'config_restore_thickness_after_advection', config_restore_thickness_after_advection)
 
       dminfo => domain % dminfo
 
@@ -793,6 +795,13 @@ module li_time_integration_fe
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         
+         ! restore thickness if using config_restore_thickness_after_advection
+         if ( config_restore_thickness_after_advection ) then
+            call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+            call mpas_pool_get_array(geometryPool, 'thicknessOld', thicknessOld)
+            thickness(:) = thicknessOld(:)
+         endif
 
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          call li_update_geometry(geometryPool)


### PR DESCRIPTION
This namelist option resets thickness to the previous timestep's values
after advection has taken place. This is useful for spinning up tracer
fields like damage while holding ice thickness constant.

I tested this on the Thwaites_1to10km_r02_20210914 mesh with a damage spinup using the following namelist settings (some of which are added in PR 13: https://github.com/MALI-Dev/E3SM/pull/13):
`&velocity_solver
    config_velocity_solver = 'FO'
    config_sia_tangent_slope_calculation = 'from_vertex_barycentric'
    config_flowParamA_calculation = 'PB1982'
    config_do_velocity_reconstruction_for_external_dycore = .false.
    config_simple_velocity_type = 'uniform'
    config_use_glp = .false.
    config_nonconvergence_error = .false.
/
&advection
    config_thickness_advection = 'fo'
    config_tracer_advection = 'fo'
    config_restore_thickness_after_advection = .true.
/
&calving
    config_calving = 'none'
    config_calculate_damage = .true.
    config_damage_advection = .true.
    config_damage_calving_threshold = 1.0
    !config_damage_stiffness_min = 1.0
    config_damage_rheology_coupling = .false.
    config_damage_gl_setting = 'nye'
    config_data_calving = .false.
    config_calving_timescale = 0.0
    config_restore_calving_front = .true.
    config_remove_icebergs = .true.
    config_remove_small_islands = .true.
/
`

Damage is advecting, but thickness stays static. In these snapshots, the green damage cells represent NaNs, which are cause by a bug elsewhere that will be addressed in another PR.
![image](https://user-images.githubusercontent.com/17446278/133820732-17d01067-9e09-4c6f-94d8-d115758054ff.png)

![image](https://user-images.githubusercontent.com/17446278/133820759-2f94be1c-69a8-495f-abd6-363640da2402.png)

