### PR TITLE
Add missing variable definitions in mpas_li_time_integration_fe.F and mpas_li_calving.

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -138,6 +138,7 @@ module li_calving
       integer :: err_tmp
 
       err = 0
+      err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
       call mpas_pool_get_config(liConfigs, 'config_calving_timescale', config_calving_timescale)
@@ -975,7 +976,7 @@ module li_calving
             elseif (nIceNeighbors == 1) then
                ! check if this neighbor has any additional neighbors with ice
                nIceNeighbors2 = 0
-               nOpenOceanNeighbors = 0
+               nOpenOceanNeighbors2 = 0
                do n = 1, nEdgesOnCell(neighborWithIce)
                   jCell = cellsOnCell(n, neighborWithIce)
                   if (li_mask_is_ice(cellMask(jCell))) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -109,6 +109,7 @@ module li_time_integration_fe
       logical, pointer :: config_finalize_damage_after_advection
 
       err = 0
+      err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)


### PR DESCRIPTION
Two instances of missing err_tmp in mpas_li_calving.F and mpas_li_time_integration_fe.F, and one instance of missing nOpenOceanNeighbors2 in mpas_li_calving.F, remove_small_islands subroutine were causing code to die while timestepping.

Testing on the Thwaites_1to10km_r02_20210914 mesh indicates that these changes prevent an error that was occurring within the first few timesteps.