### PR TITLE
Add ismip6 retreat parameterization

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -705,6 +705,10 @@
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6RunoffPrevious" packages="ismip6GroundedFaceMelt" />
+			<var name="ismip6_2dThermalForcingPrevious" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6RunoffCurrent" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -791,7 +795,11 @@
                         <var name="ismip6shelfMelt_offset" packages="ismip6ShelfMelt"/>
                         <!-- these variables just for ISMIP6 grounded glacier forcing -->
                         <var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
-                        <var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
+			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6RunoffPrevious" packages="ismip6GroundedFaceMelt" />
+			<var name="ismip6_2dThermalForcingPrevious" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6RunoffCurrent" packages="ismip6GroundedFaceMelt" />
+                        <var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 		</stream>
 
 
@@ -1228,7 +1236,6 @@ is the value of that variable from the *previous* time level!
                 <var name="frontAblationMask" type="integer" dimensions="nCells Time" units="none" time_levs="1" 
                      description="mask of grid cells at which front ablation will be applied. Determined by settings of applyToGrounded, applyToFloating, and applyToGroundingLine in routines that call li_apply_front_ablation_velocity."
                 />
-                />
 		<var name="faceMeltSpeed" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
 		     description="linear speed of submarine melting at grounded glacier front"
   		/>
@@ -1243,8 +1250,18 @@ is the value of that variable from the *previous* time level!
 		/>
                <var name="unmeltedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left unmelted from required facemelt flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
-		/>
-                <!--  description="Optional field of offset that should be appliped to the melt field calculated by the ISMIP6 melt method.  This field is added directly to the melt field calculated by the method and can be used to use the method in anomaly mode.  Note this field is NOT the anomaly.  Let m be the final melt field generated, m_t be the ISMIP6 melt calculation at any time, m_t0 the ISMIP6 melt at time 0, and m_0 a reference melt field (e.g. observed melt field used for initialization).  The melt anomaly would be defined as (delta m)=m_t-m_t0. Then, m=(delta m) + m_0.  Rearranging, m=m_t+(m_0-m_t0).  ismip6shelfMelt_offset is the term in parentheses.  Note that the general usage requires that the first time step be run with ismip6shelfMelt_offset=0 in order to determine m_t0, and then NCO or similar tool used to generate the (m_0-m_t0) field to be input as ismip6shelfMelt_offset in the forward run." -->
+	        />
+		<var name="ismip6_2dThermalForcingPrevious" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="0.0"
+		     description="thermal forcing for ISMIP6 retreat paramterization, from previous input time."
+	        />
+                <var name="ismip6RunoffPrevious" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"
+                     description="Runoff forcing for ISMIP6 grounded ice melting method, from previous input time" 
+	     />
+      	     <var name="ismip6_2dThermalForcingCurrent" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="0.0"
+                     description="thermal forcing for ISMIP6 retreat paramterization, from previous input time."
+                />
+                <var name="ismip6RunoffCurrent" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"
+                     description="Runoff forcing for ISMIP6 grounded ice melting method, from previous input time"
                 />
                 <var name="upliftRate"            type="real"     dimensions="nCells Time"
                      units="m s^{-1}"  description="time rate of change in bedTopography.  This field is prescribed as input and not currently calculated in the model."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -138,7 +138,7 @@
 	<nml_record name="calving" in_defaults="true">
 		<nml_option name="config_calving" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for calving ice (as defined below)."
-		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'mask', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving'"
+		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'mask', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving', 'ismip6_retreat'"
 		/>
                 <nml_option name="config_use_Albany_flowA_eqn_for_vM" type="logical" default_value=".false." units="unitless"
 			    description="Not yet supported. Determine whether to use MPAS or Albany calculation for flowParamA used in von Mises stress calving"
@@ -240,6 +240,10 @@
                         description="A scalar parameter that specifies a calving rate as proportional to the value of damage above some threshold value when using the 'calving_rate' method for the 'config_damage_calving_method' option (with the threshold damage value specified by 'config_damage_calving_threshold')."
 	                possible_values="any positive real value"
 		/>
+                <nml_option name="config_ismip6_retreat_k" type="real" default_value="-170.0" units="m (m^{3} s^{-1})^{-0.4} deg. C^{-1}"
+                            description="Coefficient for ISMIP6 retreat parameterization from Slater et al. (2019)"
+                            possible_values="any negative real value"
+                />
 	</nml_record>
 
 	<nml_record name="thermal_solver" in_defaults="true">

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -705,10 +705,6 @@
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
-                        <var name="ismip6RunoffPrevious" packages="ismip6GroundedFaceMelt" />
-			<var name="ismip6_2dThermalForcingPrevious" packages="ismip6GroundedFaceMelt" />
-                        <var name="ismip6RunoffCurrent" packages="ismip6GroundedFaceMelt" />
-                        <var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -846,6 +846,19 @@
                         <var name="regionGroupNames"/-->
 		</stream>
 
+		<!-- Input stream for use with config_calving = ismip6_retreat, which requires multiple
+		     time levels from forcing file, which could inadvertently clobber some fields if
+                     not set up carefully. So we use an immutable stream to avoid mishap. -->
+                <stream name="ismip6-gis"
+                                type="input"
+				immutable="true"
+				filename_template="ismip6-gis.nc"
+                                input_interval="0001-00-00_00:00:00">
+
+                        <var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
+			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
+		</stream>
+
 	</streams>
 
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -795,7 +795,8 @@
                         <var name="ismip6RunoffPrevious" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcingPrevious" packages="ismip6GroundedFaceMelt" />
                         <var name="ismip6RunoffCurrent" packages="ismip6GroundedFaceMelt" />
-                        <var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
+			<var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
+			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		</stream>
 
 
@@ -1056,6 +1057,9 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="timestepNumber" type="integer" dimensions="Time" units="none"
                      description="time step number.  initial time is 0."
+                />
+	        <var name="forcingTimeStamp" type="text" dimensions="" units="unitless" packages="ismip6GroundedFaceMelt" default_value="'no_date_available'"
+                     description="Time of ismip6RunoffCurrent and ismip6_2dThermalForcingCurrent, with format 'YYYY-MM-DD_HH:MM:SS."
                 />
 	</var_struct>
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1258,10 +1258,10 @@ is the value of that variable from the *previous* time level!
                      description="Runoff forcing for ISMIP6 grounded ice melting method, from previous input time" 
 	     />
       	     <var name="ismip6_2dThermalForcingCurrent" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="0.0"
-                     description="thermal forcing for ISMIP6 retreat paramterization, from previous input time."
+                     description="thermal forcing for ISMIP6 retreat parameterization, at current input time."
                 />
                 <var name="ismip6RunoffCurrent" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"
-                     description="Runoff forcing for ISMIP6 grounded ice melting method, from previous input time"
+                     description="Runoff forcing for ISMIP6 grounded ice melting method, for current input time"
                 />
                 <var name="upliftRate"            type="real"     dimensions="nCells Time"
                      units="m s^{-1}"  description="time rate of change in bedTopography.  This field is prescribed as input and not currently calculated in the model."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -854,6 +854,7 @@
                                 type="input"
 				immutable="true"
 				filename_template="ismip6-gis.nc"
+				reference_time="1950-07-01_00:00:00"
                                 input_interval="0001-00-00_00:00:00">
 
                         <var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1741,13 +1741,13 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
-      real (kind=RKIND), dimension(:), allocatable :: TFoceanPrevious, ismip6RunoffPrevious
-      real (kind=RKIND), dimension(:), allocatable :: TFoceanCurrent, ismip6RunoffCurrent
+      real (kind=RKIND), dimension(:), pointer :: TFoceanPrevious, ismip6RunoffPrevious
+      real (kind=RKIND), dimension(:), pointer :: TFoceanCurrent, ismip6RunoffCurrent
       real (kind=RKIND), dimension(:), allocatable :: submergedArea
       real (kind=RKIND) :: deltatForcing ! time between forcing updates
-      type (MPAS_Time_Type) :: forcingTime, forcingTimeOld ! times from forcing file as time types
-      character(len=StrKIND) :: forcingTimeStamp, forcingTimeOldStamp ! times from forcing file as strings
-      type (MPAS_Alarm_type), pointer :: alarm_cursor
+      type (MPAS_Time_Type), save :: forcingTime, forcingTimeOld
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
+      character(len=StrKIND) :: forcingTimeStamp, forcingTimeOldStamp
       type (MPAS_stream_list_type), pointer :: stream_cursor
 
       applyToGrounded = .true.
@@ -1765,6 +1765,8 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'xtime', xtime)
+      call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -1776,31 +1778,20 @@ module li_calving
       call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
       call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
       call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
+      call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcingPrevious', TFoceanPrevious)
+      call mpas_pool_get_array(geometryPool, 'ismip6RunoffPrevious', ismip6RunoffPrevious)
+      call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcingCurrent', TFoceanCurrent)
+      call mpas_pool_get_array(geometryPool, 'ismip6RunoffCurrent', ismip6RunoffCurrent)
       
-      ! Variables to separate previous and current thermal forcing and runoff fields
-      allocate(TFoceanPrevious(nCells+1))
-      allocate(ismip6RunoffPrevious(nCells+1))
-      allocate(TFoceanCurrent(nCells+1))
-      allocate(ismip6RunoffCurrent(nCells+1))
+      ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
 
       stream_cursor => domain % streamManager % streams % head
       do while (associated(stream_cursor))
-         if (stream_cursor % direction == MPAS_STREAM_INPUT) then
-            ! Only consider streams of direction input (don't consider input/output streams)
-            if ((trim(stream_cursor % name) == 'input') .or. &
-                (trim(stream_cursor % name) == 'restart')) then
-               ! Don't attempt to interact with these two special streams
-               ! (even though restart is not type input, including to be safe)
-               stream_cursor => stream_cursor % next
-               cycle
-            endif
-
-            if (trim(stream_cursor % name) == 'ismip-gis') then
-               ! We found the stream we are looking for
-               ! Force a read of this stream, and use the most recent time available in the file.
-               ! TODO: Determine whether there is a smarter way to do this that doesn't require
-               ! reading this stream every timestep.
+         if (trim(stream_cursor % name) == 'ismip-gis') then
+            if (xtime == simulationStartTime) then
+               ! At the beginning of the simulations, force a read of this stream,
+               ! and use the most recent time available in the file.
                call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
                                          whence = MPAS_STREAM_LATEST_BEFORE, saveActualWhen= .true., ierr=err_tmp)
 
@@ -1809,32 +1800,50 @@ module li_calving
                TFoceanCurrent = TFocean
                ismip6RunoffCurrent = ismip6Runoff
 
-               call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
-                                   "' from time: " // trim(forcingTimeStamp))
+               call mpas_log_write("  * Forced a read of input stream 'ismip6-gis'" // &
+                                   " from time: " // trim(forcingTimeStamp))
                ! Force a read of this stream, and use the second most recent time in the file
                call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
-                            when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)
+                                when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)
 
                call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
 
                TFoceanPrevious = TFocean
                ismip6RunoffPrevious = ismip6Runoff
 
-               call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
-                                   "' from time: " // trim(forcingTimeOldStamp))
+               call mpas_log_write("  * Forced a read of input stream 'ismip6-gis'" // &
+                                         " from time: " // trim(forcingTimeOldStamp))
 
                call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
                call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               ! reset mostRecentAccessTime to enable elseif block below
+               call mpas_set_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
                err = ior(err, err_tmp)
-               exit ! skip the rest of this loop - we processed the stream we were looking for
-            endif
-         end if ! if stream direction is INPUT
 
+               ! Do not overwrite forcing fields with values from previous time
+               ismip6Runoff = ismip6RunoffCurrent
+               TFocean = TFoceanCurrent
+            elseif (forcingTime < stream_cursor % mostRecentAccessTime) then
+               TFoceanPrevious = TFoceanCurrent
+               ismip6RunoffPrevious = ismip6RunoffCurrent
+               TFoceanCurrent = TFocean
+               ismip6RunoffCurrent = ismip6Runoff
+
+               forcingTimeOld = forcingTime
+               forcingTime = stream_cursor % mostRecentAccessTime
+               call mpas_get_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               call mpas_get_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
+               call mpas_log_write("  * ismip6 retreat forcings have been updated:" // &
+                                " forcingTime: " // trim(forcingTimeStamp) //  &
+                                "; forcingTimeOld: " // trim(forcingTimeOldStamp))
+            else
+               call mpas_log_write(" * No new forcing times for ismip6 retreat this timestep.")
+            endif
+            exit ! We have processed the stream we wanted.
+         endif
          stream_cursor => stream_cursor % next
-      end do
-      ! Do not overwrite forcing fields with values from previous time
-      ismip6Runoff = ismip6RunoffCurrent
-      TFocean = TFoceanCurrent
+      enddo ! end loop over stream_cursors
 
       ! Get submerged area of each cell to convert from kg m^{-2} s^{-1} to m^3 s^{-1}
       submergedArea(:) = 0.0_RKIND
@@ -1894,10 +1903,6 @@ module li_calving
       err = ior(err, err_tmp)
       call remove_small_islands(meshPool, geometryPool)
 
-      deallocate(TFoceanPrevious)
-      deallocate(ismip6RunoffPrevious)
-      deallocate(TFoceanCurrent)
-      deallocate(ismip6RunoffCurrent)
       deallocate(submergedArea)
 
    end subroutine ismip6_retreat

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -254,6 +254,11 @@ module li_calving
          call specified_calving_velocity(domain, err_tmp)
          err = ior(err, err_tmp)
 
+      elseif (trim(config_calving) == 'ismip6_retreat') then
+
+         call ismip6_retreat(domain, err_tmp)
+         err = ior(err, err_tmp)
+
       else
 
          call mpas_log_write("Invalid option for config_calving specified: " // trim(config_calving), MPAS_LOG_ERR)
@@ -1681,26 +1686,26 @@ module li_calving
 !
 !    routine ismip6_retreat
 !
-!> /brief Use ISMIP6 retreat parameterization for Greenland (Slater et al.,
-!2019, 2020).
+!> /brief Use ISMIP6 retreat parameterization for Greenland (Slater et al., 2019, 2020).
 !> /author Trevor Hillebrand
 !> /date November 2021
 !> /details This routine applies the ISMIP6 glacier retreat parateterization
-!> based on ocean thermal forcing and subglacial discharge. 
+!> based on ocean thermal forcing and subglacial discharge.
 !> Slater, D. A., Straneo, F., Felikson, D., Little, C. M., Goelzer, H.,
 !> Fettweis, X., & Holte, J. (2019).
 !> Estimating Greenland tidewater glacier retreat driven by submarine melting.
 !> The Cryosphere, 13(9), 2489-2509.
 !> https://doi.org/10.5194/tc-13-2489-2019
 !> Slater, D. A., Felikson, D., Straneo, F., Goelzer, H., Little, C. M.,
-!> Morlighem, M., et al. (2020). 
+!> Morlighem, M., et al. (2020).
 !> Twenty-first century ocean forcing of the Greenland ice sheet for modelling
-!> of sea level contribution. 
+!> of sea level contribution.
 !> The Cryosphere, 14(3), 985-1008. https://doi.org/10.5194/tc-14-985-2020
    subroutine ismip6_retreat(domain, err) 
 
       use li_diagnostic_vars
-
+      use mpas_timekeeping
+      use mpas_stream_manager
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -1719,61 +1724,167 @@ module li_calving
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-      integer :: iCell, jCell, iNeighbor, nGroundedNeighbors, err_tmp
+      integer :: iCell, jCell, iEdge, iNeighbor, err_tmp
       type (block_type), pointer :: block
-      integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnCell
       type (mpas_pool_type), pointer :: geometryPool, meshPool, &
-                                        velocityPool, scratchPool, thermalPool
-      real (kind=RKIND), pointer :: config_ismip6_retreat_k
+                                        velocityPool
+      real (kind=RKIND), pointer :: config_ismip6_retreat_k, seaLevel
       real (kind=RKIND), dimension(:), pointer ::  &
                                         calvingVelocity, thickness, &
-                                        xvelmean, yvelmean, calvingThickness
-       integer, pointer :: nCells
-      integer, dimension(:), pointer :: cellMask
+                                        xvelmean, yvelmean, calvingThickness, &
+                                        bedTopography
+      integer, pointer :: nCells
+      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:), pointer :: cellMask, nEdgesOnCell
+      real (kind=RKIND) :: waterDepth
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
       real (kind=RKIND), dimension(:), allocatable :: TFoceanPrevious, ismip6RunoffPrevious
+      real (kind=RKIND), dimension(:), allocatable :: TFoceanCurrent, ismip6RunoffCurrent
+      real (kind=RKIND), dimension(:), allocatable :: submergedArea
       real (kind=RKIND) :: deltatForcing ! time between forcing updates
-      type (MPAS_Time_Type) :: forcingTime, forcingTimeOld !timestamp from forcing file
+      type (MPAS_Time_Type) :: forcingTime, forcingTimeOld ! times from forcing file as time types
+      character(len=StrKIND) :: forcingTimeStamp, forcingTimeOldStamp ! times from forcing file as strings
+      type (MPAS_Alarm_type), pointer :: alarm_cursor
+      type (MPAS_stream_list_type), pointer :: stream_cursor
 
       applyToGrounded = .true.
       applyToFloating = .true.
       applyToGroundingLine = .false.
 
       call mpas_pool_get_config(liConfigs, 'config_ismip6_retreat_k', config_ismip6_retreat_k)
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       ! get fields
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_array(velocityPool, 'xvelmean', xvelmean)
-      call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      ! Get ISMIP6 forcing fields for this time
+      call mpas_pool_get_array(velocityPool, 'xvelmean', xvelmean)
+      call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
       call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
       call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
-      ! Read in previous thermal forcing and runoff fields
+      
+      ! Variables to separate previous and current thermal forcing and runoff fields
       allocate(TFoceanPrevious(nCells+1))
       allocate(ismip6RunoffPrevious(nCells+1))
+      allocate(TFoceanCurrent(nCells+1))
+      allocate(ismip6RunoffCurrent(nCells+1))
+      allocate(submergedArea(nCells+1))
 
-      ! When model time passes a new forcing time, update calvingVelocity
-      !if (forcingTime .ne. forcingTimeOld) then
+      stream_cursor => domain % streamManager % streams % head
+      do while (associated(stream_cursor))
+         if (stream_cursor % direction == MPAS_STREAM_INPUT) then
+            ! Only consider streams of direction input (don't consider input/output streams)
+            if ((trim(stream_cursor % name) == 'input') .or. &
+                (trim(stream_cursor % name) == 'restart')) then
+               ! Don't attempt to interact with these two special streams
+               ! (even though restart is not type input, including to be safe)
+               stream_cursor => stream_cursor % next
+               cycle
+            endif
+
+            ! Only force a read of streams that are recurring.  To find out if a stream is recurring, we need to
+            ! get its input alarm.  To find the alarm, loop over the alarms in the stream manager's clock until we find it.
+            alarm_cursor => domain % streamManager % streamClock % alarmListHead
+            do while (associated(alarm_cursor))
+               if (trim(stream_cursor % name) == 'ismip-gis') then
+                  ! We found the stream we are looking for
+                  if (alarm_cursor % isRecurring) then
+                     ! Force a read of this stream, and use the most recent time available in the file.
+                     ! TODO: Determine whether there is a smarter way to do this that doesn't require 
+                     ! reading this stream every timestep.
+                     call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
+                          whence = MPAS_STREAM_LATEST_BEFORE, saveActualWhen= .true., ierr=err_tmp)
+
+                     call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+
+                     TFoceanCurrent = TFocean
+                     ismip6RunoffCurrent = ismip6Runoff
+
+                     call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
+                           "' from time: " // trim(forcingTimeStamp))
+                     ! Force a read of this stream, and use the second most recent time in the file
+                     call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
+                            when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)
+
+                     call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+
+                     TFoceanPrevious = TFocean
+                     ismip6RunoffPrevious = ismip6Runoff
+
+                     call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
+                           "' from time: " // trim(forcingTimeOldStamp))
+
+                     call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+                     call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+                     err = ior(err, err_tmp)
+                  endif
+                  exit ! skip the rest of this loop - we processed the alarm we were looking for
+               endif
+               alarm_cursor => alarm_cursor % next
+            end do
+         end if ! if stream direction is INPUT
+
+         stream_cursor => stream_cursor % next
+      end do
+      ! Do not overwrite forcing fields with values from previous time
+      ismip6Runoff = ismip6RunoffCurrent
+      TFocean = TFoceanCurrent
+
+      ! Get submerged area of each cell to convert from kg m^{-2} s^{-1} to m^3 s^{-1}
+      submergedArea(:) = 0.0_RKIND
+      do iCell = 1, nCells
+         if ( li_mask_is_dynamic_margin(cellMask(iCell)) .and. bedTopography(iCell) < seaLevel ) then
+            waterDepth = max(0.0_RKIND, seaLevel - bedTopography(iCell))
+            do iNeighbor = 1, nEdgesOnCell(iCell)
+               iEdge = edgesOnCell(iNeighbor, iCell)
+               jCell = cellsOnCell(iNeighbor, iCell)
+               ! sum up length of edges adjacent to open ocean or non-dynamic cells
+               if ( (.not. li_mask_is_dynamic_ice(jCell)) &
+                       .and. (bedTopography(jCell) < seaLevel) ) then
+                  submergedArea(iCell) = submergedArea(iCell) + dvEdge(iEdge) * waterDepth
+               endif
+            enddo
+         endif
+      enddo
+
+      ! Get the time between forcings to calculate retreat rate.
+      call mpas_get_timeInterval(forcingTime - forcingTimeOld, dt=deltatForcing)
+      call mpas_log_write("deltatForcing = $r", realArgs = (/deltatForcing/))
+
+      ! This if-statement is probably unnecessary, but this ensures there is no divide-by-zero error
+      ! if somehow deltatForcing = 0.0.
+      if (forcingTime .ne. forcingTimeOld) then
          do iCell=1, nCells
-            calvingVelocity(iCell) = config_ismip6_retreat_k * ( (ismip6Runoff(iCell)**0.4_RKIND * TFocean(iCell)) -  &
-                                     (ismip6RunoffPrevious(iCell)**0.4_RKIND * TFoceanPrevious(iCell)) ) / deltatForcing
+            ! For now, hard-coding factor of 4.0 to roughly convert mean annual to mean summer runoff.
+            ! Factor of 1000.0 is freshwater density.
+            calvingVelocity(iCell) = max(-1.0_RKIND * config_ismip6_retreat_k * ( ( (4.0_RKIND * submergedArea(iCell) &
+                                         * ismip6Runoff(iCell) / 1000.0_RKIND)**0.4_RKIND * TFocean(iCell) ) -  &
+                                         ( (4.0_RKIND * submergedArea(iCell) * ismip6RunoffPrevious(iCell) / 1000.0_RKIND)**0.4_RKIND &
+                                         * TFoceanPrevious(iCell) ) ) / deltatForcing + &
+                                         sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND), 0.0_RKIND)
          enddo
-      !endif
+      endif
 
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
       ! Convert calvingVelocity to calvingThickness
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, err)
+
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_timer_start("halo updates")
@@ -1782,6 +1893,7 @@ module li_calving
 
       ! === apply calving ===
       thickness(:) = thickness(:) - calvingThickness(:)
+
       ! update mask
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
       err = ior(err, err_tmp)
@@ -1789,6 +1901,9 @@ module li_calving
 
       deallocate(TFoceanPrevious)
       deallocate(ismip6RunoffPrevious)
+      deallocate(TFoceanCurrent)
+      deallocate(ismip6RunoffCurrent)
+      deallocate(submergedArea)
 
    end subroutine ismip6_retreat
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1796,46 +1796,38 @@ module li_calving
                cycle
             endif
 
-            ! Only force a read of streams that are recurring.  To find out if a stream is recurring, we need to
-            ! get its input alarm.  To find the alarm, loop over the alarms in the stream manager's clock until we find it.
-            alarm_cursor => domain % streamManager % streamClock % alarmListHead
-            do while (associated(alarm_cursor))
-               if (trim(stream_cursor % name) == 'ismip-gis') then
-                  ! We found the stream we are looking for
-                  if (alarm_cursor % isRecurring) then
-                     ! Force a read of this stream, and use the most recent time available in the file.
-                     ! TODO: Determine whether there is a smarter way to do this that doesn't require 
-                     ! reading this stream every timestep.
-                     call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
-                          whence = MPAS_STREAM_LATEST_BEFORE, saveActualWhen= .true., ierr=err_tmp)
+            if (trim(stream_cursor % name) == 'ismip-gis') then
+               ! We found the stream we are looking for
+               ! Force a read of this stream, and use the most recent time available in the file.
+               ! TODO: Determine whether there is a smarter way to do this that doesn't require
+               ! reading this stream every timestep.
+               call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
+                                         whence = MPAS_STREAM_LATEST_BEFORE, saveActualWhen= .true., ierr=err_tmp)
 
-                     call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
 
-                     TFoceanCurrent = TFocean
-                     ismip6RunoffCurrent = ismip6Runoff
+               TFoceanCurrent = TFocean
+               ismip6RunoffCurrent = ismip6Runoff
 
-                     call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
-                           "' from time: " // trim(forcingTimeStamp))
-                     ! Force a read of this stream, and use the second most recent time in the file
-                     call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
+               call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
+                                   "' from time: " // trim(forcingTimeStamp))
+               ! Force a read of this stream, and use the second most recent time in the file
+               call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
                             when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)
 
-                     call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
 
-                     TFoceanPrevious = TFocean
-                     ismip6RunoffPrevious = ismip6Runoff
+               TFoceanPrevious = TFocean
+               ismip6RunoffPrevious = ismip6Runoff
 
-                     call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
-                           "' from time: " // trim(forcingTimeOldStamp))
+               call mpas_log_write("  * Forced a read of input stream '" // trim(stream_cursor%name) // &
+                                   "' from time: " // trim(forcingTimeOldStamp))
 
-                     call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
-                     call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
-                     err = ior(err, err_tmp)
-                  endif
-                  exit ! skip the rest of this loop - we processed the alarm we were looking for
-               endif
-               alarm_cursor => alarm_cursor % next
-            end do
+               call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
+               exit ! skip the rest of this loop - we processed the stream we were looking for
+            endif
          end if ! if stream direction is INPUT
 
          stream_cursor => stream_cursor % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1679,6 +1679,120 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!    routine ismip6_retreat
+!
+!> /brief Use ISMIP6 retreat parameterization for Greenland (Slater et al.,
+!2019, 2020).
+!> /author Trevor Hillebrand
+!> /date November 2021
+!> /details This routine applies the ISMIP6 glacier retreat parateterization
+!> based on ocean thermal forcing and subglacial discharge. 
+!> Slater, D. A., Straneo, F., Felikson, D., Little, C. M., Goelzer, H.,
+!> Fettweis, X., & Holte, J. (2019).
+!> Estimating Greenland tidewater glacier retreat driven by submarine melting.
+!> The Cryosphere, 13(9), 2489-2509.
+!> https://doi.org/10.5194/tc-13-2489-2019
+!> Slater, D. A., Felikson, D., Straneo, F., Goelzer, H., Little, C. M.,
+!> Morlighem, M., et al. (2020). 
+!> Twenty-first century ocean forcing of the Greenland ice sheet for modelling
+!> of sea level contribution. 
+!> The Cryosphere, 14(3), 985-1008. https://doi.org/10.5194/tc-14-985-2020
+   subroutine ismip6_retreat(domain, err) 
+
+      use li_diagnostic_vars
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: & 
+         domain          !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      integer :: iCell, jCell, iNeighbor, nGroundedNeighbors, err_tmp
+      type (block_type), pointer :: block
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell
+      type (mpas_pool_type), pointer :: geometryPool, meshPool, &
+                                        velocityPool, scratchPool, thermalPool
+      real (kind=RKIND), pointer :: config_ismip6_retreat_k
+      real (kind=RKIND), dimension(:), pointer ::  &
+                                        calvingVelocity, thickness, &
+                                        xvelmean, yvelmean, calvingThickness
+       integer, pointer :: nCells
+      integer, dimension(:), pointer :: cellMask
+      logical :: applyToGrounded, applyToFloating, applyToGroundingLine
+      real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
+      real (kind=RKIND), dimension(:), allocatable :: TFoceanPrevious, ismip6RunoffPrevious
+      real (kind=RKIND) :: deltatForcing ! time between forcing updates
+      type (MPAS_Time_Type) :: forcingTime, forcingTimeOld !timestamp from forcing file
+
+      applyToGrounded = .true.
+      applyToFloating = .true.
+      applyToGroundingLine = .false.
+
+      call mpas_pool_get_config(liConfigs, 'config_ismip6_retreat_k', config_ismip6_retreat_k)
+
+      block => domain % blocklist
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      ! get fields
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(velocityPool, 'xvelmean', xvelmean)
+      call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
+      call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      ! Get ISMIP6 forcing fields for this time
+      call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
+      call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
+      ! Read in previous thermal forcing and runoff fields
+      allocate(TFoceanPrevious(nCells+1))
+      allocate(ismip6RunoffPrevious(nCells+1))
+
+      ! When model time passes a new forcing time, update calvingVelocity
+      !if (forcingTime .ne. forcingTimeOld) then
+         do iCell=1, nCells
+            calvingVelocity(iCell) = config_ismip6_retreat_k * ( (ismip6Runoff(iCell)**0.4_RKIND * TFocean(iCell)) -  &
+                                     (ismip6RunoffPrevious(iCell)**0.4_RKIND * TFoceanPrevious(iCell)) ) / deltatForcing
+         enddo
+      !endif
+
+      call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
+      ! Convert calvingVelocity to calvingThickness
+      call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
+                                              calvingThickness, calvingVelocity, applyToGrounded, &
+                                              applyToFloating, applyToGroundingLine, domain, err)
+      ! Update halos on calvingThickness before applying it.
+      ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+      call mpas_timer_stop("halo updates")
+
+      ! === apply calving ===
+      thickness(:) = thickness(:) - calvingThickness(:)
+      ! update mask
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      err = ior(err, err_tmp)
+      call remove_small_islands(meshPool, geometryPool)
+
+      deallocate(TFoceanPrevious)
+      deallocate(ismip6RunoffPrevious)
+
+   end subroutine ismip6_retreat
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !    routine li_apply_front_ablation_velocity
 !
 !> \brief Convert a calving or melting velocity to an ice thickness removal

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1869,6 +1869,9 @@ module li_calving
                                          * TFoceanPrevious(iCell) ) ) / deltatForcing + &
                                          sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND), 0.0_RKIND)
          enddo
+      else ! throw an error if the forcing times are the same
+          call mpas_log_write("Forcings used in ismip6_retreat have the same timestamp. Check xtime in the input file(s).")
+          err = 1
       endif
 
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -259,8 +259,8 @@ module li_calving
       elseif (trim(config_calving) == 'ismip6_retreat') then
 
          if (trim(config_front_mass_bal_grounded) .ne. 'none') then
-            call mpas_log_write('config_front_mass_bal_grounded must be set to `none` '// &
-                                'when config_calving = `ismip6_retreat`.')
+            call mpas_log_write("config_front_mass_bal_grounded must be set to 'none' '// &
+                                'when config_calving = 'ismip6_retreat'.", MPAS_LOG_ERR)
             err = 1
          else
             call ismip6_retreat(domain, err_tmp)
@@ -1872,8 +1872,8 @@ module li_calving
 
       ! check that the ismip6-gis stream was found
       if (.not. streamFound) then
-         call mpas_log_write('Error: Input stream ismip6-gis is required for config_calving = ismip6_retreat, ' // &
-                             'but was not found.')
+         call mpas_log_write('Input stream ismip6-gis is required for config_calving = ismip6_retreat, ' // &
+                             'but was not found.', MPAS_LOG_ERR)
          err = 1
       endif
       ! Get submerged area of each cell to convert from kg m^{-2} s^{-1} to m^3 s^{-1}

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1837,6 +1837,9 @@ module li_calving
       enddo ! end loop over stream_cursors
 
       ! Get submerged area of each cell to convert from kg m^{-2} s^{-1} to m^3 s^{-1}
+      ! TODO: ensure that this unit conversion is still appropriate when we
+      ! eventually use this subroutine with fields passed from the E3SM coupler
+      ! rather than external ISMIP6 forcings.
       submergedArea(:) = 0.0_RKIND
       do iCell = 1, nCells
          if ( li_mask_is_dynamic_margin(cellMask(iCell)) .and. bedTopography(iCell) < seaLevel ) then
@@ -1863,6 +1866,9 @@ module li_calving
          do iCell=1, nCells
             ! For now, hard-coding factor of 4.0 to roughly convert mean annual to mean summer runoff.
             ! Factor of 1000.0 is freshwater density.
+            ! TODO: ensure that this scaling factor is still appropriate when we
+            ! eventually use this subroutine with fields passed from the E3SM coupler
+            ! rather than external ISMIP6 forcings.
             calvingVelocity(iCell) = max(-1.0_RKIND * config_ismip6_retreat_k * ( ( (4.0_RKIND * submergedArea(iCell) &
                                          * ismip6Runoff(iCell) / 1000.0_RKIND)**0.4_RKIND * TFocean(iCell) ) -  &
                                          ( (4.0_RKIND * submergedArea(iCell) * ismip6RunoffPrevious(iCell) / 1000.0_RKIND)**0.4_RKIND &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1858,7 +1858,7 @@ module li_calving
 
       ! Get the time between forcings to calculate retreat rate.
       call mpas_get_timeInterval(forcingTime - forcingTimeOld, dt=deltatForcing)
-      call mpas_log_write("deltatForcing = $r", realArgs = (/deltatForcing/))
+      call mpas_log_write("ismip6 retreat deltatForcing = $r", realArgs = (/deltatForcing/))
 
       ! This if-statement is probably unnecessary, but this ensures there is no divide-by-zero error
       ! if somehow deltatForcing = 0.0.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1816,9 +1816,6 @@ module li_calving
 
                call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
                call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
-               ! reset mostRecentAccessTime to enable elseif block below
-               call mpas_set_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
-               err = ior(err, err_tmp)
 
                ! Do not overwrite forcing fields with values from previous time
                ismip6Runoff = ismip6RunoffCurrent

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1806,7 +1806,7 @@ module li_calving
       stream_cursor => domain % streamManager % streams % head
       do while (associated(stream_cursor))
          ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
-         if (trim(stream_cursor % name) == 'ismip-gis') then
+         if (trim(stream_cursor % name) == 'ismip6-gis') then
             streamFound = .true.
             if (xtime == simulationStartTime) then
                ! Use forcing fields and time from most recent time in file, which was read on init.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1790,18 +1790,12 @@ module li_calving
       do while (associated(stream_cursor))
          if (trim(stream_cursor % name) == 'ismip-gis') then
             if (xtime == simulationStartTime) then
-               ! At the beginning of the simulations, force a read of this stream,
-               ! and use the most recent time available in the file.
-               call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
-                                         whence = MPAS_STREAM_LATEST_BEFORE, saveActualWhen= .true., ierr=err_tmp)
-
+               ! Use forcing fields and time from most recent time in file, which was read on init.
                call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
 
                TFoceanCurrent = TFocean
                ismip6RunoffCurrent = ismip6Runoff
 
-               call mpas_log_write("  * Forced a read of input stream 'ismip6-gis'" // &
-                                   " from time: " // trim(forcingTimeStamp))
                ! Force a read of this stream, and use the second most recent time in the file
                call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
                                 when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -105,7 +105,8 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
 
       ! calving-relevant config options
-      character (len=StrKIND), pointer :: config_calving
+      character (len=StrKIND), pointer :: config_calving, &
+                                          config_front_mass_bal_grounded
       logical, pointer :: config_print_calving_info, config_data_calving
       real(kind=RKIND), pointer :: config_calving_timescale
 
@@ -141,6 +142,7 @@ module li_calving
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
+      call mpas_pool_get_config(liConfigs, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
       call mpas_pool_get_config(liConfigs, 'config_calving_timescale', config_calving_timescale)
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_data_calving', config_data_calving)
@@ -256,8 +258,14 @@ module li_calving
 
       elseif (trim(config_calving) == 'ismip6_retreat') then
 
-         call ismip6_retreat(domain, err_tmp)
-         err = ior(err, err_tmp)
+         if (trim(config_front_mass_bal_grounded) .ne. 'none') then
+            call mpas_log_write('config_front_mass_bal_grounded must be set to `none` '// &
+                                'when config_calving = `ismip6_retreat`.')
+            err = 1
+         else
+            call ismip6_retreat(domain, err_tmp)
+            err = ior(err, err_tmp)
+         end if
 
       else
 
@@ -1690,7 +1698,14 @@ module li_calving
 !> /author Trevor Hillebrand
 !> /date November 2021
 !> /details This routine applies the ISMIP6 glacier retreat parateterization
-!> based on ocean thermal forcing and subglacial discharge.
+!> based on ocean thermal forcing and subglacial discharge. This routine uses multiple
+!> time-levels fields provided by ISMIP6. Once we use E3SM fields, this will need to be restructured.
+!> The routine searches for an input stream named 'ismip6-gis', from which it reads ismip6Runoff and 
+!> ismip6_2dThermalForcing fields from the previous forcing time whenever the mostRecentAccessTime
+!> attribute of the ismip6-gis stream is updated. It then calculates calvingVelocity based on
+!> the change in ismip6Runoff and ismip6_2dThermalForcing between the two most recent time-levels, and
+!> calls apply_front_ablation_velocity to calculate a calvingThickness. config_front_mass_bal_grounded
+!> must be set to 'none' when using this routine.
 !> Slater, D. A., Straneo, F., Felikson, D., Little, C. M., Goelzer, H.,
 !> Fettweis, X., & Holte, J. (2019).
 !> Estimating Greenland tidewater glacier retreat driven by submarine melting.
@@ -1739,7 +1754,6 @@ module li_calving
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
       real (kind=RKIND) :: waterDepth
       real (kind=RKIND), dimension(:), pointer :: dvEdge
-      logical :: applyToGrounded, applyToFloating, applyToGroundingLine
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
       real (kind=RKIND), dimension(:), pointer :: TFoceanPrevious, ismip6RunoffPrevious
       real (kind=RKIND), dimension(:), pointer :: TFoceanCurrent, ismip6RunoffCurrent
@@ -1749,13 +1763,15 @@ module li_calving
       character (len=StrKIND), pointer :: xtime, simulationStartTime
       character(len=StrKIND) :: forcingTimeStamp, forcingTimeOldStamp
       type (MPAS_stream_list_type), pointer :: stream_cursor
-
-      applyToGrounded = .true.
-      applyToFloating = .true.
-      applyToGroundingLine = .false.
+      logical :: streamFound ! used to throw an error if required stream is not found
 
       call mpas_pool_get_config(liConfigs, 'config_ismip6_retreat_k', config_ismip6_retreat_k)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
+
+      if (config_ismip6_retreat_k .ge. 0.0) then
+         call mpas_log_write('Error: config_ismip6_retreat_k should be negative, but is >= 0.0.')
+         err = 1
+      endif
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
@@ -1786,12 +1802,16 @@ module li_calving
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
 
+      streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error
       stream_cursor => domain % streamManager % streams % head
       do while (associated(stream_cursor))
+         ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
          if (trim(stream_cursor % name) == 'ismip-gis') then
+            streamFound = .true.
             if (xtime == simulationStartTime) then
                ! Use forcing fields and time from most recent time in file, which was read on init.
                call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
 
                TFoceanCurrent = TFocean
                ismip6RunoffCurrent = ismip6Runoff
@@ -1799,8 +1819,10 @@ module li_calving
                ! Force a read of this stream, and use the second most recent time in the file
                call mpas_stream_mgr_read(domain % streamManager, streamID = stream_cursor % name, rightNow = .true., &
                                 when = forcingTimeStamp, whence = MPAS_STREAM_LATEST_STRICTLY_BEFORE, saveActualWhen= .true., ierr=err_tmp)
+               err = ior(err, err_tmp)
 
                call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
 
                TFoceanPrevious = TFocean
                ismip6RunoffPrevious = ismip6Runoff
@@ -1809,7 +1831,9 @@ module li_calving
                                          " from time: " // trim(forcingTimeOldStamp))
 
                call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
                call mpas_set_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
 
                ! Do not overwrite forcing fields with values from previous time
                ismip6Runoff = ismip6RunoffCurrent
@@ -1823,6 +1847,7 @@ module li_calving
                forcingTimeOld = forcingTime
                forcingTime = stream_cursor % mostRecentAccessTime
                call mpas_get_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+               err = ior(err, err_tmp)
                call mpas_get_time(forcingTimeOld, dateTimeString=forcingTimeOldStamp, ierr=err_tmp)
                err = ior(err, err_tmp)
                call mpas_log_write("  * ismip6 retreat forcings have been updated:" // &
@@ -1836,6 +1861,12 @@ module li_calving
          stream_cursor => stream_cursor % next
       enddo ! end loop over stream_cursors
 
+      ! check that the ismip6-gis stream was found
+      if (.not. streamFound) then
+         call mpas_log_write('Error: Input stream ismip6-gis is required for config_calving = ismip6_retreat, ' // &
+                             'but was not found.')
+         err = 1
+      endif
       ! Get submerged area of each cell to convert from kg m^{-2} s^{-1} to m^3 s^{-1}
       ! TODO: ensure that this unit conversion is still appropriate when we
       ! eventually use this subroutine with fields passed from the E3SM coupler
@@ -1883,8 +1914,9 @@ module li_calving
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
       ! Convert calvingVelocity to calvingThickness
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
-                                              calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, err)
+                                              calvingThickness, calvingVelocity, applyToGrounded=.true., &
+                                              applyToFloating=.true., applyToGroundingLine=.false., &
+                                              domain=domain, err=err)
 
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1920,6 +1920,11 @@ module li_calving
           err = 1
       endif
 
+      ! Testing indicates this halo update is necessary before calling li_apply_front_ablation_velocity.
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'calvingVelocity')
+      call mpas_timer_stop("halo updates")
+
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
       ! Convert calvingVelocity to calvingThickness
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1750,7 +1750,7 @@ module li_calving
                                         calvingVelocity, thickness, &
                                         xvelmean, yvelmean, calvingThickness, &
                                         bedTopography
-      integer, pointer :: nCells
+      integer, pointer :: nCells, timestepNumber
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
       real (kind=RKIND) :: waterDepth
@@ -1786,6 +1786,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'xtime', xtime)
       call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
       call mpas_pool_get_array(meshPool, 'forcingTimeStamp', forcingTimeStamp)
+      call mpas_pool_get_array(meshPool, 'timestepNumber', timestepNumber)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -1806,7 +1807,7 @@ module li_calving
       allocate(submergedArea(nCells+1))
 
       ! On a restart, set forcingTime to enable elseif statement below
-      if (config_do_restart) then
+      if ( (config_do_restart) .and. (timestepNumber == 1) ) then
          call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
          err = ior(err, err_tmp)
       endif
@@ -1815,7 +1816,7 @@ module li_calving
       stream_cursor => domain % streamManager % streams % head
       do while (associated(stream_cursor))
          ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
-         if (trim(stream_cursor % name) == 'ismip6-gis') then
+         if ( trim(stream_cursor % name) == 'ismip6-gis' .and. (stream_cursor % valid) ) then
             streamFound = .true.
             if (xtime == simulationStartTime) then
                ! Use forcing fields and time from most recent time in file, which was read on init.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1745,6 +1745,7 @@ module li_calving
       type (mpas_pool_type), pointer :: geometryPool, meshPool, &
                                         velocityPool
       real (kind=RKIND), pointer :: config_ismip6_retreat_k, seaLevel
+      logical, pointer :: config_do_restart
       real (kind=RKIND), dimension(:), pointer ::  &
                                         calvingVelocity, thickness, &
                                         xvelmean, yvelmean, calvingThickness, &
@@ -1760,13 +1761,14 @@ module li_calving
       real (kind=RKIND), dimension(:), allocatable :: submergedArea
       real (kind=RKIND) :: deltatForcing ! time between forcing updates
       type (MPAS_Time_Type), save :: forcingTime, forcingTimeOld
-      character (len=StrKIND), pointer :: xtime, simulationStartTime
-      character(len=StrKIND) :: forcingTimeStamp, forcingTimeOldStamp
+      character (len=StrKIND), pointer :: xtime, simulationStartTime, forcingTimeStamp
+      character(len=StrKIND) :: forcingTimeOldStamp
       type (MPAS_stream_list_type), pointer :: stream_cursor
       logical :: streamFound ! used to throw an error if required stream is not found
 
       call mpas_pool_get_config(liConfigs, 'config_ismip6_retreat_k', config_ismip6_retreat_k)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
+      call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
 
       if (config_ismip6_retreat_k .ge. 0.0) then
          call mpas_log_write('Error: config_ismip6_retreat_k should be negative, but is >= 0.0.')
@@ -1783,6 +1785,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'xtime', xtime)
       call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
+      call mpas_pool_get_array(meshPool, 'forcingTimeStamp', forcingTimeStamp)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -1801,6 +1804,12 @@ module li_calving
       
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
+
+      ! On a restart, set forcingTime to enable elseif statement below
+      if (config_do_restart) then
+         call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
+         err = ior(err, err_tmp)
+      endif
 
       streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error
       stream_cursor => domain % streamManager % streams % head

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -459,7 +459,7 @@ module li_core
          ! will allow that.
          ! Finally, set whence to latest_before so we have piecewise-constant forcing.
          ! Could add, e.g., linear interpolation later.
-         call mpas_stream_mgr_read(domain % streamManager, whence=MPAS_STREAM_LATEST_BEFORE, ierr=err_tmp)
+         call mpas_stream_mgr_read(domain % streamManager, whence=MPAS_STREAM_LATEST_BEFORE, saveActualWhen = .true., ierr=err_tmp)
          err = ior(err, err_tmp)
          call mpas_stream_mgr_reset_alarms(domain % streamManager, direction=MPAS_STREAM_INPUT, ierr=err_tmp)
          err = ior(err, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
@@ -100,6 +100,7 @@ module li_core_interface
 
       ! Local variables
       character (len=StrKIND), pointer :: config_velocity_solver
+      character (len=StrKIND), pointer :: config_calving
       character (len=StrKIND), pointer :: config_basal_mass_bal_float
       character (len=StrKIND), pointer :: config_front_mass_bal_grounded
       character (len=StrKIND), pointer :: config_thermal_solver
@@ -119,6 +120,7 @@ module li_core_interface
 
       call mpas_pool_get_config(configPool, 'config_velocity_solver', config_velocity_solver)
       call mpas_pool_get_config(configPool, 'config_SGH', config_SGH)
+      call mpas_pool_get_config(configPool, 'config_calving', config_calving)
       call mpas_pool_get_config(configPool, 'config_write_albany_ascii_mesh', config_write_albany_ascii_mesh)
       call mpas_pool_get_config(configPool, 'config_basal_mass_bal_float', config_basal_mass_bal_float)
       call mpas_pool_get_config(configPool, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
@@ -159,10 +161,10 @@ module li_core_interface
               "'config_basal_mass_bal_float' is set to 'ismip6'")
       endif
 
-      if (trim(config_front_mass_bal_grounded) == 'ismip6') then
+      if ((trim(config_front_mass_bal_grounded) == 'ismip6') .or. (trim(config_calving) == 'ismip6_retreat')) then
          ismip6GroundedFaceMeltActive=.true.
          call mpas_log_write("The 'ismip6GroundedFaceMelt' package and assocated variables have been enabled because " // &
-               "'config_front_mass_bal_grounded' is set to 'ismip6'")
+               "'config_front_mass_bal_grounded' is set to 'ismip6' or 'config_calving' is set to 'ismip6_retreat'")
       endif
 
       if ((trim(config_thermal_solver) == 'temperature') .or. (trim(config_thermal_solver) == 'enthalpy')) then


### PR DESCRIPTION
This PR adds the ISMIP6 glacier retreat parameterization described by Slater et al. (2019, 2020), which specifies a retreat length ∆L = k * ∆(Q^0.4 * TF), where Q is the mean summer discharge from the subglacial hydrologic system, TF is ocean thermal forcing, and k is a tuning parameter. This is activated using the namelist option config_calving = 'ismip6_retreat'. For now, the tuning parameter k is set using config_ismip6_retreat_k. In the future, this could be replaced by a 2D field in an input stream, as k likely needs to be tuned individually by glacier or ice-sheet sector. The glacier margin can advance if
 ∆(Q^0.4 * TF) is negative due to a colder ocean and/or less subglacial discharge compared with previous year, but the rate of advance can never exceed ice velocity (i.e., there is no freeze-on).

Because this parameterization requires two time-levels from ismip6_2dThermalForcing and ismip6Runoff, this PR includes changes to the MPAS framework that allow easier manipulation of multiple times by adding a mostRecentAccessTime attribute to streams.

I tested this on the Humboldt_1to10km_r04_20210615 mesh using MIROC5 RCP8.5 climate, q = 1/5 basal friction law exponent, and three different values of k corresponding to the 25th, 50th, and 75th percentile values from Slater et al. (2019): -60, -170, and -370. The screenshot below shows ice thickness for k=-370, with ice fronts for k=-60 and k=-170 in white and cyan, respectively. Black contour is initial ice extent:
![image](https://user-images.githubusercontent.com/17446278/148982273-57dc3539-6fe8-480b-93f2-4de2e6248da8.png)
