### PR TITLE
Restore inadvertent deletion of FFLAGS from intel_cori-haswell.cmake

### DIFF
--- a/cime_config/machines/cmake_macros/intel_cori-haswell.cmake
+++ b/cime_config/machines/cmake_macros/intel_cori-haswell.cmake
@@ -1,3 +1,4 @@
+string(APPEND FFLAGS " -fp-model consistent -fimf-use-svml")i
 if (NOT DEBUG)
   string(APPEND FFLAGS " -O2 -debug minimal -qno-opt-dynamic-align")
 endif()


### PR DESCRIPTION
This was accidentally deleted in
66432b7db334187c8b49c07312e5d58682806e53.
Note that I am restoring the version of this line currently on master
that was updated Nov. 11, 2021, in ee9eabe95ba8d69e4f7667d006bf1fa417325a24.