### PR TITLE
Damage threshold with von Mises stress calving or eigencalving

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -244,9 +244,9 @@
 		                description="Selection of the method for initializing damage in the first floating grid cells past the grounding line: 'nye' uses Nye's zero stress criteria (Nye, 1957, Proc. R. Soc. A, 239) for defining the damage value, 'extrapolate' extrapolates values from the floating ice downstream back to the first floating cells."
 		            possible_values="'nye', 'extrapolate'"
 		/>
-		        <nml_option name="config_damage_calving_method" type="character" default_value="threshold" units="unitless"
-		                description="Selection of the method for damage calving. For 'threshold', ice with damage above the value specified by 'config_damage_calving_threshold' will be removed (currently, only if this ice is also AT a marine margin, but eventually this will be expanded to also include any ice at the threshold adjacent to cells at the marine margin). For 'calving_rate', a rate of calving is specified as proportional to the damage value above some threshold, with the constant of proportionality specified by 'config_damagecalvingParameter' and the threshold defined by config_damage_calving_threshold."
-		            possible_values="'calving_rate', 'threshold'"
+		        <nml_option name="config_damage_calving_method" type="character" default_value="none" units="unitless"
+		                description="Selection of the method for damage calving. For 'threshold', ice with damage above the value specified by 'config_damage_calving_threshold' will be removed if it is connected to the marine margin. The 'threshold' option can be combined with config_calving = 'von_Mises_stress' and config_calving = 'eigencalving'. For 'calving_rate', a rate of calving is specified as proportional to the damage value above some threshold, with the constant of proportionality specified by 'config_damagecalvingParameter' and the threshold defined by config_damage_calving_threshold. The 'calving_rate' option cannot currently be combined with other calving routines, and requires config_calving = 'damagecalving'."
+		            possible_values="'calving_rate', 'threshold', 'none'"
 		/>
     <nml_option name="config_damagecalvingParameter" type="real" default_value="1.0e-4" units="m/s"
                         description="A scalar parameter that specifies a calving rate as proportional to the value of damage above some threshold value when using the 'calving_rate' method for the 'config_damage_calving_method' option (with the threshold damage value specified by 'config_damage_calving_threshold')."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -141,7 +141,7 @@
 
 	<nml_record name="calving" in_defaults="true">
 		<nml_option name="config_calving" type="character" default_value="none" units="unitless"
-		            description="Selection of the method for calving ice (as defined below)."
+		            description="Selection of the method for calving ice (as defined below). 'von_Mises_stress' and 'eigencalving' options can be used in combination with damage threshold calving (see descrption of config_damage_calving_method for details)."
 		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'mask', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving', 'ismip6_retreat'"
 		/>
                 <nml_option name="config_use_Albany_flowA_eqn_for_vM" type="logical" default_value=".false." units="unitless"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1533,9 +1533,11 @@ module li_calving
                                         velocityPool, scratchPool, thermalPool
       real (kind=RKIND), pointer :: config_grounded_von_Mises_threshold_stress, &
                                     config_floating_von_Mises_threshold_stress, &
-                                    config_flowLawExponent, config_calving_speed_limit
+                                    config_flowLawExponent, config_calving_speed_limit, &
+                                    config_damage_calving_threshold
       character (len=StrKIND), pointer :: config_grounded_von_Mises_threshold_stress_source, &
-                            config_floating_von_Mises_threshold_stress_source
+                                          config_floating_von_Mises_threshold_stress_source
+      character (len=StrKIND), pointer :: config_damage_calving_method
       logical, pointer :: config_use_Albany_flowA_eqn_for_vM
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin, &
                                         calvingVelocity, thickness, &
@@ -1547,7 +1549,7 @@ module li_calving
       real (kind=RKIND), pointer :: config_default_flowParamA
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
-      real (kind=RKIND), dimension(:), pointer :: vonMisesStress
+      real (kind=RKIND), dimension(:), pointer :: vonMisesStress, damage
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
 
       err = 0
@@ -1562,6 +1564,8 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_calving_speed_limit', config_calving_speed_limit)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
       !call mpas_pool_get_config(liConfigs, 'config_default_flowParamA',
       !config_default_flowParamA) ! REMOVE THIS ONCE YOU CAN GET A FROM
@@ -1635,7 +1639,7 @@ module li_calving
           endif
 
           vonMisesStress(:) = 0.0_RKIND
-
+          
           ! get flowParamA from MPAS or use Albany-like equation
           if ( config_use_Albany_flowA_eqn_for_vM ) then
           !calculate Albany-type flowParamA
@@ -1645,11 +1649,16 @@ module li_calving
              call li_calculate_flowParamA(meshPool, temperature, thickness,flowParamA,err) ! Get MPAS flowParamA
           endif
 
-         !Using a depth-averaged ice viscosity parameter B_depthAvg
-         !=sum(layerThickness(:,iCell) *
-         !flowParamA(:,iCell)**(-1.0_RKIND/config_flowLawExponent), dim=1) /
-         !thickness(iCell)
-         ! Calculate effective von  Mises stress.
+
+          ! update mask
+          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+          err = ior(err, err_tmp)
+
+          !Using a depth-averaged ice viscosity parameter B_depthAvg
+          !=sum(layerThickness(:,iCell) *
+          !flowParamA(:,iCell)**(-1.0_RKIND/config_flowLawExponent), dim=1) /
+          !thickness(iCell)
+          ! Calculate effective von  Mises stress.
           calvingVelocity(:) = 0.0_RKIND
 
           do iCell = 1,nCells
@@ -1719,6 +1728,15 @@ module li_calving
              enddo
           endif
 
+          if ( trim(config_damage_calving_method) == 'threshold' ) then
+             ! remove ice exceeding damage threshold
+             call mpas_log_write('config_use_damage_calving_multiplier == .true.; &
+                                  config_damage_calving_method == threshold; &
+                                  removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
+            
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
+             err = ior(err, err_tmp)
+          endif
 
           ! === apply calving ===
           thickness(:) = thickness(:) - calvingThickness(:)
@@ -1728,7 +1746,7 @@ module li_calving
           err = ior(err, err_tmp)
 
           call remove_small_islands(meshPool, geometryPool)
-
+          
           block => block % next
 
       enddo ! associated(block)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1149,6 +1149,8 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
       real(kind=RKIND), pointer :: config_calving_eigencalving_parameter_scalar_value
       character (len=StrKIND), pointer :: config_calving_eigencalving_parameter_source
+      character (len=StrKIND), pointer :: config_damage_calving_method
+      real(kind=RKIND), pointer :: config_damage_calving_threshold
       logical, pointer :: config_print_calving_info
       real(kind=RKIND), pointer :: config_calving_thickness
       real (kind=RKIND), dimension(:), pointer :: eigencalvingParameter
@@ -1184,6 +1186,8 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_calving_eigencalving_parameter_source', &
               config_calving_eigencalving_parameter_source)
       call mpas_pool_get_config(liConfigs, 'config_calving_thickness', config_calving_thickness)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_threshold', config_damage_calving_threshold)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
       ! block loop
       block => domain % blocklist
@@ -1212,7 +1216,6 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-
 
          ! get parameter value
          if (trim(config_calving_eigencalving_parameter_source) == 'scalar') then
@@ -1243,6 +1246,15 @@ module li_calving
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, err)
+
+         if ( trim(config_damage_calving_method) == 'threshold' ) then
+             ! remove ice exceeding damage threshold
+            call mpas_log_write(' config_damage_calving_method == threshold; &
+                                  removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
+            
+            call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
+            err = ior(err, err_tmp)
+         endif
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
          ! Testing seemed to indicate this is not necessary, but I don't
@@ -1252,7 +1264,6 @@ module li_calving
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
          call mpas_timer_stop("halo updates")
-
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
 
@@ -1730,13 +1741,22 @@ module li_calving
 
           if ( trim(config_damage_calving_method) == 'threshold' ) then
              ! remove ice exceeding damage threshold
-             call mpas_log_write('config_use_damage_calving_multiplier == .true.; &
-                                  config_damage_calving_method == threshold; &
+             call mpas_log_write('config_damage_calving_method == threshold; &
                                   removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
             
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
              err = ior(err, err_tmp)
           endif
+
+          ! Update halos on calvingThickness or faceMeltingThickness before
+          ! applying it.
+          ! Testing seemed to indicate this is not necessary, but I don't
+          ! understand
+          ! why not, so leaving it.
+          ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
+          call mpas_timer_start("halo updates")
+          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+          call mpas_timer_stop("halo updates")
 
           ! === apply calving ===
           thickness(:) = thickness(:) - calvingThickness(:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1247,13 +1247,24 @@ module li_calving
                                               calvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, err)
 
-         if ( trim(config_damage_calving_method) == 'threshold' ) then
-             ! remove ice exceeding damage threshold
-            call mpas_log_write(' config_damage_calving_method == threshold; &
-                                  removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
-            
+         if ( trim(config_damage_calving_method) == 'none' ) then
+            ! do nothing
+         elseif ( trim(config_damage_calving_method) == 'threshold' ) then
+            ! remove ice exceeding damage threshold
+            call mpas_log_write('config_damage_calving_method == threshold; &
+                                 removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
+
             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
             err = ior(err, err_tmp)
+         elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
+             call mpas_log_write('config_damage_calving_method == calving_rate &
+                                  is not supported with config_calving == eigencalving', MPAS_LOG_ERR)
+             err = 1
+             return
+         else
+             call mpas_log_write('Invalid setting for config_damage_calving_method', MPAS_LOG_ERR)
+             err = 1
+             return
          endif
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
@@ -1739,13 +1750,24 @@ module li_calving
              enddo
           endif
 
-          if ( trim(config_damage_calving_method) == 'threshold' ) then
+          if ( trim(config_damage_calving_method) == 'none' ) then
+             ! do nothing
+          elseif ( trim(config_damage_calving_method) == 'threshold' ) then
              ! remove ice exceeding damage threshold
              call mpas_log_write('config_damage_calving_method == threshold; &
                                   removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
             
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
              err = ior(err, err_tmp)
+          elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
+              call mpas_log_write('config_damage_calving_method == calving_rate &
+                                   is not supported with config_calving == von_Mises_stress', MPAS_LOG_ERR)
+              err = 1
+              return
+          else
+              call mpas_log_write('Invalid setting for config_damage_calving_method', MPAS_LOG_ERR)
+              err = 1
+              return
           endif
 
           ! Update halos on calvingThickness or faceMeltingThickness before


### PR DESCRIPTION
Allow ice connected to the margin with damage exceeding a user-defined threshold value to calve while also using `config_calving = 'von_Mises_stress'` or `config_calving = 'eigencalving'`. We have found that having both rate- and damage-based calving laws active are necessary to reproduce observations at Thwaites Glacier, for example. To use this feature, set `config_damage_calving_method = 'threshold'` while using `config_calving = 'von_Mises_stress'` or `config_calving = 'eigencalving'`. Unless you are specifying damage as an input field for some reason, you will also want `config_calculate_damage = .true.`.