### PR TITLE
Add spatially variable von Mises threshold stress

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -200,6 +200,14 @@
                             description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on floating ice. Generally seems to need to be low (1e5 to 2e5 for Humboldt Glacier) to allow floating ice to retreat. If set to 0.0, floating ice will be removed from dynamic cells each timestep; calvingThickness will be correct, but calvingVelocity will not be correct for those cells. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
                             possible_values="Any positive real value"
                 />
+                <nml_option name="config_grounded_von_Mises_threshold_stress_source" type="character" default_value="scalar" units="unitless"
+                            description="Source of von MIses threshold stress value for calving from grounded ice."
+                            possible_values="'data' (read from input file), 'scalar' (specified by config_grounded_von_Mises_threshold_stress)" 
+                />
+                <nml_option name="config_floating_von_Mises_threshold_stress_source" type="character" default_value="scalar" units="unitless"
+                            description="Source of von MIses threshold stress value for calving from floating ice."
+                            possible_values="'data' (read from input file), 'scalar' (specified by config_floating_von_Mises_threshold_stress)" 
+                />
 		<nml_option name="config_finalize_damage_after_advection" type="logical" default_value=".true." units="unitless"
                         description="If true, then the 'li_finalize_damage_after_advection' subroutine is applied, doing the following: 1) set the value of damage at the grounding line based on the choice of 'config_damage_gl_setting', 2) reset the value of damage to its initial value (to avoid healing), based on choice of 'config_preserve_damage', 3) couple the updated damage value to the rheology if 'config_damage_rheology_coupling' is true."
 		            possible_values=".true. or .false."
@@ -666,6 +674,8 @@
                         <var name="surfaceAirTemperature"/>
                         <var name="basalHeatFlux"/>
                         <var name="eigencalvingParameter"/>
+                        <var name="groundedVonMisesThresholdStress"/>
+                        <var name="floatingVonMisesThresholdStress"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <var name="upliftRate"/>
@@ -754,6 +764,8 @@
 			<var name="sfcMassBal"/>
                         <var name="floatingBasalMassBal"/>
                         <var name="eigencalvingParameter"/>
+                        <var name="groundedVonMisesThresholdStress"/>
+                        <var name="floatingVonMisesThresholdStress"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <var name="upliftRate"/>
@@ -1135,6 +1147,12 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
+                />
+                <var name="groundedVonMisesThresholdStress" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
+                     description="Threshold stress for von Mises calving from grounded ice."
+                />
+                <var name="floatingVonMisesThresholdStress" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
+                     description="Threshold stress for von Mises calving from floating ice."
                 />
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -763,6 +763,9 @@
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>
                         <var name="floatingBasalMassBal"/>
+                        <!-- If restart file sizes become too large, eigencalvingParameter,
+                             groundedVonMisesThresholdStress, and floatingVonMisesThresholdStress
+                             could be moved to packages. -->
                         <var name="eigencalvingParameter"/>
                         <var name="groundedVonMisesThresholdStress"/>
                         <var name="floatingVonMisesThresholdStress"/>

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1563,15 +1563,6 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_calving_speed_limit', config_calving_speed_limit)
 
-      if ( config_grounded_von_Mises_threshold_stress <=  0.0_RKIND ) then
-         err = 1
-         call mpas_log_write("config_grounded_von_Mises_threshold_stress must be >0.0", MPAS_LOG_ERR)
-         endif
-
-      if ( config_floating_von_Mises_threshold_stress < 0.0_RKIND ) then
-         err = 1
-         call mpas_log_write("config_floating_von_Mises_threshold_stress must be >=0.0", MPAS_LOG_ERR)
-      endif
       !call mpas_pool_get_config(liConfigs, 'config_default_flowParamA',
       !config_default_flowParamA) ! REMOVE THIS ONCE YOU CAN GET A FROM
       !ALBANY!!!!!
@@ -1606,7 +1597,7 @@ module li_calving
           call mpas_pool_get_array(geometryPool, 'floatingVonMisesThresholdStress', floatingVonMisesThresholdStress)
           call mpas_pool_get_array(thermalPool, 'temperature', temperature)
 
-          ! get parameter value
+          ! get parameter value and check that values are valid
           if (trim(config_grounded_von_Mises_threshold_stress_source) == 'scalar') then
                 groundedVonMisesThresholdStress(:) = config_grounded_von_Mises_threshold_stress
           elseif (trim(config_grounded_von_Mises_threshold_stress_source) == 'data') then
@@ -1617,6 +1608,11 @@ module li_calving
                       config_grounded_von_Mises_threshold_stress_source, MPAS_LOG_ERR)
           endif
 
+          if ( minval(groundedVonMisesThresholdStress(:)) <= 0.0_RKIND ) then
+                err = 1
+                call mpas_log_write("groundedVonMisesThresholdStress must be >0.0", MPAS_LOG_ERR)
+          endif
+
           if (trim(config_floating_von_Mises_threshold_stress_source) == 'scalar') then
                 floatingVonMisesThresholdStress(:) = config_floating_von_Mises_threshold_stress
           elseif (trim(config_floating_von_Mises_threshold_stress_source) == 'data') then
@@ -1625,6 +1621,17 @@ module li_calving
                 err = 1
                 call mpas_log_write("Invalid value specified for option config_floating_von_Mises_threshold_stress_source" // &
                       config_floating_von_Mises_threshold_stress_source, MPAS_LOG_ERR)
+          endif
+
+          if ( minval(floatingVonMisesThresholdStress(:)) < 0.0_RKIND ) then
+                err = 1
+                call mpas_log_write("floatingVonMisesThresholdStress must be >=0.0", MPAS_LOG_ERR)
+          endif
+
+          ! If von Mises threshold stresses contain invalid values, do not
+          ! continue.
+          if ( err == 1 ) then
+             return
           endif
 
           vonMisesStress(:) = 0.0_RKIND
@@ -1671,7 +1678,8 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, err)
+                                              applyToFloating, applyToGroundingLine, domain, err_tmp)
+          err = ior(err, err_tmp)
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
          ! Testing seemed to indicate this is not necessary, but I don't

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1534,10 +1534,14 @@ module li_calving
       real (kind=RKIND), pointer :: config_grounded_von_Mises_threshold_stress, &
                                     config_floating_von_Mises_threshold_stress, &
                                     config_flowLawExponent, config_calving_speed_limit
+      character (len=StrKIND), pointer :: config_grounded_von_Mises_threshold_stress_source, &
+                            config_floating_von_Mises_threshold_stress_source
       logical, pointer :: config_use_Albany_flowA_eqn_for_vM
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin, &
                                         calvingVelocity, thickness, &
-                                        xvelmean, yvelmean, calvingThickness
+                                        xvelmean, yvelmean, calvingThickness, &
+                                        floatingVonMisesThresholdStress, &
+                                        groundedVonMisesThresholdStress
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA, &
                                         temperature, layerThickness
       real (kind=RKIND), pointer :: config_default_flowParamA
@@ -1553,13 +1557,20 @@ module li_calving
       applyToFloating = .true.
       applyToGroundingLine = .false.
 
+      call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress_source', config_grounded_von_Mises_threshold_stress_source)
+      call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress_source', config_floating_von_Mises_threshold_stress_source)
       call mpas_pool_get_config(liConfigs, 'config_grounded_von_Mises_threshold_stress', config_grounded_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_floating_von_Mises_threshold_stress', config_floating_von_Mises_threshold_stress)
       call mpas_pool_get_config(liConfigs, 'config_calving_speed_limit', config_calving_speed_limit)
 
       if ( config_grounded_von_Mises_threshold_stress <=  0.0_RKIND ) then
-         call mpas_log_write("config_grounded_von_Mises_threshold_stress must be >0.0", MPAS_LOG_ERR)
          err = 1
+         call mpas_log_write("config_grounded_von_Mises_threshold_stress must be >0.0", MPAS_LOG_ERR)
+         endif
+
+      if ( config_floating_von_Mises_threshold_stress < 0.0_RKIND ) then
+         err = 1
+         call mpas_log_write("config_floating_von_Mises_threshold_stress must be >=0.0", MPAS_LOG_ERR)
       endif
       !call mpas_pool_get_config(liConfigs, 'config_default_flowParamA',
       !config_default_flowParamA) ! REMOVE THIS ONCE YOU CAN GET A FROM
@@ -1591,7 +1602,30 @@ module li_calving
           call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
           call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+          call mpas_pool_get_array(geometryPool, 'groundedVonMisesThresholdStress', groundedVonMisesThresholdStress)
+          call mpas_pool_get_array(geometryPool, 'floatingVonMisesThresholdStress', floatingVonMisesThresholdStress)
           call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+
+          ! get parameter value
+          if (trim(config_grounded_von_Mises_threshold_stress_source) == 'scalar') then
+                groundedVonMisesThresholdStress(:) = config_grounded_von_Mises_threshold_stress
+          elseif (trim(config_grounded_von_Mises_threshold_stress_source) == 'data') then
+                ! do nothing - use value from input file
+          else
+                err = 1
+                call mpas_log_write("Invalid value specified for option config_grounded_von_Mises_threshold_stress_source" // &
+                      config_grounded_von_Mises_threshold_stress_source, MPAS_LOG_ERR)
+          endif
+
+          if (trim(config_floating_von_Mises_threshold_stress_source) == 'scalar') then
+                floatingVonMisesThresholdStress(:) = config_floating_von_Mises_threshold_stress
+          elseif (trim(config_floating_von_Mises_threshold_stress_source) == 'data') then
+                ! do nothing - use value from input file
+          else
+                err = 1
+                call mpas_log_write("Invalid value specified for option config_floating_von_Mises_threshold_stress_source" // &
+                      config_floating_von_Mises_threshold_stress_source, MPAS_LOG_ERR)
+          endif
 
           vonMisesStress(:) = 0.0_RKIND
 
@@ -1622,13 +1656,13 @@ module li_calving
              ! Calculate calving velocity for grounded cells at marine margin
              if ( .not. li_mask_is_floating_ice(cellMask(iCell)) ) then
                 calvingVelocity(iCell) = min(sqrt(xvelmean(iCell)**2.0_RKIND + yvelmean(iCell)**2.0_RKIND) * &
-                                         vonMisesStress(iCell) / config_grounded_von_Mises_threshold_stress, config_calving_speed_limit)
+                                         vonMisesStress(iCell) / groundedVonMisesThresholdStress(iCell), config_calving_speed_limit)
              ! If config_floating_von_Mises_threshold_stress is not 0.0, calculate
              ! calvingVelocity. If config_floating_von_Mises_threshold_stress is
              ! 0.0, remove floating ice in loop below.
              elseif ( li_mask_is_floating_ice(cellMask(iCell)) .and. config_floating_von_Mises_threshold_stress .ne. 0.0_RKIND) then
                 calvingVelocity(iCell) = min(sqrt(xvelmean(iCell)**2 + yvelmean(iCell)**2) * &
-                                         vonMisesStress(iCell) / config_floating_von_Mises_threshold_stress, config_calving_speed_limit)
+                                         vonMisesStress(iCell) / floatingVonMisesThresholdStress(iCell), config_calving_speed_limit)
              endif
           enddo
 


### PR DESCRIPTION
Add the ability to have the von Mises threshold stress for grounded and floating ice read in from input files. Add config options `config_grounded_von_Mises_threshold_stress_source` and `config_floating_von_Mises_threshold_stress_source` which are set  to `'data'` if the spatially varying field is to be read from an input file, and to `'scalar'` if it is to be set by `config_grounded_von_Mises_threshold_stress` and `config_grounded_von_Mises_threshold_stress`.