### PR TITLE
Add SMB mask for bareland 

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -120,6 +120,10 @@
 			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage.  When this is true, geometry changes from surface and basal mass balance (grounded or floating) and facemelting are not retained, but changes from calving are."
 			    possible_values=".true. or .false."
                 />
+        <nml_option name="config_smbMask" type="logical" default_value=".false." units="unitless"
+                    description="Mask to zero out applied SMB in regions where there is no ice at the timestep."
+                    possible_values=".true. or .false."
+        />
 <!-- This option to be implemented in the future.
 		<nml_option name="config_allow_additional_advance" type="logical" default_value=".true." units="none"
 		            description="Determines whether ice can advance beyond its initial extent"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -120,8 +120,8 @@
 			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage.  When this is true, geometry changes from surface and basal mass balance (grounded or floating) and facemelting are not retained, but changes from calving are."
 			    possible_values=".true. or .false."
                 />
-        <nml_option name="config_smbMask" type="logical" default_value=".false." units="unitless"
-                    description="Mask to zero out applied SMB in regions where there is no ice at the timestep."
+        <nml_option name="config_zero_sfcMassBalApplied_over_bare_land" type="logical" default_value=".true." units="unitless"
+                    description="Mask to zero out sfcMassBalApplied in regions where there is no ice at the timestep."
                     possible_values=".true. or .false."
         />
 <!-- This option to be implemented in the future.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -776,7 +776,7 @@ module li_advection
 
          ! Zero out any positive surface mass balance for ice-free ocean cells
          if (sfcMassBalApplied(iCell) > 0.0_RKIND .and. &
-             bedTopography(iCell) < config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
+             bedTopography(iCell) <= config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
             sfcMassBalApplied(iCell) = 0.0_RKIND
          end if
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -744,6 +744,7 @@ module li_advection
       integer :: nLayers    ! number of layers
       integer :: nTracers   ! number of tracers
       real (kind=RKIND), pointer :: config_sea_level ! sea level relative to z = 0
+      logical, pointer :: config_smbMask
 
       integer :: iCell, iLayer, iTracer
 
@@ -778,6 +779,15 @@ module li_advection
              bedTopography(iCell) < config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
             sfcMassBalApplied(iCell) = 0.0_RKIND
          end if
+
+         ! Zero out positive surface mass balance for bare land cells
+         call mpas_pool_get_config(liConfigs, 'config_smbMask', config_smbMask)
+         if (config_smbMask) then
+            if (sfcMassBalApplied(iCell) > 0.0_RKIND .and. &
+                bedTopography(iCell) > config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
+                sfcMassBalApplied(iCell) = 0.0_RKIND
+             endif
+         endif
 
          ! surface accumulation
          if (sfcMassBalApplied(iCell) > 0.0_RKIND) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -744,7 +744,7 @@ module li_advection
       integer :: nLayers    ! number of layers
       integer :: nTracers   ! number of tracers
       real (kind=RKIND), pointer :: config_sea_level ! sea level relative to z = 0
-      logical, pointer :: config_smbMask
+      logical, pointer :: config_zero_sfcMassBalApplied_over_bare_land
 
       integer :: iCell, iLayer, iTracer
 
@@ -755,6 +755,8 @@ module li_advection
       allocate(thckTracerProducts(nTracers))
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_zero_sfcMassBalApplied_over_bare_land', &
+		                config_zero_sfcMassBalApplied_over_bare_land)
 
       ! apply surface mass balance
       ! If positive, then add the SMB to the top layer, conserving mass*tracer products
@@ -776,17 +778,16 @@ module li_advection
 
          ! Zero out any positive surface mass balance for ice-free ocean cells
          if (sfcMassBalApplied(iCell) > 0.0_RKIND .and. &
-             bedTopography(iCell) <= config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
+            bedTopography(iCell) < config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
             sfcMassBalApplied(iCell) = 0.0_RKIND
          end if
 
          ! Zero out positive surface mass balance for bare land cells
-         call mpas_pool_get_config(liConfigs, 'config_smbMask', config_smbMask)
-         if (config_smbMask) then
+         if (config_zero_sfcMassBalApplied_over_bare_land) then
             if (sfcMassBalApplied(iCell) > 0.0_RKIND .and. &
-                bedTopography(iCell) > config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
-                sfcMassBalApplied(iCell) = 0.0_RKIND
-             endif
+               bedTopography(iCell) >= config_sea_level .and. .not.(li_mask_is_ice(cellMask(iCell)) ) ) then
+               sfcMassBalApplied(iCell) = 0.0_RKIND
+            endif
          endif
 
          ! surface accumulation


### PR DESCRIPTION
This PR adds a mask for the applied SMB field such that `sfcMassBal=0` in bareland regions 
and adds a config option for utilizing the SMB mask.
