### PR TITLE
Distribute unablatedVolumeDynCell among neighboring cells in li_apply_front_ablation_velocity

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -256,6 +256,10 @@
                             description="Coefficient for ISMIP6 retreat parameterization from Slater et al. (2019)"
                             possible_values="any negative real value"
                 />
+                <nml_option name="config_distribute_unablatedVolumeDynCell" type="logical" default_value=".true." units="unitless"
+                        description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity."
+                        possible_values=".true. or .false."
+                />
 	</nml_record>
 
 	<nml_record name="thermal_solver" in_defaults="true">

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2080,6 +2080,7 @@ module li_calving
       integer, dimension(:), pointer :: frontAblationMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, faceMeltingThickness
       real (kind=RKIND), pointer :: config_sea_level
+      logical, pointer :: config_distribute_unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity, faceMeltSpeed
@@ -2113,6 +2114,7 @@ module li_calving
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_distribute_unablatedVolumeDynCell', config_distribute_unablatedVolumeDynCell)
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -2549,68 +2551,69 @@ module li_calving
          endif
       enddo
 
-      ! 3. Distribute unablatedVolumeDynCell among neighboring cells. This is
-      ! necesssary when a cell is fully depleted but still has not ablated as
-      ! much ice as required by the ablation parameterization. This still may
-      ! result in large error for very high ablation rates, which could be
-      ! alleviated by adding a do-while loop.
+      if ( config_distribute_unablatedVolumeDynCell ) then
+         ! 3. Distribute unablatedVolumeDynCell among neighboring cells. This is
+         ! necesssary when a cell is fully depleted but still has not ablated as
+         ! much ice as required by the ablation parameterization. This still may
+         ! result in large error for very high ablation rates, which should be
+         ! prevented by limiting the timestep based on the ablation velocity.
 
-      ! a. Calculate volume to be distributed evenly among neighboring dynamic
-      ! cells
-      do iCell = 1, nCells
-         if ( (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
-            nDynNeighbors = 0
-            ! Count neighbors between which to evenly distribute
-            ! unablatedVolumeDynCell
-            do iEdge = 1, nEdgesOnCell(iCell)
-               iNeighbor = cellsOnCell(iEdge, iCell)
-               if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
-                    .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
-                  nDynNeighbors = nDynNeighbors + 1
-               endif
-            enddo
-            if ( nDynNeighbors > 0 ) then
-               ! Now distribute unablatedVolumeDynCell between those neighbors
+         ! a. Calculate volume to be distributed evenly among neighboring dynamic cells
+         do iCell = 1, nCells
+            if ( (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
+               nDynNeighbors = 0
+               ! Count neighbors between which to evenly distribute
+               ! unablatedVolumeDynCell
                do iEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(iEdge, iCell)
                   if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
-                    .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
-                     unablatedVolumeDynCell(iNeighbor) = unablatedVolumeDynCell(iNeighbor) + &
-                                                             unablatedVolumeDynCell(iCell) / nDynNeighbors
+                       .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
+                     nDynNeighbors = nDynNeighbors + 1
                   endif
                enddo
-               ! This cell now has no more unablatedVolume
-               unablatedVolumeDynCell(iCell) = 0.0_RKIND
+               if ( nDynNeighbors > 0 ) then
+                  ! Now distribute unablatedVolumeDynCell between those neighbors
+                  do iEdge = 1, nEdgesOnCell(iCell)
+                     iNeighbor = cellsOnCell(iEdge, iCell)
+                     if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
+                       .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
+                        unablatedVolumeDynCell(iNeighbor) = unablatedVolumeDynCell(iNeighbor) + &
+                                                                unablatedVolumeDynCell(iCell) / nDynNeighbors
+                     endif
+                  enddo
+                  ! This cell now has no more unablatedVolume
+                  unablatedVolumeDynCell(iCell) = 0.0_RKIND
+               endif
             endif
-         endif
-      enddo
+         enddo
 
-      ! b. Apply ablation
-      do iCell = 1, nCells
-          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
-               .and. ( cellVolume(iCell) > (ablationSmallThk * areaCell(iCell)) ) &
-               .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
-               removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
-               ablationThickness(iCell) = ablationThickness(iCell) + removeVolumeHere / areaCell(iCell) ! add to ablationThickness calculated in 2c
-               ablatedVolumeDynCell(iCell) = ablatedVolumeDynCell(iCell) + removeVolumeHere
-               unablatedVolumeDynCell(iCell) = unablatedVolumeDynCell(iCell) - removeVolumeHere
-               cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-               ! For debugging it may be helpful to add a separate metric for
-               ! this step.
-               if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
-           endif
-      enddo
-      !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+         ! b. Apply ablation
+         do iCell = 1, nCells
+             if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
+                  .and. ( cellVolume(iCell) > (ablationSmallThk * areaCell(iCell)) ) &
+                  .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
+                  removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
+                  ablationThickness(iCell) = ablationThickness(iCell) + removeVolumeHere / areaCell(iCell) ! add to ablationThickness calculated in 2c
+                  ablatedVolumeDynCell(iCell) = ablatedVolumeDynCell(iCell) + removeVolumeHere
+                  unablatedVolumeDynCell(iCell) = unablatedVolumeDynCell(iCell) - removeVolumeHere
+                  cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+                  ! For debugging it may be helpful to add a separate metric for
+                  ! this step.
+                  if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
+              endif
+         enddo
+         !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+
+         ! c. Clean up to account for roundoff level errors that can occur
+         do iCell = 1, nCells
+            if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
+               ablationThickness(iCell) = thickness(iCell)
+            endif
+         enddo
+      endif ! config_distribute_unablatedVolumeDynCell
 
       ! 4. Clean up after applying ablation velocity from parameterization
-      ! a. Clean up to account for roundoff level errors that can occur
-      do iCell = 1, nCells
-         if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
-            ablationThickness(iCell) = thickness(iCell)
-         endif
-      enddo
-
-      ! b. Zap any stranded ice.  This only needs to be considered for floating ice.
+      ! a. Zap any stranded ice.  This only needs to be considered for floating ice.
       ablationSubtotal3 = 0.0_RKIND
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
@@ -2633,7 +2636,7 @@ module li_calving
          endif
       enddo
 
-      ! c. Clean up to account for roundoff level errors that can occur
+      ! b. Clean up to account for roundoff level errors that can occur
       do iCell = 1, nCells
          if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
             ablationThickness(iCell) = thickness(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2565,7 +2565,7 @@ module li_calving
             do iEdge = 1, nEdgesOnCell(iCell)
                iNeighbor = cellsOnCell(iEdge, iCell)
                if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
-                    .and. (cellVolume(iNeighbor) > 0.0_RKIND) ) then
+                    .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
                   nDynNeighbors = nDynNeighbors + 1
                endif
             enddo
@@ -2574,7 +2574,7 @@ module li_calving
                do iEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(iEdge, iCell)
                   if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
-                    .and. (cellVolume(iNeighbor) > 0.0_RKIND) ) then
+                    .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
                      unablatedVolumeDynCell(iNeighbor) = unablatedVolumeDynCell(iNeighbor) + &
                                                              unablatedVolumeDynCell(iCell) / nDynNeighbors
                   endif
@@ -2588,7 +2588,8 @@ module li_calving
       ! b. Apply ablation
       do iCell = 1, nCells
           if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
-               .and. (cellVolume(iCell) > 0.0_RKIND) .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
+               .and. ( cellVolume(iCell) > (ablationSmallThk * areaCell(iCell)) ) &
+               .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
                removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
                ablationThickness(iCell) = ablationThickness(iCell) + removeVolumeHere / areaCell(iCell) ! add to ablationThickness calculated in 2c
                ablatedVolumeDynCell(iCell) = ablatedVolumeDynCell(iCell) + removeVolumeHere

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2107,7 +2107,7 @@ module li_calving
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
       real(kind=RKIND), parameter :: ablationSmallThk = 1.0e-8_RKIND ! in meters, a small thickness threshold
-      integer :: err_tmp
+      integer :: err_tmp, iter, nDynNeighbors
 
       err = 0
       err_tmp = 0
@@ -2541,8 +2541,6 @@ module li_calving
             if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
          endif
       enddo
-      !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
-
 
       ! Clean up to account for roundoff level errors that can occur
       do iCell = 1, nCells
@@ -2551,7 +2549,66 @@ module li_calving
          endif
       enddo
 
-      ! Clean up - zap any stranded ice.  This only needs to be considered for floating ice.
+      ! 3. Distribute unablatedVolumeDynCell among neighboring cells. This is
+      ! necesssary when a cell is fully depleted but still has not ablated as
+      ! much ice as required by the ablation parameterization. This still may
+      ! result in large error for very high ablation rates, which could be
+      ! alleviated by adding a do-while loop.
+
+      ! a. Calculate volume to be distributed evenly among neighboring dynamic
+      ! cells
+      do iCell = 1, nCells
+         if ( (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
+            nDynNeighbors = 0
+            ! Count neighbors between which to evenly distribute
+            ! unablatedVolumeDynCell
+            do iEdge = 1, nEdgesOnCell(iCell)
+               iNeighbor = cellsOnCell(iEdge, iCell)
+               if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
+                    .and. (cellVolume(iNeighbor) > 0.0_RKIND) ) then
+                  nDynNeighbors = nDynNeighbors + 1
+               endif
+            enddo
+            if ( nDynNeighbors > 0 ) then
+               ! Now distribute unablatedVolumeDynCell between those neighbors
+               do iEdge = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(iEdge, iCell)
+                  if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
+                    .and. (cellVolume(iNeighbor) > 0.0_RKIND) ) then
+                     unablatedVolumeDynCell(iNeighbor) = unablatedVolumeDynCell(iNeighbor) + &
+                                                             unablatedVolumeDynCell(iCell) / nDynNeighbors
+                  endif
+               enddo
+               ! This cell now has no more unablatedVolume
+               unablatedVolumeDynCell(iCell) = 0.0_RKIND
+            endif
+         endif
+      enddo
+
+      ! b. Apply ablation
+      do iCell = 1, nCells
+          if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
+               .and. (cellVolume(iCell) > 0.0_RKIND) )then
+               removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
+               ablationThickness(iCell) = ablationThickness(iCell) + removeVolumeHere / areaCell(iCell) ! add to ablationThickness calculated in 2c
+               ablatedVolumeDynCell(iCell) = ablatedVolumeDynCell(iCell) + removeVolumeHere
+               unablatedVolumeDynCell(iCell) = unablatedVolumeDynCell(iCell) - removeVolumeHere
+               cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
+
+               if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
+           endif
+      enddo
+      !call mpas_log_write("Done calculating ablation for dynamic floating cells. Removed $r m^3", realArgs=(/calvingSubtotal2/))
+
+      ! 4. Clean up after applying ablation velocity from parameterization
+      ! a. Clean up to account for roundoff level errors that can occur
+      do iCell = 1, nCells
+         if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
+            ablationThickness(iCell) = thickness(iCell)
+         endif
+      enddo
+
+      ! b. Zap any stranded ice.  This only needs to be considered for floating ice.
       ablationSubtotal3 = 0.0_RKIND
       do iCell = 1, nCells
          if (li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell)))) then
@@ -2574,7 +2631,7 @@ module li_calving
          endif
       enddo
 
-      ! Clean up to account for roundoff level errors that can occur
+      ! c. Clean up to account for roundoff level errors that can occur
       do iCell = 1, nCells
          if (abs(ablationThickness(iCell) - thickness(iCell)) < ablationSmallThk) then
             ablationThickness(iCell) = thickness(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2107,7 +2107,7 @@ module li_calving
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
       real(kind=RKIND), parameter :: ablationSmallThk = 1.0e-8_RKIND ! in meters, a small thickness threshold
-      integer :: err_tmp, iter, nDynNeighbors
+      integer :: err_tmp, nDynNeighbors
 
       err = 0
       err_tmp = 0
@@ -2588,13 +2588,14 @@ module li_calving
       ! b. Apply ablation
       do iCell = 1, nCells
           if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
-               .and. (cellVolume(iCell) > 0.0_RKIND) )then
+               .and. (cellVolume(iCell) > 0.0_RKIND) .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
                removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
                ablationThickness(iCell) = ablationThickness(iCell) + removeVolumeHere / areaCell(iCell) ! add to ablationThickness calculated in 2c
                ablatedVolumeDynCell(iCell) = ablatedVolumeDynCell(iCell) + removeVolumeHere
                unablatedVolumeDynCell(iCell) = unablatedVolumeDynCell(iCell) - removeVolumeHere
                cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
-
+               ! For debugging it may be helpful to add a separate metric for
+               ! this step.
                if (iCell <= nCellsSolve) ablationSubtotal2 = ablationSubtotal2 + removeVolumeHere
            endif
       enddo


### PR DESCRIPTION
If a cell is left with unablated volume after step 2c in li_apply_front_ablation_velocity, distribute that volume among its dynamic neighbors to prevent large errors in the ablated volume. This can be turned on or off using the `config_distribute_unablatedVolumeDynCell` namelist option. Testing with von Mises calving on the MISMIP+ domain indicates that this greatly reduces inaccuracies in the calving routine, but that very large calving events can still trigger the >10% calving inaccuracy error. However, this should only be a secondary means of getting accurate calving results; the primary means should be by using an appropriately small timestep determined by the ablation velocity in a CFL-like condition.