### PR TITLE
Add applied basal mass balance fields

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1147,13 +1147,22 @@ is the value of that variable from the *previous* time level!
                      description="applied surface mass balance on grounded ice"
                 />
                 <var name="basalMassBal" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
-                     description="applied basal mass balance"
+                     description="Potential basal mass balance"
                 />
                 <var name="groundedBasalMassBal" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
-                     description="Basal mass balance on grounded regions"
+                     description="Potential basal mass balance on grounded regions"
                 />
                 <var name="floatingBasalMassBal" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
-                     description="Basal mass balance on floating regions"
+                     description="Potential basal mass balance on floating regions"
+                />
+                <var name="basalMassBalApplied" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                     description="applied basal mass balance"
+                />
+                <var name="groundedBasalMassBalApplied" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                     description="Applied basal mass balance on grounded regions"
+                />
+                <var name="floatingBasalMassBalApplied" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                     description="Applied basal mass balance on floating regions"
                 />
                 <var name="calvingMask" type="integer" dimensions="nCells Time" units="m" time_levs="1"
                         description="mask of grid cells that should be calved.  0=no calving, 1=should be calved"

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -172,9 +172,9 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  bedTopography
       real (kind=RKIND), dimension(:), pointer ::  sfcMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  groundedSfcMassBalApplied
-      real (kind=RKIND), dimension(:), pointer ::  basalMassBal
-      real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBal
-      real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBal
+      real (kind=RKIND), dimension(:), pointer ::  basalMassBalApplied
+      real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBalApplied
+      real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness
       real (kind=RKIND), dimension(:), pointer ::  surfaceSpeed
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
@@ -286,9 +286,9 @@ contains
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
-         call mpas_pool_get_array(geometryPool, 'basalMassBal', basalMassBal)
-         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBal', groundedBasalMassBal)
-         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+         call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
@@ -331,12 +331,9 @@ contains
             blockSumFloatingSfcMassBal = blockSumFloatingSfcMassBal + &
                (sfcMassBalApplied(iCell) - groundedSfcMassBalApplied(iCell)) * areaCell(iCell) * scyr
             ! BMB (kg yr-1)
-            blockSumBasalMassBal = blockSumBasalMassBal + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
-                * areaCell(iCell) * basalMassBal(iCell) * scyr
-            blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND)&
-                * areaCell(iCell) * groundedBasalMassBal(iCell) * scyr
-            blockSumFloatingBasalMassBal = blockSumFloatingBasalMassBal + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND)&
-                * areaCell(iCell) * floatingBasalMassBal(iCell) * scyr
+            blockSumBasalMassBal = blockSumBasalMassBal + areaCell(iCell) * basalMassBalApplied(iCell) * scyr
+            blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr
+            blockSumFloatingBasalMassBal = blockSumFloatingBasalMassBal + areaCell(iCell) * floatingBasalMassBalApplied(iCell) * scyr
 
             ! mass lass due do calving (kg yr^{-1})
             blockSumCalvingFlux = blockSumCalvingFlux + calvingThickness(iCell) * &

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -174,9 +174,9 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  bedTopography
       real (kind=RKIND), dimension(:), pointer ::  sfcMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  groundedSfcMassBalApplied
-      real (kind=RKIND), dimension(:), pointer ::  basalMassBal
-      real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBal
-      real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBal
+      real (kind=RKIND), dimension(:), pointer ::  basalMassBalApplied
+      real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBalApplied
+      real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness
       real (kind=RKIND), dimension(:), pointer ::  surfaceSpeed
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
@@ -279,9 +279,9 @@ contains
          call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
-         call mpas_pool_get_array(geometryPool, 'basalMassBal', basalMassBal)
-         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBal', groundedBasalMassBal)
-         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+         call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
@@ -372,18 +372,15 @@ contains
 
             ! regional sum of basal mass balance (kg yr^{-1})
             blockSumRegionBasalMassBal(iRegion) = blockSumRegionBasalMassBal(iRegion) + &
-              ( real(regionCellMasks(iRegion,iCell),RKIND) * real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
-                * areaCell(iCell) * basalMassBal(iCell) * scyr )
+              ( real(regionCellMasks(iRegion,iCell),RKIND) * areaCell(iCell) * basalMassBalApplied(iCell) * scyr )
 
             ! regional sum of floating basal mass balance (kg yr^{-1})
             blockSumRegionFloatingBasalMassBal(iRegion) = blockSumRegionFloatingBasalMassBal(iRegion) + &
-              ( real(regionCellMasks(iRegion,iCell),RKIND) * real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
-                * areaCell(iCell) * floatingBasalMassBal(iCell) * scyr )
+              ( real(regionCellMasks(iRegion,iCell),RKIND) * areaCell(iCell) * floatingBasalMassBalApplied(iCell) * scyr )
 
             ! regional sum of grounded basal mass balance (kg yr^{-1})
             blockSumRegionGroundedBasalMassBal(iRegion) = blockSumRegionGroundedBasalMassBal(iRegion) + &
-              ( real(regionCellMasks(iRegion,iCell),RKIND) * real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
-                * areaCell(iCell) * groundedBasalMassBal(iCell) * scyr )
+              ( real(regionCellMasks(iRegion,iCell),RKIND) * areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr )
 
             ! regional sum of mass lass due do calving (kg yr^{-1})
             blockSumRegionCalvingFlux(iRegion) = blockSumRegionCalvingFlux(iRegion) + &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -144,6 +144,9 @@ module li_advection
            basalMassBal,          & ! basal mass balance
            groundedBasalMassBal,  & ! basal mass balance for grounded ice
            floatingBasalMassBal,  & ! basal mass balance for floating ice
+           basalMassBalApplied,          & ! basal mass balance limited by ice thickness
+           groundedBasalMassBalApplied,  & ! basal mass balance for grounded ice limited by ice thickness
+           floatingBasalMassBalApplied,  & ! basal mass balance for floating ice limited by ice thickness
            dynamicThickening,     & ! dynamic thickening rate
            groundedToFloatingThickness, & ! thickness changing from grounded to floating or vice versa
            fluxAcrossGroundingLine        ! magnitude of flux across GL
@@ -255,6 +258,9 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'basalMassBal', basalMassBal)
       call mpas_pool_get_array(geometryPool, 'groundedBasalMassBal', groundedBasalMassBal)
       call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+      call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
+      call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+      call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'layerThicknessEdge', layerThicknessEdge)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
@@ -439,21 +445,37 @@ module li_advection
          ! Grounded and floating basal mass balance should come from the thermal solver.
 
          ! TODO: more complicated treatment at GL?
+         ! Limit basal mass balance by ice thickness
+         groundedBasalMassBalApplied(:) = groundedBasalMassBal(:)
+         floatingBasalMassBalApplied(:) = floatingBasalMassBal(:)
+         do iCell = 1, nCells
+            if ( groundedBasalMassBal(iCell) < 0.0_RKIND ) then
+               groundedBasalMassBalApplied(iCell) = -1.0_RKIND * min(abs(groundedBasalMassBal(iCell)), &
+                                                                     thickness(iCell) * config_ice_density / dt)
+            endif
+            if ( floatingBasalMassBal(iCell) < 0.0_RKIND ) then
+               floatingBasalMassBalApplied(iCell) =  -1.0_RKIND * min(abs(floatingBasalMassBal(iCell)), &
+                                                                      thickness(iCell) * config_ice_density / dt)
+            endif
+         enddo
 
          where ( li_mask_is_grounded_ice(cellMask) )
 
             basalMassBal = groundedBasalMassBal
+            basalMassBalApplied = groundedBasalMassBalApplied
 
          elsewhere ( li_mask_is_floating_ice(cellMask) )
 
             ! Currently, floating and grounded ice are mutually exclusive.
             ! This could change if the GL is parameterized, in which case this logic may need adjustment.
             basalMassBal = floatingBasalMassBal
+            basalMassBalApplied = floatingBasalMassBalApplied
 
          elsewhere ( .not. (li_mask_is_ice(cellMask) ) )
 
             ! We don't allow a positive basal mass balance where ice is not already present.
             basalMassBal = 0.0_RKIND
+            basalMassBalApplied = 0.0_RKIND
 
          end where
 
@@ -465,7 +487,7 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
-              basalMassBal,        &
+              basalMassBalApplied, &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -488,8 +510,8 @@ module li_advection
                   call mpas_log_write('cellMask=$i, is ice=$l, is grounded=$l, is floating=$l', &
                        intArgs=(/cellMask(iCell)/), logicArgs=(/li_mask_is_ice(cellMask(iCell)), &
                        li_mask_is_grounded_ice(cellMask(iCell)), li_mask_is_floating_ice(cellMask(iCell)) /) )
-                  call mpas_log_write('basalMassBal=$r, grounded=$r, floating=$r', realArgs=(/ basalMassBal(iCell)*31536000./917.,&
-                          groundedBasalMassBal(iCell)*31536000./917., floatingBasalMassBal(iCell)*31536000./917. /) )
+                  call mpas_log_write('basalMassBalApplied=$r, grounded=$r, floating=$r', realArgs=(/ basalMassBalApplied(iCell)*31536000./917.,&
+                          groundedBasalMassBalApplied(iCell)*31536000./917., floatingBasalMassBalApplied(iCell)*31536000./917. /) )
                endif
             enddo
          endif
@@ -685,7 +707,7 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
-              basalMassBal,        &
+              basalMassBalApplied,        &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -704,7 +726,7 @@ module li_advection
       real (kind=RKIND), dimension(:), intent(in) ::  &
            bedTopography,      & !< Input: bed elevation (m)
            sfcMassBal,         & !< Input: surface mass balance (kg/m^2/s)
-           basalMassBal          !< Input: basal mass balance (kg/m^2/s)
+           basalMassBalApplied          !< Input: basal mass balance (kg/m^2/s)
 
       real(kind=RKIND), dimension(:,:), intent(in) :: &
            surfaceTracers,     & !< Input: tracer values of new ice at upper surface
@@ -756,7 +778,7 @@ module li_advection
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_zero_sfcMassBalApplied_over_bare_land', &
-		                config_zero_sfcMassBalApplied_over_bare_land)
+                                config_zero_sfcMassBalApplied_over_bare_land)
 
       ! apply surface mass balance
       ! If positive, then add the SMB to the top layer, conserving mass*tracer products
@@ -840,12 +862,12 @@ module li_advection
 
          ! apply basal mass balance
 
-         if (basalMassBal(iCell) > 0.0_RKIND) then
+         if (basalMassBalApplied(iCell) > 0.0_RKIND) then
 
             ! basal freeze-on
             ! modify tracers conservatively in top layer
 
-            basalAccum = basalMassBal(iCell) * dt / rhoi
+            basalAccum = basalMassBalApplied(iCell) * dt / rhoi
 
             ! compute mass-tracer products in bottom layer
             thckTracerProducts(:) = layerThickness(nLayers,iCell)*advectedTracers(:,nLayers,iCell)  &
@@ -857,11 +879,11 @@ module li_advection
             ! new tracers in top layer
             advectedTracers(:,nLayers,iCell) = thckTracerProducts(:) / layerThickness(nLayers,iCell)
 
-         elseif (basalMassBal(iCell) < 0.0_RKIND) then
+         elseif (basalMassBalApplied(iCell) < 0.0_RKIND) then
 
             ! surface ablation from the bottom up
 
-            basalAblat = -basalMassBal(iCell) * dt /rhoi    ! positive for melting
+            basalAblat = -basalMassBalApplied(iCell) * dt /rhoi    ! positive for melting
 
             do iLayer = nLayers, 1, -1
                if (basalAblat > layerThickness(iLayer,iCell)) then   ! melt the entire layer
@@ -877,7 +899,7 @@ module li_advection
 
             !TODO - If remaining basalAblat > 0, then keep track of it to conserve energy
 
-         endif   ! basalMassBal > 0
+         endif   ! basalMassBalApplied > 0
 
       enddo   ! iCell
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -445,37 +445,21 @@ module li_advection
          ! Grounded and floating basal mass balance should come from the thermal solver.
 
          ! TODO: more complicated treatment at GL?
-         ! Limit basal mass balance by ice thickness
-         groundedBasalMassBalApplied(:) = groundedBasalMassBal(:)
-         floatingBasalMassBalApplied(:) = floatingBasalMassBal(:)
-         do iCell = 1, nCells
-            if ( groundedBasalMassBal(iCell) < 0.0_RKIND ) then
-               groundedBasalMassBalApplied(iCell) = -1.0_RKIND * min(abs(groundedBasalMassBal(iCell)), &
-                                                                     thickness(iCell) * config_ice_density / dt)
-            endif
-            if ( floatingBasalMassBal(iCell) < 0.0_RKIND ) then
-               floatingBasalMassBalApplied(iCell) =  -1.0_RKIND * min(abs(floatingBasalMassBal(iCell)), &
-                                                                      thickness(iCell) * config_ice_density / dt)
-            endif
-         enddo
 
          where ( li_mask_is_grounded_ice(cellMask) )
 
             basalMassBal = groundedBasalMassBal
-            basalMassBalApplied = groundedBasalMassBalApplied
 
          elsewhere ( li_mask_is_floating_ice(cellMask) )
 
             ! Currently, floating and grounded ice are mutually exclusive.
             ! This could change if the GL is parameterized, in which case this logic may need adjustment.
             basalMassBal = floatingBasalMassBal
-            basalMassBalApplied = floatingBasalMassBalApplied
 
          elsewhere ( .not. (li_mask_is_ice(cellMask) ) )
 
             ! We don't allow a positive basal mass balance where ice is not already present.
             basalMassBal = 0.0_RKIND
-            basalMassBalApplied = 0.0_RKIND
 
          end where
 
@@ -487,7 +471,10 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
+              basalMassBal,        &
               basalMassBalApplied, &
+              groundedBasalMassBalApplied, &
+              floatingBasalMassBalApplied, &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -707,7 +694,10 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
-              basalMassBalApplied,        &
+              basalMassBal,        &
+              basalMassBalApplied, &
+              groundedBasalMassBalApplied, &
+              floatingBasalMassBalApplied, &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -726,7 +716,7 @@ module li_advection
       real (kind=RKIND), dimension(:), intent(in) ::  &
            bedTopography,      & !< Input: bed elevation (m)
            sfcMassBal,         & !< Input: surface mass balance (kg/m^2/s)
-           basalMassBalApplied          !< Input: basal mass balance (kg/m^2/s)
+           basalMassBal          !< Iinput: basal mass balance (kg/m^2/s)
 
       real(kind=RKIND), dimension(:,:), intent(in) :: &
            surfaceTracers,     & !< Input: tracer values of new ice at upper surface
@@ -752,7 +742,10 @@ module li_advection
       real(kind=RKIND), dimension(:), intent(out) :: &
            groundedSfcMassBalApplied !< Output: surface mass balance actually applied to grounded ice on this time step (kg/m^2/s)
 
-
+      real(kind=RKIND), dimension(:), intent(out) :: &
+           basalMassBalApplied,         & !< Output: basal mass balance actually applied on this time step (kg/m^2/s)
+           groundedBasalMassBalApplied, & !< Output: basal mass balance actually applied to grounded ice on this time step (kg/m^2/s)
+           floatingBasalMassBalApplied    !< Output: basal mass balance actually applied to floating ice on this time step (kg/m^2/s)
       ! local variables
 
       real (kind=RKIND) ::  &
@@ -784,8 +777,9 @@ module li_advection
       ! If positive, then add the SMB to the top layer, conserving mass*tracer products
       ! If negative, then melt from the top down until the melting term is used up or the ice is gone
 
-      ! Initialize applied SMB field
+      ! Initialize applied SMB and BMB fields
       sfcMassBalApplied(:) = sfcMassBal(:)
+      basalMassBalApplied(:) = basalMassBal(:)
 
       do iCell = 1, nCells
 
@@ -855,11 +849,6 @@ module li_advection
 
          endif   ! sfcMassBal > 0
 
-         groundedSfcMassBalApplied(:) = 0.0_RKIND
-         where (li_mask_is_grounded_ice(cellMask) .or. bedTopography > config_sea_level)
-            groundedSfcMassBalApplied = sfcMassBalApplied
-         end where
-
          ! apply basal mass balance
 
          if (basalMassBalApplied(iCell) > 0.0_RKIND) then
@@ -897,11 +886,32 @@ module li_advection
                endif
             enddo
 
-            !TODO - If remaining basalAblat > 0, then keep track of it to conserve energy
+            if (basalAblat > 0.0_RKIND) then
+               basalMassBalApplied(iCell) = basalMassBalApplied(iCell) + basalAblat * rhoi / dt
+               !TODO - If remaining basalAblat > 0, then keep track of it to conserve energy
+            endif
 
          endif   ! basalMassBalApplied > 0
 
       enddo   ! iCell
+
+      ! Separate grounded and floating components, as necessary.
+      where (li_mask_is_grounded_ice(cellMask) .or. bedTopography > config_sea_level)
+            groundedSfcMassBalApplied = sfcMassBalApplied
+      elsewhere
+            groundedSfcMassBalApplied = 0.0_RKIND
+      end where
+
+      where (li_mask_is_grounded_ice(cellMask))
+            groundedBasalMassBalApplied = basalMassBalApplied
+            floatingBasalMassBalApplied = 0.0_RKIND
+      elsewhere (li_mask_is_floating_ice(cellMask))
+            floatingBasalMassBalApplied = basalMassBalApplied
+            groundedBasalMassBalApplied = 0.0_RKIND
+      elsewhere
+            groundedBasalMassBalApplied = 0.0_RKIND
+            floatingBasalMassBalApplied = 0.0_RKIND
+      end where
 
       deallocate(thckTracerProducts)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -716,7 +716,7 @@ module li_advection
       real (kind=RKIND), dimension(:), intent(in) ::  &
            bedTopography,      & !< Input: bed elevation (m)
            sfcMassBal,         & !< Input: surface mass balance (kg/m^2/s)
-           basalMassBal          !< Iinput: basal mass balance (kg/m^2/s)
+           basalMassBal          !< Input: basal mass balance (kg/m^2/s)
 
       real(kind=RKIND), dimension(:,:), intent(in) :: &
            surfaceTracers,     & !< Input: tracer values of new ice at upper surface


### PR DESCRIPTION
Add applied basal mass balance fields, in which the calculated and prescribed basal mass balance is limited by the ice thickness. This addresses the problems recorded in issue https://github.com/MALI-Dev/E3SM/issues/22.