### PR TITLE
Fix restart & decomp errors for ismip6 retreat parameterization 

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1866,7 +1866,7 @@ module li_calving
       real (kind=RKIND), dimension(:), allocatable :: submergedArea
       real (kind=RKIND) :: deltatForcing ! time between forcing updates
       type (MPAS_Time_Type), save :: forcingTime, forcingTimeOld
-      character (len=StrKIND), pointer :: xtime, simulationStartTime, forcingTimeStamp
+      character (len=StrKIND), pointer :: forcingTimeStamp
       character(len=StrKIND) :: forcingTimeOldStamp
       type (MPAS_stream_list_type), pointer :: stream_cursor
       logical :: streamFound ! used to throw an error if required stream is not found
@@ -1888,8 +1888,6 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'xtime', xtime)
-      call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
       call mpas_pool_get_array(meshPool, 'forcingTimeStamp', forcingTimeStamp)
       call mpas_pool_get_array(meshPool, 'timestepNumber', timestepNumber)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -1911,21 +1909,18 @@ module li_calving
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
 
-      ! On a restart, set forcingTime to enable elseif statement below
-      if ( (config_do_restart) .and. (timestepNumber == 1) ) then
-         call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
-         err = ior(err, err_tmp)
-
-         forcingTimeOld = forcingTime  ! Initialize in case we don't read the forcing this timestep below
-      endif
-
       streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error
       stream_cursor => domain % streamManager % streams % head
       do while (associated(stream_cursor))
          ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
          if ( trim(stream_cursor % name) == 'ismip6-gis' .and. (stream_cursor % valid) ) then
             streamFound = .true.
-            if (xtime == simulationStartTime) then
+            if (timestepNumber == 1) then
+               ! On the first timestep of a cold start OR restart initialize all needed fields by forcing a read of
+               ! the previous forcing data on the first timestep.  This could be potentially be an unnecessary read on the
+               ! initial time of a restart run, but that is a small cost for simplifying logic and making the initial time of both
+               ! cold starts and restarts behave the same.  The potentially extra read does not affect the algorithm.
+
                ! Use forcing fields and time from most recent time in file, which was read on init.
                call mpas_get_time(stream_cursor%mostRecentAccessTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
                err = ior(err, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1915,6 +1915,8 @@ module li_calving
       if ( (config_do_restart) .and. (timestepNumber == 1) ) then
          call mpas_set_time(forcingTime, dateTimeString=forcingTimeStamp, ierr=err_tmp)
          err = ior(err, err_tmp)
+
+         forcingTimeOld = forcingTime  ! Initialize in case we don't read the forcing this timestep below
       endif
 
       streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -157,6 +157,13 @@ module li_calving
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
+      ! Update mask and geometry before calling any calving routines.  May not be necessary, but best be safe.
+      call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      err = ior(err, err_tmp)
+      call li_update_geometry(geometryPool)
+
       ! based on the calving timescale, set the fraction of ice that calves
       if (config_calving_timescale > 0.0_RKIND) then
          calvingFraction = min(deltat/config_calving_timescale, 1.0_RKIND)
@@ -1233,10 +1240,6 @@ module li_calving
                     realArgs=(/minval(eigencalvingParameter), maxval(eigencalvingParameter)/))
          endif
 
-         ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         err = ior(err, err_tmp)
-
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
@@ -1442,10 +1445,6 @@ module li_calving
             call mpas_log_write("calvingVelocity(m s) value range on this processor: Min=$r, Max=$r", &
                     realArgs=(/minval(calvingVelocity), maxval(calvingVelocity)/))
          endif
-
-         ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         err = ior(err, err_tmp)
 
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
@@ -1670,11 +1669,6 @@ module li_calving
           else
              call li_calculate_flowParamA(meshPool, temperature, thickness,flowParamA,err) ! Get MPAS flowParamA
           endif
-
-
-          ! update mask
-          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-          err = ior(err, err_tmp)
 
           !Using a depth-averaged ice viscosity parameter B_depthAvg
           !=sum(layerThickness(:,iCell) *

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1991,7 +1991,7 @@ module li_calving
                iEdge = edgesOnCell(iNeighbor, iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                ! sum up length of edges adjacent to open ocean or non-dynamic cells
-               if ( (.not. li_mask_is_dynamic_ice(jCell)) &
+               if ( (.not. li_mask_is_dynamic_ice(cellMask(jCell))) &
                        .and. (bedTopography(jCell) < seaLevel) ) then
                   submergedArea(iCell) = submergedArea(iCell) + dvEdge(iEdge) * waterDepth
                endif


### PR DESCRIPTION
The recently created landice/humboldt/mesh-3km_restart_test/velo-none_calving-ismip6_retreat test revealed that the ISMIP6 retreat parameterization caused a fatal timekeeping error on a restart if the restart time did not happen to coincide with a time in the forcing file.  This merge fixes that error by treating the initial time level of a restart the same way as a cold start by forcing a read of the previous forcing time level as required by the parameterization.  The aforementioned test passes after this change.  

Additionally the ISMIP6 retreat param. was failing decomposition tests as seen by the new  landice_humboldt_mesh-3km_decomposition_test_velo-none_calving-ismip6_retreat test.  This was due to an indexing error that is also fixed by this PR.