### PR TITLE
Create a calving CFL limit and apply to adaptive timestepper

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -480,6 +480,10 @@
 			description="A multiplier on the minimum allowable time step calculated from the CFL condition. (Setting to 1.0 may be unstable, so smaller values are recommended.)"
 			possible_values="Any positive real value less than 1.0."
 		/>
+		<nml_option name="config_adaptive_timestep_calvingCFL_fraction" type="real" default_value="0.5" units="none"
+			description="A multiplier on the minimum allowable time step calculated from the calving CFL condition. This should be conservative given the calving CFL calculation is lagged"
+			possible_values="Any positive real value less than 1.0."
+		/>
 		<nml_option name="config_adaptive_timestep_include_DCFL" type="logical" default_value=".false." units="none"
 			description="Option of whether to include the diffusive CFL condition in the determination of the maximum allowable timestep. The diffusive CFL condition at any location is estimated based on the local ice flux and surface slope."
 			possible_values=".true. or .false."
@@ -1176,6 +1180,9 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep (less than or equal to ice thickness)"
+                />
+                <var name="calvingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
+                        description="approximation of maximum allowable timestep based on calvingVelocity"
                 />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1197,8 +1197,8 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
                         description="approximation of maximum allowable timestep based on calvingVelocity"
                 />
-                <var name="dtCalvingCFLratio" type="real" dimensions="Time" units="s" time_levs="1" default_value="0.0"
-                        description="ratio of timestep being used to the maximum timestep calculated for the calving CFL condition"
+                <var name="dtCalvingCFLratio" type="real" dimensions="Time" units="none" time_levs="1" default_value="0.0"
+                        description="ratio of timestep being used to the maximum timestep calculated for the calving CFL condition.  This metric can be used to assess the accuracy of the calving CFL calculation being lagged by a timestep."
                 />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
@@ -1465,7 +1465,7 @@ is the value of that variable from the *previous* time level!
                 <var name="tauMin" type="real" dimensions="nCells Time" units="Pa"
                      description="minimum deviatoric principal stress"
                 />
-	        <var name="principalStrainRateRatio" type="real" dimensions="nCells" units="none"
+	        <var name="principalStrainRateRatio" type="real" dimensions="nCells Time" units="none"
 	             description="the ratio of the minimum and maximum principal horizontal strain rates"
 	        />
                 <var name="fluxAcrossGroundingLine" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1095,6 +1095,9 @@ is the value of that variable from the *previous* time level!
 		<var name="allowableDtDCFL" type="real" time_levs="1" dimensions="Time" units="s"
 		     description="The maximum allowable time step based on the diffusive CFL condition.  Value on a given time is the value appropriate for  between the previous time level and the current time level."
                 />
+		<var name="processLimitingTimestep" type="integer" time_levs="1" dimensions="Time" units="none" default_value="0"
+		     description="A code for which process limits the timestep length through the CFL condition. 1=advective CFL, 2=diffusive CFL, 3=calving CFL.  Value of 0 indicates adaptive timestepper not used."
+                />
                 <var name="simulationStartTime" type="text" dimensions="" units="unitless" default_value="'no_date_available'"
                      description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -272,8 +272,8 @@
                             description="Fraction of total volume intended to be ablated remaining before an error is triggered."
                             possible_values="any positive real value"
                 />
-                <nml_option name="config_distribute_unablatedVolumeDynCell" type="logical" default_value=".true." units="unitless"
-                        description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity."
+                <nml_option name="config_distribute_unablatedVolumeDynCell" type="logical" default_value=".false." units="unitless"
+                        description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity.  If you choose to set config_adaptive_timestep_calvingCFL_fraction much larger than 1.0 (which is not recommended), setting this option to true usually results in more accurate calving behavior. "
                         possible_values=".true. or .false."
                 />
 	</nml_record>
@@ -484,15 +484,15 @@
 			description="A multiplier on the minimum allowable time step calculated from the advective CFL condition. (Setting to 1.0 may be unstable, so smaller values are recommended.)  Note that 'advective' is not in the name.  This is for backwards compatibility"
 			possible_values="Any positive real value less than 1.0."
 		/>
-		<nml_option name="config_adaptive_timestep_calvingCFL_fraction" type="real" default_value="0.5" units="none"
+		<nml_option name="config_adaptive_timestep_calvingCFL_fraction" type="real" default_value="1.0" units="none"
 			description="A multiplier on the minimum allowable time step calculated from the calving CFL condition. This should be conservative given the calving CFL calculation is lagged"
-			possible_values="Any positive real value.  Note that values greater than 1.0 are allowed and may be desired.  This is because the calving CFL is an approximate calculation."
+			possible_values="Any positive real value.  Note that values greater than 1.0 are allowed and may be desired.  This is because the calving CFL is an approximate calculation.  A value between 0.75 and 1.0, possibly as large as 1.25, was found to maintain converged accuracy for many configurations explored, so it is recommended to use values in this range.  However, much larger values (up to 2 or 3) provide acceptable accuracy for some configurations (but it is not clear what conditions allow it).  If values much greater than 1.0 are used, it is recommended to set config_distribute_unablatedVolumeDynCell to true."
 		/>
 		<nml_option name="config_adaptive_timestep_include_DCFL" type="logical" default_value=".false." units="none"
 			description="Option of whether to include the diffusive CFL condition in the determination of the maximum allowable timestep. The diffusive CFL condition at any location is estimated based on the local ice flux and surface slope."
 			possible_values=".true. or .false."
 		/>
-		<nml_option name="config_adaptive_timestep_include_calving" type="logical" default_value=".false." units="none"
+		<nml_option name="config_adaptive_timestep_include_calving" type="logical" default_value=".true." units="none"
 			description="Option of whether to include the calving CFL condition in the determination of the maximum allowable timestep. This only is applied if config_calving is set to a method that uses a calvingVelocity.  Note that this is an approximate CFL condition and is lagged a timestep."
 			possible_values=".true. or .false."
 		/>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -799,6 +799,8 @@
                         <var name="floatingVonMisesThresholdStress"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
+                        <!-- calvingCFLdt only needed if calving CFL is being applied, but it is a scalar value so no harm in including it always -->
+                        <var name="calvingCFLdt"/>
                         <var name="upliftRate"/>
 			<!-- normalVelocity is needed for advection on the next timestep -->
 			<var name="normalVelocity"/>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1193,6 +1193,9 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
                         description="approximation of maximum allowable timestep based on calvingVelocity"
                 />
+                <var name="dtCalvingCFLratio" type="real" dimensions="Time" units="s" time_levs="1" default_value="0.0"
+                        description="ratio of timestep being used to the maximum timestep calculated for the calving CFL condition"
+                />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -268,6 +268,10 @@
                             description="Coefficient for ISMIP6 retreat parameterization from Slater et al. (2019)"
                             possible_values="any negative real value"
                 />
+                <nml_option name="config_calving_error_threshold" type="real" default_value="0.1" units="none"
+                            description="Fraction of total volume intended to be ablated remaining before an error is triggered."
+                            possible_values="any positive real value"
+                />
                 <nml_option name="config_distribute_unablatedVolumeDynCell" type="logical" default_value=".true." units="unitless"
                         description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity."
                         possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -477,15 +477,19 @@
 			possible_values="Any non-negative real value."
 		/>
 		<nml_option name="config_adaptive_timestep_CFL_fraction" type="real" default_value="0.25" units="none"
-			description="A multiplier on the minimum allowable time step calculated from the CFL condition. (Setting to 1.0 may be unstable, so smaller values are recommended.)"
+			description="A multiplier on the minimum allowable time step calculated from the advective CFL condition. (Setting to 1.0 may be unstable, so smaller values are recommended.)  Note that 'advective' is not in the name.  This is for backwards compatibility"
 			possible_values="Any positive real value less than 1.0."
 		/>
 		<nml_option name="config_adaptive_timestep_calvingCFL_fraction" type="real" default_value="0.5" units="none"
 			description="A multiplier on the minimum allowable time step calculated from the calving CFL condition. This should be conservative given the calving CFL calculation is lagged"
-			possible_values="Any positive real value less than 1.0."
+			possible_values="Any positive real value.  Note that values greater than 1.0 are allowed and may be desired.  This is because the calving CFL is an approximate calculation."
 		/>
 		<nml_option name="config_adaptive_timestep_include_DCFL" type="logical" default_value=".false." units="none"
 			description="Option of whether to include the diffusive CFL condition in the determination of the maximum allowable timestep. The diffusive CFL condition at any location is estimated based on the local ice flux and surface slope."
+			possible_values=".true. or .false."
+		/>
+		<nml_option name="config_adaptive_timestep_include_calving" type="logical" default_value=".false." units="none"
+			description="Option of whether to include the calving CFL condition in the determination of the maximum allowable timestep. This only is applied if config_calving is set to a method that uses a calvingVelocity.  Note that this is an approximate CFL condition and is lagged a timestep."
 			possible_values=".true. or .false."
 		/>
 		<nml_option name="config_adaptive_timestep_force_interval" type="character" default_value="1000-00-00_00:00:00" units="unitless"

--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -97,7 +97,6 @@
                 <var name="basalSpeedMax" type="real" dimensions="Time" units="m yr^{-1}"
                         description="maximum basal speed in the domain"
                 />
-
  	</var_struct>
 	<streams>
 		<stream name="globalStatsOutput" type="output"
@@ -110,7 +109,14 @@
 				clobber_mode="truncate"
 				runtime_format="single_file">
 			<var name="xtime"/>
+			<var name="deltat"/>
                         <var name="daysSinceStart"/>
+                        <var name="simulationStartTime"/>
+                        <var name="allowableDtACFL"/>
+                        <var name="allowableDtDCFL"/>
+                        <var name="calvingCFLdt"/>
+                        <var name="dtCalvingCFLratio"/>
+                        <var name="processLimitingTimestep"/>
                         <var_struct name="globalStatsAM"/>
 		</stream>
 	</streams>

--- a/components/mpas-albany-landice/src/mode_forward/Makefile
+++ b/components/mpas-albany-landice/src/mode_forward/Makefile
@@ -30,7 +30,8 @@ mpas_li_core.o: mpas_li_time_integration.o \
                      mpas_li_velocity.o \
                      mpas_li_thermal.o \
                      mpas_li_diagnostic_vars.o \
-                     mpas_li_statistics.o
+                     mpas_li_statistics.o \
+                     mpas_li_calving.o
 
 mpas_li_time_integration.o: mpas_li_time_integration_fe.o
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1168,6 +1168,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), pointer :: calvingCFLdt
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), pointer :: cellMask
@@ -1222,6 +1223,7 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1250,7 +1252,7 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, err=err_tmp)
+                                              applyToFloating, applyToGroundingLine, domain, calvingCFLdt, err=err_tmp)
          err = ior(err, err_tmp)
 
          if ( trim(config_damage_calving_method) == 'none' ) then
@@ -1386,6 +1388,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), pointer :: calvingCFLdt
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), pointer :: cellMask
@@ -1428,6 +1431,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingVelocityData', calvingVelocityData)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1452,7 +1456,7 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.true., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, err=err_tmp)
          err = ior(err, err_tmp)
 
          ! === apply calving ===
@@ -1854,6 +1858,7 @@ module li_calving
                                         calvingVelocity, thickness, &
                                         xvelmean, yvelmean, calvingThickness, &
                                         bedTopography
+      real (kind=RKIND), pointer :: calvingCFLdt
       integer, pointer :: nCells, timestepNumber
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
@@ -1895,6 +1900,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+      call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(velocityPool, 'xvelmean', xvelmean)
       call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
@@ -2032,7 +2038,7 @@ module li_calving
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded=.true., &
                                               applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, err=err)
+                                              domain=domain, maxDt=calvingCFLdt, err=err)
 
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
@@ -2836,6 +2842,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+      real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
       real (kind=RKIND), dimension(:), pointer :: damage
       integer, dimension(:), pointer :: calvingFrontMask
@@ -2890,6 +2897,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
+         call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
 
 
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
@@ -2906,7 +2914,7 @@ module li_calving
                 * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND) ! calculate only for floating ice
              call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.false., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, err=err_tmp)
              err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1250,7 +1250,8 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, err)
+                                              applyToFloating, applyToGroundingLine, domain, err=err_tmp)
+         err = ior(err, err_tmp)
 
          if ( trim(config_damage_calving_method) == 'none' ) then
             ! do nothing
@@ -1570,6 +1571,7 @@ module li_calving
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA, &
                                         temperature, layerThickness
       real (kind=RKIND), pointer :: config_default_flowParamA
+      real (kind=RKIND), pointer :: calvingCFLdt
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress, damage
@@ -1619,6 +1621,7 @@ module li_calving
           call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
           call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
           call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
+          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
           call mpas_pool_get_array(geometryPool, 'groundedVonMisesThresholdStress', groundedVonMisesThresholdStress)
           call mpas_pool_get_array(geometryPool, 'floatingVonMisesThresholdStress', floatingVonMisesThresholdStress)
@@ -1708,7 +1711,7 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, err_tmp)
+                                              applyToFloating, applyToGroundingLine, domain, calvingCFLdt, err_tmp)
           err = ior(err, err_tmp)
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
@@ -2098,7 +2101,7 @@ module li_calving
 !-----------------------------------------------------------------------
 
    subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, ablationThickness, ablationVelocity, &
-                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, err)
+                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, maxDt, err)
 
       use ieee_arithmetic, only : ieee_is_nan
 
@@ -2119,9 +2122,10 @@ module li_calving
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
+      real (kind=RKIND), optional :: maxDt !< Output: an approximation of the max allowable dt based on a CFL-like condition
       integer, intent(out) :: err !< Output: error flag
 
-      integer, pointer :: nEdges, nCells, nCellsSolve, maxEdges
+      integer, pointer :: nEdges, nEdgesSolve, nCells, nCellsSolve, maxEdges
       integer :: iEdge, iCell, jCell, kCell, iNeighbor, jNeighbor
       integer :: nEmptyNeighbors, nGroundedNeighbors, counter, nTwoCellsBack, nOneCellBack
       real (kind=RKIND), dimension(:), pointer :: thickness
@@ -2129,12 +2133,13 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask, edgeMask
       integer, dimension(:), pointer :: frontAblationMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, faceMeltingThickness
       real (kind=RKIND), pointer :: config_sea_level
       logical, pointer :: config_distribute_unablatedVolumeDynCell
-      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: dvEdge, dcEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity, faceMeltSpeed
       real (kind=RKIND), dimension(:), pointer :: areaCell
@@ -2161,6 +2166,7 @@ module li_calving
       real(kind=RKIND), dimension(6) :: localInfo, globalInfo
       real(kind=RKIND) :: edgeLengthScaling
       real(kind=RKIND), parameter :: ablationSmallThk = 1.0e-8_RKIND ! in meters, a small thickness threshold
+      real(kind=RKIND) :: minOfMaxAllowableDt
       integer :: err_tmp, nDynNeighbors
 
       err = 0
@@ -2171,9 +2177,12 @@ module li_calving
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(meshPool, 'angleEdge', angleEdge)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
@@ -2296,6 +2305,18 @@ module li_calving
             enddo
          endif
       enddo
+
+      ! Calculate an approximate ablation CFL limiting dt
+      if (present(maxDt)) then
+         minOfMaxAllowableDt = 1.0e16_RKIND ! Initialize to large number
+         do iEdge = 1, nEdgesSolve
+            if ((frontAblationMask(cellsOnEdge(1,iEdge)) > 0) .or. (frontAblationMask(cellsOnEdge(2,iEdge)) > 0)) then
+               minOfMaxAllowableDt = min(minOfMaxAllowableDt, &
+                    0.5_RKIND * dcEdge(iEdge) / &
+                    (max(ablationVelocity(cellsOnEdge(1,iEdge)), ablationVelocity(cellsOnEdge(2,iEdge))) + 1.0E-18_RKIND) )
+            endif
+         enddo
+      endif
 
       ! Init fields for accounting
       ablationThickness(:) = 0.0_RKIND
@@ -2706,6 +2727,10 @@ module li_calving
       localInfo(6) = sum(unablatedVolumeDynCell(1:nCellsSolve))
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_dmpar_sum_real_array(domain % dminfo, 6, localInfo, globalInfo)
+      if (present(maxDt)) then
+         ! Do this global reduce at the same time as the previous for efficiency
+         call mpas_dmpar_min_real(domain % dminfo, minOfMaxAllowableDt, maxDt)
+      endif
       call mpas_log_write("== Ablation complete. Total calved                    = $r", realArgs = (/globalInfo(4)/))
       call mpas_log_write("==                   Ablated from non-dynamic cells   = $r", realArgs = (/globalInfo(1)/))
       call mpas_log_write("==                   Ablated from dynamic cells       = $r", realArgs = (/globalInfo(2)/))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2155,6 +2155,7 @@ module li_calving
       integer, dimension(:), pointer :: frontAblationMask
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, faceMeltingThickness
       real (kind=RKIND), pointer :: config_sea_level
+      real (kind=RKIND), pointer :: config_calving_error_threshold
       logical, pointer :: config_distribute_unablatedVolumeDynCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge, dcEdge
       real (kind=RKIND), dimension(:), pointer :: angleEdge
@@ -2190,6 +2191,7 @@ module li_calving
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_calving_error_threshold', config_calving_error_threshold)
       call mpas_pool_get_config(liConfigs, 'config_distribute_unablatedVolumeDynCell', config_distribute_unablatedVolumeDynCell)
 
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -2765,7 +2767,7 @@ module li_calving
                  realArgs=(/globalInfo(5) + globalInfo(6), &
                  100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
       endif
-      if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > 0.1_RKIND) .and. &
+      if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > config_calving_error_threshold) .and. &
           (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
          call mpas_log_write("Failed to ablate an amount greater than 10% of the ice ablated.  " // &
                  "Try reducing time step or li_apply_front_ablation_velocity may need improvements.", &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2138,8 +2138,10 @@ module li_calving
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
-      real (kind=RKIND), optional :: maxDt !< Output: an approximation of the max allowable dt based on a CFL-like condition
-      real (kind=RKIND), optional :: CFLratio !< Output: the ratio of the actual timestep being applied to what maximum allowable
+      real (kind=RKIND), optional :: maxDt
+          !< Output: an approximation of the max allowable dt based on a CFL-like condition calculated from ablation velocity
+      real (kind=RKIND), optional :: CFLratio
+          !< Output: the ratio of the actual timestep being applied to the maximum allowable timestep from the CFL-like condition
       integer, intent(out) :: err !< Output: error flag
 
       integer, pointer :: nEdges, nEdgesSolve, nCells, nCellsSolve, maxEdges
@@ -2609,7 +2611,7 @@ module li_calving
                      requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
                      unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
                      !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
-                     !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
+                     !   realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/)) ! Note: change to global IDs
                      if (bedTopography(jCell) >= config_sea_level) then
                         requiredAblationVolumeDynEdge(iEdge) = 0.0_RKIND ! Don't pass this further if it would go above sea level
                      endif
@@ -2750,10 +2752,10 @@ module li_calving
             unablatedVolumeDynCell(iCell) = 0.0_RKIND
          endif
          ! Clean up round off.  Because this is volume, threshold can be kind of large
-         if (unablatedVolumeNonDynCell(iCell) < 1.0e-5_RKIND) then
+         if (unablatedVolumeNonDynCell(iCell) < (ablationSmallThk * areaCell(iCell))) then
             unablatedVolumeNonDynCell(iCell) = 0.0_RKIND
          endif
-         if (unablatedVolumeDynCell(iCell) < 1.0e-5_RKIND) then
+         if (unablatedVolumeDynCell(iCell) < (ablationSmallThk * areaCell(iCell))) then
             unablatedVolumeDynCell(iCell) = 0.0_RKIND
          endif
       enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2513,6 +2513,9 @@ module li_calving
             ablationThickness(iCell) = removeVolumeHere / areaCell(iCell)
             ablatedVolumeNonDynCell(iCell) = removeVolumeHere
             unablatedVolumeNonDynCell(iCell) = requiredAblationVolumeNonDynCell(iCell) - removeVolumeHere
+            if (bedTopography(iCell) >= config_sea_level) then
+               unablatedVolumeNonDynCell(iCell) = 0.0_RKIND ! Ignore leftover potential calving when we hit sea level
+            endif
             cellVolume(iCell) = cellVolume(iCell) - removeVolumeHere
             if (iCell <= nCellsSolve) ablationSubtotal1 = ablationSubtotal1 + removeVolumeHere
          endif
@@ -2557,7 +2560,7 @@ module li_calving
             .and. li_mask_is_margin(cellMask(iCell)) ) then                            ! that is at the edge of the ice
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
-               if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) <= config_sea_level)) then
+               if ((.not. li_mask_is_ice(cellMask(jCell))) .and. (bedTopography(jCell) < config_sea_level)) then
                   iEdge = edgesOnCell(iNeighbor, iCell)
                   edgeLengthScaling = scale_edge_length(angleEdge(iEdge), uvelForAblation(iCell), vvelForAblation(iCell))
                   requiredAblationVolumeDynEdge(iEdge) = ablationVelocity(iCell) * &
@@ -2589,7 +2592,7 @@ module li_calving
                endif
             enddo
 
-            ! Now that we know calvLengthCell, pass along the required calving volume relative to the interface length
+            ! Now that we know ablateLengthCell, pass along the required calving volume relative to the interface length
             if ( ablateLengthCell > 0.0_RKIND ) then
                do iNeighbor = 1, nEdgesOnCell(iCell)
                   iEdge = edgesOnCell(iNeighbor, iCell)
@@ -2605,8 +2608,11 @@ module li_calving
                      endif
                      requiredAblationVolumeDynEdge(iEdge) = ablateLengthEdge / ablateLengthCell * volumeAvailableToPass
                      unablatedVolumeNonDynCell(iCell) = unablatedVolumeNonDynCell(iCell) - requiredAblationVolumeDynEdge(iEdge)
-                    !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
-                    !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
+                     !call mpas_log_write("   Passed calving $r from non-dynamic cell $i to dynamic cell $i", &
+                     !        realArgs=(/requiredAblationVolumeDynEdge(iEdge)/), intArgs=(/iCell, jCell/))
+                     if (bedTopography(jCell) >= config_sea_level) then
+                        requiredAblationVolumeDynEdge(iEdge) = 0.0_RKIND ! Don't pass this further if it would go above sea level
+                     endif
                   endif
                enddo
             endif
@@ -2618,7 +2624,7 @@ module li_calving
 
       ! c. Now apply ablation to each cell
       do iCell = 1, nCells
-         if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level)) then
+         if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level)) then
             ! Can loop over all dyn cells - only ones with calving on their edges will have calving applied.
             ! Note, we ignore any leftover calving/melting if it would be applied to cells where the bed is above sea level.
             do iNeighbor = 1, nEdgesOnCell(iCell)
@@ -2659,7 +2665,7 @@ module li_calving
                ! unablatedVolumeDynCell
                do iEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(iEdge, iCell)
-                  if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
+                  if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) < config_sea_level) &
                        .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
                      nDynNeighbors = nDynNeighbors + 1
                   endif
@@ -2668,7 +2674,7 @@ module li_calving
                   ! Now distribute unablatedVolumeDynCell between those neighbors
                   do iEdge = 1, nEdgesOnCell(iCell)
                      iNeighbor = cellsOnCell(iEdge, iCell)
-                     if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) <= config_sea_level) &
+                     if ((li_mask_is_dynamic_ice(cellMask(iNeighbor))) .and. (bedTopography(iNeighbor) < config_sea_level) &
                        .and. ( cellVolume(iNeighbor) > (ablationSmallThk * areaCell(iNeighbor)) ) ) then
                         unablatedVolumeDynCell(iNeighbor) = unablatedVolumeDynCell(iNeighbor) + &
                                                                 unablatedVolumeDynCell(iCell) / nDynNeighbors
@@ -2682,7 +2688,7 @@ module li_calving
 
          ! b. Apply ablation
          do iCell = 1, nCells
-             if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) <= config_sea_level) &
+             if ((li_mask_is_dynamic_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) &
                   .and. ( cellVolume(iCell) > (ablationSmallThk * areaCell(iCell)) ) &
                   .and. (unablatedVolumeDynCell(iCell) > 0.0_RKIND) ) then
                   removeVolumeHere = min(cellVolume(iCell), unablatedVolumeDynCell(iCell))  ! Don't use more than available
@@ -2736,6 +2742,21 @@ module li_calving
          endif
       enddo
 
+      ! Clean up to unablated volume arrays before checking for errors
+      do iCell = 1, nCells
+         ! Eliminate leftover potental calving from cells above sea level to avoid erroneous warnings/errors
+         if (bedTopography(iCell) >= config_sea_level) then
+            unablatedVolumeNonDynCell(iCell) = 0.0_RKIND
+            unablatedVolumeDynCell(iCell) = 0.0_RKIND
+         endif
+         ! Clean up round off.  Because this is volume, threshold can be kind of large
+         if (unablatedVolumeNonDynCell(iCell) < 1.0e-5_RKIND) then
+            unablatedVolumeNonDynCell(iCell) = 0.0_RKIND
+         endif
+         if (unablatedVolumeDynCell(iCell) < 1.0e-5_RKIND) then
+            unablatedVolumeDynCell(iCell) = 0.0_RKIND
+         endif
+      enddo
 
       ! End of routine accounting/reporting
       localInfo(1) = ablationSubtotal1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1169,6 +1169,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), pointer :: cellMask
@@ -1224,6 +1225,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+         call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1252,7 +1254,8 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, calvingCFLdt, err=err_tmp)
+                                              applyToFloating, applyToGroundingLine, domain, calvingCFLdt, dtCalvingCFLratio, &
+                                              err=err_tmp)
          err = ior(err, err_tmp)
 
          if ( trim(config_damage_calving_method) == 'none' ) then
@@ -1389,6 +1392,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:), pointer :: cellMask
@@ -1432,6 +1436,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+         call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1456,7 +1461,7 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.true., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err_tmp)
          err = ior(err, err_tmp)
 
          ! === apply calving ===
@@ -1576,6 +1581,7 @@ module li_calving
                                         temperature, layerThickness
       real (kind=RKIND), pointer :: config_default_flowParamA
       real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress, damage
@@ -1626,6 +1632,7 @@ module li_calving
           call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
           call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
           call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
           call mpas_pool_get_array(geometryPool, 'groundedVonMisesThresholdStress', groundedVonMisesThresholdStress)
           call mpas_pool_get_array(geometryPool, 'floatingVonMisesThresholdStress', floatingVonMisesThresholdStress)
@@ -1715,7 +1722,8 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
-                                              applyToFloating, applyToGroundingLine, domain, calvingCFLdt, err_tmp)
+                                              applyToFloating, applyToGroundingLine, domain, &
+                                              calvingCFLdt, dtCalvingCFLratio, err_tmp)
           err = ior(err, err_tmp)
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
@@ -1859,6 +1867,7 @@ module li_calving
                                         xvelmean, yvelmean, calvingThickness, &
                                         bedTopography
       real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, pointer :: nCells, timestepNumber
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
@@ -1901,6 +1910,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
       call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+      call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(velocityPool, 'xvelmean', xvelmean)
       call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
@@ -2038,7 +2048,7 @@ module li_calving
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded=.true., &
                                               applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, err=err)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err)
 
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
@@ -2107,7 +2117,7 @@ module li_calving
 !-----------------------------------------------------------------------
 
    subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, ablationThickness, ablationVelocity, &
-                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, maxDt, err)
+                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, maxDt, CFLratio, err)
 
       use ieee_arithmetic, only : ieee_is_nan
 
@@ -2129,6 +2139,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       real (kind=RKIND), optional :: maxDt !< Output: an approximation of the max allowable dt based on a CFL-like condition
+      real (kind=RKIND), optional :: CFLratio !< Output: the ratio of the actual timestep being applied to what maximum allowable
       integer, intent(out) :: err !< Output: error flag
 
       integer, pointer :: nEdges, nEdgesSolve, nCells, nCellsSolve, maxEdges
@@ -2736,6 +2747,12 @@ module li_calving
       if (present(maxDt)) then
          ! Do this global reduce at the same time as the previous for efficiency
          call mpas_dmpar_min_real(domain % dminfo, minOfMaxAllowableDt, maxDt)
+         if (present(CFLratio)) then
+            CFLratio = deltat / maxDt
+            if (CFLratio > 1.0_RKIND) then
+               call mpas_log_write("Ratio of dt to calving CFL dt exceeds 1: $r", MPAS_LOG_WARN, realArgs = (/CFLratio/))
+            endif
+         endif
       endif
       call mpas_log_write("== Ablation complete. Total calved                    = $r", realArgs = (/globalInfo(4)/))
       call mpas_log_write("==                   Ablated from non-dynamic cells   = $r", realArgs = (/globalInfo(1)/))
@@ -2843,6 +2860,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: dtCalvingCFLratio
       real (kind=RKIND), dimension(:), pointer :: eMax, eMin
       real (kind=RKIND), dimension(:), pointer :: damage
       integer, dimension(:), pointer :: calvingFrontMask
@@ -2898,6 +2916,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+         call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
 
 
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
@@ -2914,7 +2933,7 @@ module li_calving
                 * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND) ! calculate only for floating ice
              call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.false., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err_tmp)
              err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -433,7 +433,11 @@ module li_core
             block => block % next
          end do
 
-         call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/), flushNow=.true.)
+         call mpas_log_write('')
+         call mpas_log_write('=============================')
+         call mpas_log_write('Starting timestep number $i', intArgs=(/timestepNumber/))
+         call mpas_log_write('=============================')
+         call mpas_log_write('', flushNow=.true.)
 
          ! ===
          ! === Perform Timestep

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -935,6 +935,7 @@ module li_core
       type (mpas_pool_type), pointer :: geometryPool
       integer, dimension(:), pointer :: vertexMask
       real (kind=RKIND), dimension(:), pointer :: thickness, thicknessOld
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       character (len=StrKIND), pointer :: config_velocity_solver
       logical, pointer :: config_do_velocity_reconstruction_for_external_dycore
       logical, pointer :: config_adaptive_timestep_include_DCFL
@@ -1008,6 +1009,11 @@ module li_core
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'thicknessOld', thicknessOld)
       thicknessOld = thickness
+
+      ! Initialize layerThickness
+      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
+      call li_calculate_layerThickness(meshPool, thickness, layerThickness)
+
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -685,6 +685,7 @@ module li_core
       use li_setup
       use li_statistics
       use li_advection
+      use li_calving, only: li_calve_ice
       use mpas_io_streams, only: MPAS_STREAM_LATEST_BEFORE
 
       implicit none
@@ -720,6 +721,8 @@ module li_core
       ! Variables needed for printing timestamps
       type (MPAS_Time_Type) :: currTime
       character(len=StrKIND) :: timeStamp
+      real(kind=RKIND), pointer :: deltat
+      real(kind=RKIND) :: deltatTemp
 
       integer :: err, err_tmp, globalErr
       logical :: solveVelo
@@ -778,6 +781,27 @@ module li_core
       ! Initial velocity solve
       call li_velocity_solve(domain, solveVelo=solveVelo, err=err_tmp)
       err = ior(err, err_tmp)
+
+      ! Initial calving solution
+      ! This is required for the calving CFL to work correctly
+      ! For rate-based calving laws, no calving actually occurs because dt=0.
+      ! For threshold calving laws (e.g. thickness-based) calving *will* occur
+      ! Note that during a timestep, calving occurs before velocity, but because
+      ! many calving laws require velocity-related fields, it need to be called
+      ! after velocity here.
+      if (.not. config_do_restart) then
+         ! Temporarily set dt to 0 to avoid actually calving anything for rate-based calving laws
+         call mpas_pool_get_array(meshPool, 'deltat', deltat)
+         deltatTemp = deltat
+         deltat = 0.0_RKIND
+
+         call li_calve_ice(domain, err_tmp)
+         err = ior(err, err_tmp)
+
+         ! Restore appropriate value for dt
+         deltat = deltatTemp
+      endif
+
 
       ! Calculate diagnostic vars
       call li_calculate_diagnostic_vars(domain, err=err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -791,7 +791,7 @@ module li_core
       ! For rate-based calving laws, no calving actually occurs because dt=0.
       ! For threshold calving laws (e.g. thickness-based) calving *will* occur
       ! Note that during a timestep, calving occurs before velocity, but because
-      ! many calving laws require velocity-related fields, it need to be called
+      ! many calving laws require velocity-related fields, it needs to be called
       ! after velocity here.
       if (.not. config_do_restart) then
          ! Temporarily set dt to 0 to avoid actually calving anything for rate-based calving laws

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1433,7 +1433,8 @@ module li_iceshelf_melt
          ! Distribute melt among neighbors
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                             faceMeltingThickness, faceMeltSpeedVertAvg, applyToGrounded, &
-                                            applyToFloating, applyToGroundingLine, domain, err)
+                                            applyToFloating, applyToGroundingLine, domain, err=err_tmp)
+         err = ior(err, err_tmp)
 
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -922,11 +922,13 @@ module li_time_integration_fe
          call mpas_log_write("Timestep limited by calving CFL condition.")
       endif
 
+      ! Take minimum of the max adaptive timestep setting and the allowable dt from the CFL condition
+      proposedDt = min(allowableDt, config_max_adaptive_timestep)
 
       ! Round down the proposed dt to avoid complications with fractional seconds
       ! (some timekeeping-related functionality, like restarts, don't support them)
       ! (need to perform floor with an 8-bit integer to allow up 293 billion years in seconds)
-      proposedDt = real(floor(allowableDt, KIND=8), RKIND)
+      proposedDt = real(floor(proposedDt, KIND=8), RKIND)
 
       ! Check if the proposed timestep is smaller than specified limit.
       ! Do this prior to limiting the timestep for the force interval

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -284,6 +284,7 @@ module li_time_integration_fe
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
       real (kind=RKIND), pointer :: calvingCFLdt
+      integer, pointer :: processLimitingTimestep
       integer, dimension(:), pointer :: edgeMask
 
       logical, pointer :: config_print_thickness_advection_info
@@ -505,7 +506,8 @@ module li_time_integration_fe
       ! Set adaptive timestep if needed
       if (config_adaptive_timestep) then
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
-         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, calvingCFLdt, domain % clock, dtSeconds, err_tmp)
+         call mpas_pool_get_array(meshPool, 'processLimitingTimestep', processLimitingTimestep)
+         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, calvingCFLdt, domain % clock, dtSeconds, processLimitingTimestep, err_tmp)
          err = ior(err,err_tmp)
          ! Set new value on all blocks
          block => domain % blocklist
@@ -833,7 +835,7 @@ module li_time_integration_fe
 !>  This routine sdjusts the time step based on the CFL condition.
 !
 !-----------------------------------------------------------------------
-   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, calvingCFLdt, clock, dtSeconds, err)
+   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, calvingCFLdt, clock, dtSeconds, CFLprocess, err)
       use mpas_timekeeping
 
       !-----------------------------------------------------------------
@@ -848,6 +850,7 @@ module li_time_integration_fe
       ! output variables
       !-----------------------------------------------------------------
       real (kind=RKIND), intent(out) :: dtSeconds  !< Output: time step in seconds determined by this routine
+      integer, intent(out) :: CFLprocess !< Output: flag for which process limits the CFL: 1=advective, 2=diffusive, 3=calving
       integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------
@@ -881,12 +884,16 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
+
+      allowableDt = allowableAdvecDt * config_adaptive_timestep_CFL_fraction
+      CFLprocess = 1
       if (config_adaptive_timestep_include_DCFL) then
          ! todo: We currently do not have a namelist option for the diffusive CFL fraction
          ! But that's ok - we rarely use it.  Could be added later if needed.
-         allowableDt = min(allowableAdvecDt * config_adaptive_timestep_CFL_fraction, allowableDiffDt)
-      else
-         allowableDt = allowableAdvecDt * config_adaptive_timestep_CFL_fraction
+         if (allowableDiffDt < allowableDt) then
+            allowableDt = allowableDiffDt
+            CFLprocess = 2
+         endif
       endif
 
       ! Only include calving CFL if requested and we are using a calving option that calculates it
@@ -897,12 +904,24 @@ module li_time_integration_fe
              trim(config_calving) == 'ismip6_retreat' .or. &
              (trim(config_calving) == 'damagecalving' .and. &
               trim(config_damage_calving_method) == 'calving_rate'))) then
-         allowableDt = min(allowableDt, config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt)
+         if (config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt < allowableDt) then
+            allowableDt = config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt
+            CFLprocess = 3
+         endif
       endif
 
-      call mpas_log_write("CFL dts adjusted for fractions: advective=$r, diffusive=$r, calving=$r", &
-         realArgs=(/allowableAdvecDt*config_adaptive_timestep_CFL_fraction, allowableDiffDt, &
-                    calvingCFLdt*config_adaptive_timestep_calvingCFL_fraction/))
+      call mpas_log_write("CFL dt adjusted for fractions (days): advective=$r, diffusive=$r, calving=$r", &
+         realArgs=(/allowableAdvecDt*config_adaptive_timestep_CFL_fraction/86400.0_RKIND, &
+                    allowableDiffDt/86400.0_RKIND, &
+                    calvingCFLdt*config_adaptive_timestep_calvingCFL_fraction/86400.0_RKIND/))
+      if (CFLprocess == 1) then
+         call mpas_log_write("Timestep limited by advective CFL condition.")
+      elseif (CFLprocess == 2) then
+         call mpas_log_write("Timestep limited by diffusive CFL condition.")
+      elseif (CFLprocess == 3) then
+         call mpas_log_write("Timestep limited by calving CFL condition.")
+      endif
+
 
       ! Round down the proposed dt to avoid complications with fractional seconds
       ! (some timekeeping-related functionality, like restarts, don't support them)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -909,6 +909,13 @@ module li_time_integration_fe
       ! (need to perform floor with an 8-bit integer to allow up 293 billion years in seconds)
       proposedDt = real(floor(allowableDt, KIND=8), RKIND)
 
+      ! Check if the proposed timestep is smaller than specified limit.
+      ! Do this prior to limiting the timestep for the force interval
+      if (proposedDt < config_min_adaptive_timestep) then
+         call mpas_log_write('New deltat is less than config_min_adaptive_timestep.', MPAS_LOG_ERR)
+         err = ior(err, 1)
+      endif
+
       ! Check if we need to force a timestep length to hit the target interval
       currTime = mpas_get_clock_time(clock, MPAS_NOW, err_tmp)
       !print *, 'curr', currTime % t % YR, currTime % t % basetime % S, currTime % t % basetime % Sn, currTime % t % basetime % Sd
@@ -945,10 +952,6 @@ module li_time_integration_fe
       dtSeconds = min(proposedDt, secondsToNextForceTime)
 
       call mpas_log_write('  Setting time step (days) to: $r', realArgs=(/dtSeconds / (86400.0_RKIND)/))
-      if (dtSeconds < config_min_adaptive_timestep) then
-         call mpas_log_write('New deltat is less than config_min_adaptive_timestep.', MPAS_LOG_ERR)
-         err = ior(err, 1)
-      endif
 
    !--------------------------------------------------------------------
    end subroutine set_timestep

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -283,6 +283,7 @@ module li_time_integration_fe
 
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
+      real (kind=RKIND), pointer :: calvingCFLdt
       integer, dimension(:), pointer :: edgeMask
 
       logical, pointer :: config_print_thickness_advection_info
@@ -503,7 +504,8 @@ module li_time_integration_fe
 
       ! Set adaptive timestep if needed
       if (config_adaptive_timestep) then
-         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, domain % clock, dtSeconds, err_tmp)
+         call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, calvingCFLdt, domain % clock, dtSeconds, err_tmp)
          err = ior(err,err_tmp)
          ! Set new value on all blocks
          block => domain % blocklist
@@ -831,7 +833,7 @@ module li_time_integration_fe
 !>  This routine sdjusts the time step based on the CFL condition.
 !
 !-----------------------------------------------------------------------
-   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, clock, dtSeconds, err)
+   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, calvingCFLdt, clock, dtSeconds, err)
       use mpas_timekeeping
 
       !-----------------------------------------------------------------
@@ -839,6 +841,7 @@ module li_time_integration_fe
       !-----------------------------------------------------------------
       real (kind=RKIND), intent(in) :: allowableAdvecDt
       real (kind=RKIND), intent(in) :: allowableDiffDt
+      real (kind=RKIND), intent(in) :: calvingCFLdt
       type (MPAS_Clock_type), intent(in) :: clock
 
       !-----------------------------------------------------------------
@@ -852,6 +855,7 @@ module li_time_integration_fe
       !-----------------------------------------------------------------
       logical, pointer :: config_adaptive_timestep_include_DCFL
       real (kind=RKIND), pointer :: config_adaptive_timestep_CFL_fraction
+      real (kind=RKIND), pointer :: config_adaptive_timestep_calvingCFL_fraction
       real (kind=RKIND), pointer :: config_max_adaptive_timestep
       real (kind=RKIND), pointer :: config_min_adaptive_timestep
       type (MPAS_Time_type) :: nextForceTime, currTime
@@ -869,11 +873,18 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_max_adaptive_timestep', config_max_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_min_adaptive_timestep', config_min_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
+      call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_calvingCFL_fraction', config_adaptive_timestep_calvingCFL_fraction)
 
       if (config_adaptive_timestep_include_DCFL) then
          allowableDt = min(allowableAdvecDt, allowableDiffDt)
       else
          allowableDt = allowableAdvecDt
+      endif
+
+      call mpas_log_write("CFL dts: advective=$r, diffusive=$r, calving=$r", realArgs=(/allowableAdvecDt, allowableDiffDt, calvingCFLdt/))
+      if (config_adaptive_timestep_calvingCFL_fraction * calvingCFLdt < allowableDt) then
+         call mpas_log_write("NOTE: Calving CFL < min of advective and diffusive CFL.")
+         allowableDt = config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt
       endif
 
       ! Take minimum of the max adaptive timestep setting and the allowable dt from the CFL condition

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -854,10 +854,13 @@ module li_time_integration_fe
       ! local variables
       !-----------------------------------------------------------------
       logical, pointer :: config_adaptive_timestep_include_DCFL
+      logical, pointer :: config_adaptive_timestep_include_calving
       real (kind=RKIND), pointer :: config_adaptive_timestep_CFL_fraction
       real (kind=RKIND), pointer :: config_adaptive_timestep_calvingCFL_fraction
       real (kind=RKIND), pointer :: config_max_adaptive_timestep
       real (kind=RKIND), pointer :: config_min_adaptive_timestep
+      character (len=StrKIND), pointer :: config_calving
+      character (len=StrKIND), pointer :: config_damage_calving_method
       type (MPAS_Time_type) :: nextForceTime, currTime
       type (MPAS_TimeInterval_type) :: intervalToNextForceTime
       real (kind=RKIND) :: secondsToNextForceTime
@@ -873,26 +876,38 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_max_adaptive_timestep', config_max_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_min_adaptive_timestep', config_min_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
+      call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_calving', config_adaptive_timestep_include_calving)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_calvingCFL_fraction', config_adaptive_timestep_calvingCFL_fraction)
+      call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
+      call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
       if (config_adaptive_timestep_include_DCFL) then
-         allowableDt = min(allowableAdvecDt, allowableDiffDt)
+         ! todo: We currently do not have a namelist option for the diffusive CFL fraction
+         ! But that's ok - we rarely use it.  Could be added later if needed.
+         allowableDt = min(allowableAdvecDt * config_adaptive_timestep_CFL_fraction, allowableDiffDt)
       else
-         allowableDt = allowableAdvecDt
+         allowableDt = allowableAdvecDt * config_adaptive_timestep_CFL_fraction
       endif
 
-      call mpas_log_write("CFL dts: advective=$r, diffusive=$r, calving=$r", realArgs=(/allowableAdvecDt, allowableDiffDt, calvingCFLdt/))
-      if (config_adaptive_timestep_calvingCFL_fraction * calvingCFLdt < allowableDt) then
-         call mpas_log_write("NOTE: Calving CFL < min of advective and diffusive CFL.")
-         allowableDt = config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt
+      ! Only include calving CFL if requested and we are using a calving option that calculates it
+      if (config_adaptive_timestep_include_calving .and. ( &
+             trim(config_calving) == 'specified_calving_velocity' .or. &
+             trim(config_calving) == 'eigencalving' .or. &
+             trim(config_calving) == 'von_Mises_stress' .or. &
+             trim(config_calving) == 'ismip6_retreat' .or. &
+             (trim(config_calving) == 'damagecalving' .and. &
+              trim(config_damage_calving_method) == 'calving_rate'))) then
+         allowableDt = min(allowableDt, config_adaptive_timestep_calvingCFL_fraction * calvingCFLDt)
       endif
 
-      ! Take minimum of the max adaptive timestep setting and the allowable dt from the CFL condition
-      proposedDt = min(allowableDt * config_adaptive_timestep_CFL_fraction, config_max_adaptive_timestep)
+      call mpas_log_write("CFL dts adjusted for fractions: advective=$r, diffusive=$r, calving=$r", &
+         realArgs=(/allowableAdvecDt*config_adaptive_timestep_CFL_fraction, allowableDiffDt, &
+                    calvingCFLdt*config_adaptive_timestep_calvingCFL_fraction/))
+
       ! Round down the proposed dt to avoid complications with fractional seconds
       ! (some timekeeping-related functionality, like restarts, don't support them)
       ! (need to perform floor with an 8-bit integer to allow up 293 billion years in seconds)
-      proposedDt = real(floor(proposedDt, KIND=8), RKIND)
+      proposedDt = real(floor(allowableDt, KIND=8), RKIND)
 
       ! Check if we need to force a timestep length to hit the target interval
       currTime = mpas_get_clock_time(clock, MPAS_NOW, err_tmp)


### PR DESCRIPTION
There is reason to think it is incorrect to allow calving to remove more than a whole grid cell in a given timestep - a CFL condition for calving.  This merge calculates a calving CFL and adds it to the adaptive timestepper.  It's important to note that the calving CFL is calculated from the *previous* timestep, because determining the calving CFL prior to starting the timestep is prohibitively difficult.  That would require doing advection and other operations to generate the geometry that the calvingVelocity will be based on just to calculate the CFL limit, and then going back and actually progressing through the time step for real once the dt has been set.  So this addition works under the principle that the calving CFL limit will not change a lot from timestep to timestep, thus a lagged CFL limit is a useful way to adapt the timestep.   Testing shows this assumption works very well most, though not all, of the time.

The calving CFL is included in the adaptive timestepper with the new config_adaptive_timestep_include_calving option.  The fraction of the calving CFL to use is controlled with the new option config_adaptive_timestep_calvingCFL_fraction.

A number of other related changes are made:
* The adaptive timestepper logic and log messages are adjusted somewhat.  A significant change is that config_adaptive_timestep_CFL_fraction now only applied to the advective CFL.  There is no longer a general fraction applied.  
* The new variable processLimitingTimestep outputs a code indicating which process (advective CFL, diffusive CFL, calving) was the limiting factor in determining each timestep length.
* The new variable calvingCFLdt calculates the dt estimated for by the calving CFL.  The variable dtCalvingCFLratio is the ratio of the actual dt used to that dt indicated by the lagged calving CFL calculation.  If conditions don't change between timesteps, this should be the value chosen for config_adaptive_timestep_calvingCFL_fraction, but if calving conditions change significantly between timesteps, this variable can be used to assess how bad the choice of dt actually was.
* The 10% calving error now can be controlled with a namelist option: config_calving_error_threshold
Note could add a check and a warning if the calving CFL on the actual time step exceeds the timestep in use.
* There was a longstanding problem in the adaptive timestepper of dying if the force interval required a timestep smaller than the minimum allowable timestep.  This has been fixed.
* Log output has been modified to make the start of each timestep more obvious.