### PR TITLE
Replace iCell with indexToCellID(iCell) in log messages

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -483,7 +483,7 @@ module li_advection
             do iCell = 1, nCells
                if (indexToCellID(iCell) == config_stats_cell_ID) then
                   call mpas_log_write(' ')
-                  call mpas_log_write('After apply_mass_balance, iCell=$i, thickness=$r', intArgs=(/iCell/), &
+                  call mpas_log_write('After apply_mass_balance, indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), &
                           realArgs=(/thickness(iCell)/) )
                   call mpas_log_write('cellMask=$i, is ice=$l, is grounded=$l, is floating=$l', &
                        intArgs=(/cellMask(iCell)/), logicArgs=(/li_mask_is_ice(cellMask(iCell)), &
@@ -1761,6 +1761,7 @@ module li_advection
 
       ! pointers to mesh arrays
       real (kind=RKIND), dimension(:), pointer :: layerThicknessFractions, layerInterfaceSigma
+      integer, dimension(:), pointer :: indexToCellID
 
       ! local arrays
       real (kind=RKIND), dimension(:), allocatable :: layerInterfaceSigma_Input
@@ -1787,6 +1788,7 @@ module li_advection
 
       call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
       call mpas_pool_get_array(meshPool, 'layerInterfaceSigma', layerInterfaceSigma)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
       allocate(layerInterfaceSigma_Input(nVertLevels+1))
       allocate(hTsum(nTracers, nVertLevels))
@@ -1852,8 +1854,8 @@ module li_advection
             difference = abs(finalEnergySum - initEnergySum)
             if (initEnergySum > eps11) then
                if (difference/initEnergySum > eps11) then
-                  call mpas_log_write('vertical_remap, mass*tracer conservation error, iCell = $i', &
-                     MPAS_LOG_WARN, intArgs=(/iCell/))
+                  call mpas_log_write('vertical_remap, mass*tracer conservation error, indexToCellID = $i', &
+                     MPAS_LOG_WARN, intArgs=(/indexToCellID(iCell)/))
                   call mpas_log_write('init energy, final energy, difference: $r $r $r', &
                      realArgs=(/initEnergySum, finalEnergySum, finalEnergySum - initEnergySum/))
                endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -394,7 +394,8 @@ module li_calving
            config_dynamic_thickness
 
       integer, dimension(:), pointer :: &
-           cellMask            ! bit mask describing whether ice is floating, dynamically active, etc.
+           cellMask, &            ! bit mask describing whether ice is floating, dynamically active, etc.
+           indexToCellID
 
       real(kind=RKIND), dimension(:), pointer :: &
            layerCenterSigma    ! vertical sigma coordinate at layer midpoints
@@ -452,6 +453,7 @@ module li_calving
 
          ! get required fields from the mesh pool
          call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
+         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
          ! get required fields from the geometry pool
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -526,7 +528,7 @@ module li_calving
                   !       Save the difference (restoreThicknessMin - thickness) so as to keep track of energy non-conservation.
 
                   if (config_print_calving_info) then
-                     call mpas_log_write('Restore ice: iCell=$i, thickness=$r', intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
+                     call mpas_log_write('Restore ice: indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
                   endif
 
                   restoreThickness(iCell) = restoreThicknessMin - thickness(iCell)
@@ -551,7 +553,7 @@ module li_calving
                   ! Remove the ice and add it to calvingThickness.
 
                   if (config_print_calving_info) then
-                     call mpas_log_write('Remove ice:  iCell=$i, thickness=$r', intArgs=(/iCell/), realArgs=(/thickness(iCell)/))
+                     call mpas_log_write('Remove ice:  indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
                   endif
 
                   calvingThickness(iCell) = thickness(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1154,7 +1154,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: areaCell
       real (kind=RKIND), dimension(:), allocatable :: mean_TF, IS_area
       integer, parameter :: maxNumBasins = 32
-      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: cellMask, indexToCellID
       real(kind=RKIND), dimension(maxNumBasins*2) :: localSums, globalSums
       real (kind=RKIND), pointer :: gamma0
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
@@ -1177,6 +1177,7 @@ module li_iceshelf_melt
 
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nOceanLayers)
+         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
 
          ! Get 3d thermal forcing (had to be read-in)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', TFocean)
@@ -1216,8 +1217,8 @@ module li_iceshelf_melt
                kinf = ksup + 1
                if ((zOcean(ksup)-zOcean(kinf)) == 0) then
                   call mpas_log_write("iceshelf_melt_ismip6: Invalid value for zOcean. " // &
-                       "ksup=$i kinf=$i zOcean(ksup)=$r zOcean(kinf)=$r iCell=$i lowerSurface=$r", MPAS_LOG_ERR, &
-                       intArgs=(/ksup, kinf, iCell/), &
+                       "ksup=$i kinf=$i zOcean(ksup)=$r zOcean(kinf)=$r indexToCellID=$i lowerSurface=$r", MPAS_LOG_ERR, &
+                       intArgs=(/ksup, kinf, indexToCellID(iCell)/), &
                        realArgs=(/zOcean(ksup), zOcean(kinf), lowerSurface(iCell) /) )
                   err = ior(err, 1)
                endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -915,7 +915,7 @@ module li_thermal
                      call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                      call mpas_log_write('surfaceAirTemperature = $r', realArgs=(/surfaceAirTemperature(iCell)/))
                      call mpas_log_write(' ')
-                     call mpas_log_write('Initial column temperatures, iCell = $i', intArgs=(/iCell/))
+                     call mpas_log_write('Initial column temperatures, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                      call mpas_log_write("0 $r", realArgs=(/surfaceTemperature(iCell)/))
                      do k = 1, nVertLevels
                         call mpas_log_write("$i $r", intArgs=(/k/), realArgs=(/temperature(k,iCell)/))
@@ -964,7 +964,7 @@ module li_thermal
 
                      if (verboseColumn) then
                         call mpas_log_write(' ')
-                        call mpas_log_write('Before prognostic enthalpy, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('Before prognostic enthalpy, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                         call mpas_log_write('Temperature (C), waterFrac, enthalpy/(rhoi*cp_ice):')
                         call mpas_log_write('0 $r', realArgs=(/surfaceEnthalpy/(rhoi*cp_ice)/))
@@ -1007,7 +1007,7 @@ module li_thermal
 
                      if (verboseColumn) then
                         call mpas_log_write(' ')
-                        call mpas_log_write('After matrix elements, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('After matrix elements, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('k, subd, diag, supd, rhs/(rhoi*ci):')
                         do k = 1, nVertLevels+2
                            call mpas_log_write('$i $r $r $r $r', intArgs=(/k-1/), realArgs= &
@@ -1071,7 +1071,7 @@ module li_thermal
 
                      if (verboseColumn) then
                         call mpas_log_write(' ')
-                        call mpas_log_write('After prognostic enthalpy, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('After prognostic enthalpy, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                         call mpas_log_write('Temperature, waterFrac, enthalpy/(rhoi*cp_ice):')
                         call mpas_log_write('0 $r', realArgs=(/surfaceEnthalpy/(rhoi*cp_ice)/))
@@ -1093,7 +1093,7 @@ module li_thermal
 
                      if (verboseColumn) then
                         call mpas_log_write(' ')
-                        call mpas_log_write('Before prognostic temperature, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('Before prognostic temperature, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                         call mpas_log_write('0 $r', realArgs=(/surfaceTemperature(iCell)/))
                         do k = 1, nVertLevels
@@ -1132,7 +1132,7 @@ module li_thermal
                      if (verboseColumn) then
                         call mpas_log_write(' ')
                         call mpas_log_write('deltat = $r', realArgs=(/deltat/))
-                        call mpas_log_write('After matrix elements, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('After matrix elements, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('k, subd, diag, supd, rhs:')
                         do k = 1, nVertLevels+2
                            call mpas_log_write('$i $r $r $r $r', intArgs=(/k-1/), realArgs= &
@@ -1170,7 +1170,7 @@ module li_thermal
 
                      if (verboseColumn) then
                         call mpas_log_write(' ')
-                        call mpas_log_write('After prognostic temperature, iCell = $i', intArgs=(/indexToCellID(iCell)/))
+                        call mpas_log_write('After prognostic temperature, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                         call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                         call mpas_log_write('0 $r', realArgs=(/surfaceTemperature(iCell)/))
                         do k = 1, nVertLevels
@@ -1235,7 +1235,7 @@ module li_thermal
                            realArgs=(/basalFrictionFlux(iCell) + basalHeatFlux(iCell) + basalConductiveFlux(iCell)/))
                      endif   ! verboseColumn
 
-                     call mpas_log_write('li_thermal, energy conservation error: iCell=$i, imbalance=$r (W/m2):', MPAS_LOG_WARN, &
+                     call mpas_log_write('li_thermal, energy conservation error: indexToCellID=$i, imbalance=$r (W/m2):', MPAS_LOG_WARN, &
                              intArgs=(/indexToCellID(iCell)/), realArgs=(/(finalEnergy - initialEnergy - deltaEnergy)/deltat/))
                      !err = ior(err, 1)
 
@@ -1302,7 +1302,7 @@ module li_thermal
                mintemp = minval(temperature(:,iCell))
 
                if (maxtemp > maxtempThreshold) then
-                  call mpas_log_write('maxtemp > maxtempThreshold: iCell=$i, maxtemp = $r', intArgs=(/iCell/), &
+                  call mpas_log_write('maxtemp > maxtempThreshold: indexToCellID=$i, maxtemp = $r', intArgs=(/indexToCellID(iCell)/), &
                      realArgs=(/maxtemp/))
                   call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                   call mpas_log_write('temperature:')
@@ -1313,7 +1313,7 @@ module li_thermal
                endif
 
                if (mintemp < mintempThreshold) then
-                  call mpas_log_write('mintemp < mintempThreshold: iCell=$i, mintemp = $r', intArgs=(/iCell/), &
+                  call mpas_log_write('mintemp < mintempThreshold: indexToCellID=$i, mintemp = $r', intArgs=(/indexToCellID(iCell)/), &
                      realArgs=(/mintemp/))
                   call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
                   call mpas_log_write('temperature:')
@@ -1343,8 +1343,8 @@ module li_thermal
             endif
 
             if (config_print_thermal_info .and. indexToCellID(iCell) == config_stats_cell_ID) then
-               call mpas_log_write('iCell=$i, basal mass balance (m/yr): grounded=$r, floating=$r', &
-                    intArgs=(/iCell/), realArgs=(/groundedBasalMassBal(iCell)*scyr/rhoi, floatingBasalMassBal(iCell)*scyr/rhoi/) )
+               call mpas_log_write('indexToCellID=$i, basal mass balance (m/yr): grounded=$r, floating=$r', &
+                    intArgs=(/indexToCellID(iCell)/), realArgs=(/groundedBasalMassBal(iCell)*scyr/rhoi, floatingBasalMassBal(iCell)*scyr/rhoi/) )
             endif
 
          enddo
@@ -1774,8 +1774,8 @@ module li_thermal
         if (config_print_thermal_info) then
            do iCell = 1, nCellsSolve
               if (indexToCellID(iCell) == config_stats_cell_ID) then
-                 call mpas_log_write('iCell=$i, betaSolve=$r, basalSpeed=$r, basalFrictionFlux=$r', &
-                   intArgs=(/iCell/), realArgs=(/betaSolve(iCell), basalSpeed(iCell), basalFrictionFlux(iCell)/))
+                 call mpas_log_write('indexToCellID=$i, betaSolve=$r, basalSpeed=$r, basalFrictionFlux=$r', &
+                   intArgs=(/indexToCellID(iCell)/), realArgs=(/betaSolve(iCell), basalSpeed(iCell), basalFrictionFlux(iCell)/))
               endif
            enddo
         endif


### PR DESCRIPTION
Replace iCell with indexToCellID(iCell) in log messages, since iCell
is not useful for debugging.