### PR TITLE
Redefine grounding line mask

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -172,6 +172,8 @@
                      description="total water flux in subglacial hydrology system" />
                 <var name="waterFluxMask" type="integer" dimensions="nEdges Time" units="none"
                      description="mask indicating how to handle fluxes on each edge: 0=calculate based on hydropotential gradient; 1=allow outflow based on hydropotential gradient, but no inflow (NOT YET IMPLEMENTED); 2=zero flux" />
+                <var name="hydroMarineMarginMask" type="integer" dimensions="nEdges Time" units="none"
+                     description="mask indicating the marine boundary of the active subglacial hydrology domain" />
                 <var name="waterFluxAdvec" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
                      description="advective water flux in subglacial hydrology system" />
                 <var name="waterFluxDiffu" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2248,7 +2248,7 @@ module li_calving
          ! OR is adjacent to an inactive floating margin cell
             if (li_mask_is_grounded_ice(cellMask(iCell)) &
                ! GL here means cell is grounded but has a neighbor that is floating or ocean.
-               ! Note that as of May 2022, this is no longer the general
+               ! Note that as of Oct 2022, this is no longer the general
                ! definition of the grounding line throughout the code.
                .and. bedTopography(iCell) < config_sea_level &
                .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2246,8 +2246,10 @@ module li_calving
          ! margin, (2) have at least one neighboring cell without ice, (3) contain
          ! grounded ice, and (4) have bed topography below sea level.
          ! OR is adjacent to an inactive floating margin cell
-            if (li_mask_is_grounding_line(cellMask(iCell)) &
-               !< GL here means cell is grounded but has a neighbor that is floating or ocean
+            if (li_mask_is_grounded_ice(cellMask(iCell)) &
+               ! GL here means cell is grounded but has a neighbor that is floating or ocean.
+               ! Note that as of May 2022, this is no longer the general
+               ! definition of the grounding line throughout the code.
                .and. bedTopography(iCell) < config_sea_level &
                .and. li_mask_is_dynamic_ice(cellMask(iCell)) ) then
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -256,7 +256,7 @@ module li_iceshelf_melt
            nEdgesOnCell, &
            edgeMask
 
-      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:,:), pointer :: edgesOnCell, cellsOnCell
 
       type (field1dInteger), pointer :: thermalCellMaskField
 
@@ -275,7 +275,7 @@ module li_iceshelf_melt
 
       real(kind=RKIND), pointer :: daysSinceStart
 
-      integer :: iCell, iEdge, err_tmp
+      integer :: iCell, jCell, iEdge, iNeighbor, err_tmp
 
       ! Local variables for some melt methods
 
@@ -509,23 +509,27 @@ module li_iceshelf_melt
             call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
             call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
             call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+            call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
             call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
             call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
             call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
 
             ! If config_front_mass_bal_grounded is not none, only apply ice shelf melt to active cells
-            ! and stranded non-dynamic cells.
+            ! and stranded non-dynamic cells. i.e., if a floating non-dynamic
+            ! cell has a grounded neighbor, do not apply ice shelf melt to it.
             do iCell = 1, nCellsSolve
                if ( li_mask_is_floating_ice(cellMask(iCell)) .and. (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
-                  do iEdge = 1, nEdgesOnCell(iCell)
-                     if ( li_mask_is_grounding_line(edgeMask(edgesOnCell(iEdge,iCell))) ) then
+                  do iNeighbor = 1, nEdgesOnCell(iCell)
+                     jCell = cellsOnCell(iNeighbor, iCell)
+                     if ( li_mask_is_grounded_ice(cellMask(jCell)) ) then
 
                          floatingBasalMassBal(iCell) = 0.0_RKIND
-
+                         cycle ! No need to look over other neighbors
                       endif
                   enddo
                 endif
             enddo
+
             block => block % next
          enddo   ! associated(block)
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -522,9 +522,8 @@ module li_iceshelf_melt
                   do iNeighbor = 1, nEdgesOnCell(iCell)
                      jCell = cellsOnCell(iNeighbor, iCell)
                      if ( li_mask_is_grounded_ice(cellMask(jCell)) ) then
-
                          floatingBasalMassBal(iCell) = 0.0_RKIND
-                         cycle ! No need to look over other neighbors
+                         exit ! No need to look over other neighbors
                       endif
                   enddo
                 endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -160,6 +160,8 @@ module li_subglacial_hydro
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
+         call calc_hydro_mask(domain)
+
          ! remove invalid values - not necessary on restart, but shouldn't hurt
          call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
          waterThickness = max(0.0_RKIND, waterThickness)
@@ -293,6 +295,8 @@ module li_subglacial_hydro
          ! If SGH is not active, skip everything
          return
       endif
+
+      call calc_hydro_mask(domain)
 
       call mpas_log_write('Beginning subglacial hydro solve.')
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_active', config_SGH_chnl_active)
@@ -728,6 +732,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
       integer, dimension(:), pointer :: waterFluxMask
+      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
@@ -797,6 +802,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxAdvec', waterFluxAdvec)
       call mpas_pool_get_array(hydroPool, 'waterFluxDiffu', waterFluxDiffu)
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
 
 
@@ -827,7 +833,7 @@ module li_subglacial_hydro
       ! at the edge of the cell in a 1-sided sense
       do iEdge = 1, nEdges
          if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (li_mask_is_grounding_line(edgeMask(iEdge)))) then
+             (hydroMarineMarginMask(iEdge)==1)) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
@@ -856,7 +862,7 @@ module li_subglacial_hydro
       ! (Do this step only after the other hydropotential special cases are treated above.)
       do iEdge = 1, nEdges
          ! Find edges along GL or margin to check for 'backwards' flow
-         if ((li_mask_is_grounding_line(edgeMask(iEdge))) .or. &
+         if ((hydroMarineMarginMask(iEdge)==1) .or. &
              li_mask_is_margin(edgeMask(iEdge)) ) then
             ! Now check if flow is backwards
             cell1 = cellsOnEdge(1, iEdge)
@@ -1364,7 +1370,10 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:,:), pointer :: edgesOnCell
       real (kind=RKIND), pointer :: deltatSGH
       real (kind=RKIND), pointer :: bedRough, bedRoughMax
       real (kind=RKIND), pointer :: rhoi
@@ -1377,6 +1386,8 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: rhoo
       integer :: err_tmp
       integer :: iCell
+      integer :: iEdge
+      logical :: onMarineMargin
 
       err = 0
       err_tmp = 0
@@ -1400,6 +1411,8 @@ module li_subglacial_hydro
 
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
 
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
@@ -1417,6 +1430,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'divergence', divergence)
       call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
       call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -1472,11 +1486,20 @@ module li_subglacial_hydro
              ((.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) ) then
            ! set pressure correctly under floating ice and open ocean
            waterPressure(iCell) = rhoo * gravity * (config_sea_level - bedTopography(iCell))
-        elseif (li_mask_is_grounding_line(cellMask(iCell))) then
-           ! At GL, don't let water pressure fall below ocean pressure
-           ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
-           if (waterPressure(iCell) < rhoo * gravity * (config_sea_level - bedTopography(iCell))) then
-               waterPressure(iCell) = rhoo * gravity * (config_sea_level - bedTopography(iCell))
+        else
+           onMarineMargin = .false.
+           do iEdge = 1, nEdgesOnCell(iCell)
+              if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
+                 onMarineMargin = .true.
+                 exit
+              endif
+           enddo
+           if (onMarineMargin) then
+              ! At marine margin, don't let water pressure fall below ocean pressure
+              ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
+              if (waterPressure(iCell) < rhoo * gravity * (config_sea_level - bedTopography(iCell))) then
+                  waterPressure(iCell) = rhoo * gravity * (config_sea_level - bedTopography(iCell))
+              endif
            endif
         endif
       enddo
@@ -1633,6 +1656,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
       integer, dimension(:), pointer :: waterFluxMask
+      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       integer, dimension(:,:), pointer :: cellsOnEdge
@@ -1680,6 +1704,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
 
@@ -1699,7 +1724,7 @@ module li_subglacial_hydro
 
       ! Note: an edge with only one grounded cell neighbor is called floating, so this logic retains channel vars
       ! on those edges to allow channel discharge across GL
-      where (.not. ( (li_mask_is_grounded_ice(edgeMask)) .or. (li_mask_is_grounding_line(edgeMask)) ) )
+      where (.not. ( (li_mask_is_grounded_ice(edgeMask)) .or. (hydroMarineMarginMask==1) ) )
          channelArea = 0.0_RKIND
          channelDischarge = 0.0_RKIND
       end where
@@ -2048,5 +2073,84 @@ module li_subglacial_hydro
    !--------------------------------------------------------------------
    end subroutine ocean_connection_N
 
+
+!***********************************************************************
+!
+!  routine calc_hydro_mask
+!
+!> \brief   Calculate the boundaries of the active hydrology domain
+!> \author  Matt Hoffman
+!> \date    24 October 2022
+!> \details
+!>  This routine calculates a mask of the boundaries of the active hydrology domain
+!-----------------------------------------------------------------------
+   subroutine calc_hydro_mask(domain)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: hydroPool
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: meshPool
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:,:), pointer :: cellsOnEdge
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nEdgesSolve
+      integer :: cell1, cell2, iEdge
+      real (kind=RKIND), pointer :: config_sea_level
+
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+         call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+         call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+
+         hydroMarineMarginMask(:) = 0
+         do iEdge = 1, nEdgesSolve
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
+                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+               hydroMarineMarginMask(iEdge) = 1
+            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
+                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+               hydroMarineMarginMask(iEdge) = 1
+            endif
+         enddo
+
+         block => block % next
+      end do
+
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'hydroMarineMarginMask')
+      call mpas_timer_stop("halo updates")
+
+   !--------------------------------------------------------------------
+   end subroutine calc_hydro_mask
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -294,10 +294,10 @@ contains
       logical :: isMargin
       logical :: isAlbanyMarginNeighbor
       logical :: aCellOnVertexHasIce, aCellOnVertexHasNoIce, aCellOnVertexHasDynamicIce, aCellOnVertexHasNoDynamicIce, &
-         aCellOnVertexIsFloating, aCellOnVertexIsAlbanyActive
+         aCellOnVertexIsFloating, aCellOnVertexIsFloatingAndDynamic, aCellOnVertexIsAlbanyActive
       logical :: aCellOnVertexIsGrounded
       logical :: aCellOnEdgeHasIce, aCellOnEdgeHasNoIce, aCellOnEdgeHasDynamicIce, aCellOnEdgeHasNoDynamicIce, &
-         aCellOnEdgeIsFloating
+         aCellOnEdgeIsFloating, aCellOnEdgeIsFloatingAndDynamic
       logical :: aCellOnEdgeIsGrounded
       logical :: aCellOnEdgeIsOpenOcean
       integer :: numCellsOnVertex
@@ -455,13 +455,17 @@ contains
       endif
 
       ! Identify the grounding line
-      ! For a cell, we define the GL as a grounded cell with ice with at least one neighbor with floating ice or open ocean
+      ! For a cell, we define the GL as a grounded cell with ice with at least one dynamic floating neighbor
+      ! Note that this is a different definition that prior to May 2022. Earlier
+      ! defined the grounding line as a grounded cell with at least one neighbor
+      ! that was floating or open ocean, which caused issues with calculating
+      ! mass budgets at grounded marine margins.
       do i=1,nCells
           if (li_mask_is_grounded_ice(cellMask(i))) then  ! only need to check grounded cells
               do j=1,nEdgesOnCell(i) ! Check if any neighbors are floating or open ocean
                  iCellNeighbor = cellsOnCell(j,i)
-                 if (li_mask_is_floating_ice(cellMask(iCellNeighbor)) .or. &
-                   ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) ) then
+                 if ( li_mask_is_floating_ice(cellMask(iCellNeighbor)) .and. &
+                      li_mask_is_dynamic_ice(cellMask(iCellNeighbor)) ) then
                     cellMask(i) = ior(cellMask(i), li_mask_ValueGroundingLine)
                  endif
                  cycle  ! no need to look at additional neighbors
@@ -485,7 +489,8 @@ contains
       !       cells (i.e., the cells exist in the mesh).  This allows external dycores to use the
       !       vertexMask to get information about triangles in the Delaunay triangulation.
       !       (This is done in a way which does not assume vertexMask==3.)
-      ! Bit: GL is a vertex with at least one neighboring cell grounded ice and at least one neighboring cell floating ice
+      ! Bit: GL is a vertex with at least one neighboring cell grounded ice and at least one neighboring cell dynamic floating ice
+      !      Note: this definition was changed May 2022 from one cell grounded and one cell floating
 
       !call mpas_timer_start('calculate mask vertex')
 
@@ -497,6 +502,7 @@ contains
           aCellOnVertexHasNoDynamicIce = .false.
           aCellOnVertexIsFloating = .false.
           aCellOnVertexIsGrounded = .false.
+          aCellOnVertexIsFloatingAndDynamic = .false.
           do j = 1, vertexDegree  ! vertexDegree is usually 3 (e.g. CVT mesh) but could be something else (e.g. 4 for quad mesh)
               iCell = cellsOnVertex(j,i)
               aCellOnVertexHasIce = (aCellOnVertexHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -504,6 +510,9 @@ contains
               aCellOnVertexHasDynamicIce = (aCellOnVertexHasDynamicIce .or. li_mask_is_dynamic_ice(cellMask(iCell)))
               aCellOnVertexHasNoDynamicIce = (aCellOnVertexHasNoDynamicIce .or. (.not. (li_mask_is_dynamic_ice(cellMask(iCell)))))
               aCellOnVertexIsFloating = (aCellOnVertexIsFloating .or. li_mask_is_floating_ice(cellMask(iCell)))
+              aCellOnVertexIsFloatingAndDynamic = ( aCellOnVertexIsFloatingAndDynamic .or. &
+                                                   (li_mask_is_floating_ice(cellMask(iCell)) .and. &
+                                                    li_mask_is_dynamic_ice(cellMask(iCell))) )
               aCellOnVertexIsGrounded = (aCellOnVertexIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
           end do
           if (aCellOnVertexHasIce) then
@@ -515,7 +524,7 @@ contains
           if (aCellOnVertexIsFloating) then
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueFloating)
           endif
-          if (aCellOnVertexIsFloating .and. aCellOnVertexIsGrounded) then
+          if (aCellOnVertexIsFloatingAndDynamic .and. aCellOnVertexIsGrounded) then
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueGroundingLine)
           endif
           if (aCellOnVertexHasIce .and. aCellOnVertexHasNoIce) then
@@ -583,7 +592,8 @@ contains
       ! Bit: Edges on margin are edges with one neighboring cell with ice and one neighboring cell without ice
       ! Bit: Edges on dynamic margin are edges with one neighboring cell with dynamic ice and
       !      one neighboring cell without dynamic ice
-      ! Bit: GL is an edge with one cell grounded ice and one cell floating ice
+      ! Bit: GL is an edge with one cell grounded ice and one cell dynamic floating ice
+      !      Note: This was changed May 2022 from one cell grounded and one floating or open ocean
 
       !call mpas_timer_start('calculate mask edge')
 
@@ -596,6 +606,7 @@ contains
           aCellOnEdgeIsFloating = .false.
           aCellOnEdgeIsGrounded = .false.
           aCellOnEdgeIsOpenOcean = .false.
+          aCellOnEdgeIsFloatingAndDynamic = .false.
           do j = 1, 2
               iCell = cellsOnEdge(j,i)
               aCellOnEdgeHasIce = (aCellOnEdgeHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -603,6 +614,9 @@ contains
               aCellOnEdgeHasDynamicIce = (aCellOnEdgeHasDynamicIce .or. li_mask_is_dynamic_ice(cellMask(iCell)))
               aCellOnEdgeHasNoDynamicIce = (aCellOnEdgeHasNoDynamicIce .or. (.not. (li_mask_is_dynamic_ice(cellMask(iCell)))))
               aCellOnEdgeIsFloating = (aCellOnEdgeIsFloating .or. li_mask_is_floating_ice(cellMask(iCell)))
+              aCellOnEdgeIsFloatingAndDynamic = ( aCellOnEdgeIsFloatingAndDynamic .or. &
+                                                (li_mask_is_floating_ice(cellMask(iCell)) .and. &
+                                                 li_mask_is_dynamic_ice(cellMask(iCell))) )
               aCellOnEdgeIsGrounded = (aCellOnEdgeIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
               aCellOnEdgeIsOpenOcean = aCellOnEdgeIsOpenOcean .or. &
                  ((bedTopography(iCell) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCell))))
@@ -618,7 +632,7 @@ contains
           if (aCellOnEdgeIsFloating) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueFloating)
           endif
-          if (aCellOnEdgeIsGrounded .and. (aCellOnEdgeIsFloating .or. aCellOnEdgeIsOpenOcean)) then
+          if (aCellOnEdgeIsGrounded .and. aCellOnEdgeIsFloatingAndDynamic) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueGroundingLine)
           endif
           if (aCellOnEdgeHasIce .and. aCellOnEdgeHasNoIce) then

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -456,7 +456,7 @@ contains
 
       ! Identify the grounding line
       ! For a cell, we define the GL as a grounded cell with ice with at least one dynamic floating neighbor
-      ! Note that this is a different definition that prior to May 2022. Earlier
+      ! Note that this is a different definition that prior to Oct 2022. Earlier
       ! defined the grounding line as a grounded cell with at least one neighbor
       ! that was floating or open ocean, which caused issues with calculating
       ! mass budgets at grounded marine margins.
@@ -490,7 +490,7 @@ contains
       !       vertexMask to get information about triangles in the Delaunay triangulation.
       !       (This is done in a way which does not assume vertexMask==3.)
       ! Bit: GL is a vertex with at least one neighboring cell grounded ice and at least one neighboring cell dynamic floating ice
-      !      Note: this definition was changed May 2022 from one cell grounded and one cell floating
+      !      Note: this definition was changed Oct 2022 from one cell grounded and one cell floating
 
       !call mpas_timer_start('calculate mask vertex')
 
@@ -593,7 +593,7 @@ contains
       ! Bit: Edges on dynamic margin are edges with one neighboring cell with dynamic ice and
       !      one neighboring cell without dynamic ice
       ! Bit: GL is an edge with one cell grounded ice and one cell dynamic floating ice
-      !      Note: This was changed May 2022 from one cell grounded and one floating or open ocean
+      !      Note: This was changed Oct 2022 from one cell grounded and one floating or open ocean
 
       !call mpas_timer_start('calculate mask edge')
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -462,13 +462,13 @@ contains
       ! mass budgets at grounded marine margins.
       do i=1,nCells
           if (li_mask_is_grounded_ice(cellMask(i))) then  ! only need to check grounded cells
-              do j=1,nEdgesOnCell(i) ! Check if any neighbors are floating or open ocean
+              do j=1,nEdgesOnCell(i) ! Check if any neighbors are floating dynamic ice
                  iCellNeighbor = cellsOnCell(j,i)
                  if ( li_mask_is_floating_ice(cellMask(iCellNeighbor)) .and. &
                       li_mask_is_dynamic_ice(cellMask(iCellNeighbor)) ) then
                     cellMask(i) = ior(cellMask(i), li_mask_ValueGroundingLine)
+                    exit  ! if we found a floating neighbor, no need to look at additional neighbors
                  endif
-                 cycle  ! no need to look at additional neighbors
               enddo
           endif
       enddo


### PR DESCRIPTION
Previously the the mask referred to as the grounding line was in fact the marine margin of grounded ice, whether or not it was at the floatation thickness. This led to trouble with mass budget calculations, which had to approximated using extensive and arduous post-processing with verbose model output, rather than calculated to machine precision on-line. Now, instead of defining the grounding line as a grounded cell with a floating or open ocean neighbor, this PR defines the grounding line as a grounded cell with a _dynamic_ floating neighbor. Logic has been updated in calving and subglacial hydrology routines to be consistent with this new definition.

This addresses the first bullet point in the list of known issues in #23.