### PR TITLE
Calculate mass budgets online

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1280,6 +1280,11 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingThicknessFromThreshold" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep for only processes that generate calving based on a threshold.  This includes mask calving, damage calving, iceberg and small island detection, and velocity speed limit."
+                <var name="groundedCalvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                        description="thickness of grounded ice that calves on a given timestep (less than or equal to ice thickness)"
+                />
+                <var name="floatingCalvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                        description="thickness of floating ice that calves on a given timestep (less than or equal to ice thickness)"
                 />
                 <var name="calvingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
                         description="approximation of maximum allowable timestep based on calvingVelocity"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1222,6 +1222,12 @@ is the value of that variable from the *previous* time level!
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on cells.  cellMask only needs to be a restart field if config_allow_additional_advance = false (to keep the mask of initial ice extent)"
                 />
+                <var name="groundedMaskForMassBudget" type="integer" dimensions="nCells Time" units="none"
+                     description="bitmask indicating where ice is considered grounded for mass budget calculation. Includes floating non-dynamic cells adjacent to grounded ice and floating ice above subglacial lakes."
+                />
+                <var name="floatingMaskForMassBudget" type="integer" dimensions="nCells Time" units="none"
+                     description="bitmask indicating where ice is considered floating for mass budget calculation. Does not include floating non-dynamic cells adjacent to grounded ice or floating ice above subglacial lakes."
+                />
                 <var name="edgeMask" type="integer" dimensions="nEdges Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on edges."
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1275,6 +1275,9 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingFrontMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
                         description="mask of the calving front position on cells"
                 />
+                <var name="incrementalCalvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                        description="thickness of ice that calves in a given step. Maybe be updated multiple times per time step to calculate calvingThickness."
+                />
                 <var name="calvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep (less than or equal to ice thickness)"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1472,8 +1472,8 @@ is the value of that variable from the *previous* time level!
                      units="m"  description="amount of change in bedTopography.  This field is calculated by the sea-level model over its time step. Positive values indicate bed uplift relative to sea level."
                 />
                <!-- Scratch variables related to geometry -->
-	       <var name="cellMaskTemporary" type="integer" dimensions="nCells" units="none"
-	       description="temporary copy of cellMask"
+	       <var name="groundedMaskForMassBudgetTemporary" type="integer" dimensions="nCells" units="none"
+	       description="temporary copy of groundedMaskForMassBudget"
 	       persistence="scratch"
 	       />
 	       <var name="edgeMaskTemporary" type="integer" dimensions="nEdges" units="none"
@@ -1484,6 +1484,10 @@ is the value of that variable from the *previous* time level!
                description="temporary copy of vertexMask"
                persistence="scratch"
 	       />
+               <var name="floatingMaskForMassBudgetTemporary" type="integer" dimensions="nCells" units="none"
+               description="temporary copy of floatingMaskForMassBudget"
+               persistence="scratch"
+               />
         </var_struct>
 
 <!-- ================ -->

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1444,6 +1444,11 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="dtFaceMeltingCFLratio" type="real" dimensions="Time" units="none" time_levs="1" default_value="0.0"
                         description="ratio of timestep being used to the maximum timestep calculated for the face-melting CFL condition.  This metric can be used to assess the accuracy of the face-melting CFL calculation being lagged by a timestep."
+                <var name="groundedFaceMeltingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                     description="Equivalent plan-view averaged thickness of grounded ice that melts on a given timestep from front ablation (less than or equal to ice thickness). Used in mass budget calculations."
+                />
+                <var name="floatingFaceMeltingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                     description="Equivalent plan-view averaged thickness of floating ice that melts on a given timestep from front ablation (less than or equal to ice thickness). Used in mass budget calculations."
                 />
                <var name="unmeltedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left unmelted from required facemelt flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1280,6 +1280,7 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingThicknessFromThreshold" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep for only processes that generate calving based on a threshold.  This includes mask calving, damage calving, iceberg and small island detection, and velocity speed limit."
+                />
                 <var name="groundedCalvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of grounded ice that calves on a given timestep (less than or equal to ice thickness)"
                 />
@@ -1368,7 +1369,6 @@ is the value of that variable from the *previous* time level!
                 <var name="damageSource" type="real" dimensions="nCells Time" units="s^{-1}" time_levs="1"
                      description="damage source term"
                 />
-                />
                 <var name="basalWaterThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="thickness of basal water"
                 />
@@ -1444,6 +1444,7 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="dtFaceMeltingCFLratio" type="real" dimensions="Time" units="none" time_levs="1" default_value="0.0"
                         description="ratio of timestep being used to the maximum timestep calculated for the face-melting CFL condition.  This metric can be used to assess the accuracy of the face-melting CFL calculation being lagged by a timestep."
+                />
                 <var name="groundedFaceMeltingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="Equivalent plan-view averaged thickness of grounded ice that melts on a given timestep from front ablation (less than or equal to ice thickness). Used in mass budget calculations."
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1245,6 +1245,9 @@ is the value of that variable from the *previous* time level!
                 <var name="groundedSfcMassBalApplied" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="applied surface mass balance on grounded ice"
                 />
+                <var name="floatingSfcMassBalApplied" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                     description="applied surface mass balance on floating ice"
+                />
                 <var name="basalMassBal" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
                      description="Potential basal mass balance"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1473,7 +1473,11 @@ is the value of that variable from the *previous* time level!
                      units="m"  description="amount of change in bedTopography.  This field is calculated by the sea-level model over its time step. Positive values indicate bed uplift relative to sea level."
                 />
                <!-- Scratch variables related to geometry -->
-	       <var name="groundedMaskForMassBudgetTemporary" type="integer" dimensions="nCells" units="none"
+               <var name="cellMaskTemporary" type="integer" dimensions="nCells" units="none"
+               description="temporary copy of cellMask"
+               persistence="scratch"
+               />
+ 	       <var name="groundedMaskForMassBudgetTemporary" type="integer" dimensions="nCells" units="none"
 	       description="temporary copy of groundedMaskForMassBudget"
 	       persistence="scratch"
 	       />

--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -85,8 +85,20 @@
                 <var name="totalCalvingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
                         description="total, area integrated mass loss due to calving. Positive values represent ice loss."
                 />
+                <var name="totalGroundedCalvingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
+                        description="total, area integrated grounded mass loss due to calving. Positive values represent ice loss."
+                />
+                <var name="totalFloatingCalvingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
+                        description="total, area integrated floating mass loss due to calving. Positive values represent ice loss."
+                />
                 <var name="totalFaceMeltingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
                         description="total, area integrated mass loss due to face melting. Positive values represent ice loss."
+                />
+                <var name="totalGroundedFaceMeltingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
+                        description="total, area integrated grounded mass loss due to face melting. Positive values represent ice loss."
+                />
+                <var name="totalFloatingFaceMeltingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
+                        description="total, area integrated floating  mass loss due to face melting. Positive values represent ice loss."
                 />
                 <var name="groundingLineFlux" type="real" dimensions="Time" units="kg yr^{-1}"
                         description="total mass flux across all grounding lines.  Note that flux from floating to grounded ice makes a negative contribution to this metric."

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -223,7 +223,6 @@ contains
       real (kind=RKIND), pointer ::  iceThicknessMax, iceThicknessMin, iceThicknessMean
       real (kind=RKIND), pointer ::  totalSfcMassBal, totalBasalMassBal
       real (kind=RKIND), pointer ::  totalGroundedSfcMassBal, totalFloatingSfcMassBal
-      real (kind=RKIND), pointer ::  totalFaceMeltingFlux
       real (kind=RKIND), pointer ::  totalGroundedBasalMassBal, totalFloatingBasalMassBal
       real (kind=RKIND), pointer ::  totalGroundedCalvingFlux, totalFloatingCalvingFlux
       real (kind=RKIND), pointer ::  totalFaceMeltingFlux, &

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -437,9 +437,9 @@ contains
             ! mass loss due to calving (kg yr^{-1})
             blockSumFaceMeltingFlux = blockSumFaceMeltingFlux + faceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
-            blockSumGroundedFaceMeltingFlux = blockSumFaceMeltingFlux + groundedFaceMeltingThickness(iCell) * &
+            blockSumGroundedFaceMeltingFlux = blockSumGroundedFaceMeltingFlux + groundedFaceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
-            blockSumFloatingFaceMeltingFlux = blockSumFaceMeltingFlux + floatingFaceMeltingThickness(iCell) * &
+            blockSumFloatingFaceMeltingFlux = blockSumFloatingFaceMeltingFlux + floatingFaceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
 
             ! mass loss due to face-melting (kg yr^{-1})

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -174,11 +174,16 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  bedTopography
       real (kind=RKIND), dimension(:), pointer ::  sfcMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  groundedSfcMassBalApplied
+      real (kind=RKIND), dimension(:), pointer ::  floatingSfcMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  basalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness
-      real (kind=RKIND), dimension(:), pointer ::  faceMeltingThickness
+      real (kind=RKIND), dimension(:), pointer ::  groundedCalvingThickness
+      real (kind=RKIND), dimension(:), pointer ::  floatingCalvingThickness
+      real (kind=RKIND), dimension(:), pointer ::  faceMeltingThickness, &
+                                                   groundedFaceMeltingThickness, &
+                                                   floatingFaceMeltingThickness
       real (kind=RKIND), dimension(:), pointer ::  surfaceSpeed
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
@@ -195,6 +200,8 @@ contains
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: hydroTerrestrialMarginMask
+      integer, dimension(:), pointer :: groundedMaskForMassBudget, &
+                                        floatingMaskForMassBudget
       integer, pointer :: nCellsSolve
       integer, pointer :: nEdgesSolve
 
@@ -218,6 +225,10 @@ contains
       real (kind=RKIND), pointer ::  totalGroundedSfcMassBal, totalFloatingSfcMassBal
       real (kind=RKIND), pointer ::  totalFaceMeltingFlux
       real (kind=RKIND), pointer ::  totalGroundedBasalMassBal, totalFloatingBasalMassBal
+      real (kind=RKIND), pointer ::  totalGroundedCalvingFlux, totalFloatingCalvingFlux
+      real (kind=RKIND), pointer ::  totalFaceMeltingFlux, &
+                                     totalGroundedFaceMeltingFlux, &
+                                     totalFloatingFaceMeltingFlux
       real (kind=RKIND), pointer ::  avgNetAccumulation
       real (kind=RKIND), pointer ::  avgGroundedBasalMelt
       real (kind=RKIND), pointer ::  avgSubshelfMelt
@@ -247,8 +258,9 @@ contains
       real (kind=RKIND) ::  blockSumSfcMassBal, blockSumBasalMassBal
       real (kind=RKIND) ::  blockSumGroundedSfcMassBal, blockSumFloatingSfcMassBal
       real (kind=RKIND) ::  blockSumGroundedBasalMassBal, blockSumFloatingBasalMassBal
-      real (kind=RKIND) ::  blockSumCalvingFlux
-      real (kind=RKIND) ::  blockSumFaceMeltingFlux
+      real (kind=RKIND) ::  blockSumCalvingFlux, blockSumGroundedCalvingFlux, blockSumFloatingCalvingFlux
+      real (kind=RKIND) ::  blockSumFaceMeltingFlux, blockSumGroundedFaceMeltingFlux, &
+                            blockSumFloatingFaceMeltingFlux
       real (kind=RKIND) ::  blockMaxSurfaceSpeed
       real (kind=RKIND) ::  blockMaxBasalSpeed
       real (kind=RKIND) ::  blockGLflux
@@ -292,7 +304,11 @@ contains
       blockSumGroundedBasalMassBal = 0.0_RKIND
       blockSumFloatingBasalMassBal = 0.0_RKIND
       blockSumCalvingFlux = 0.0_RKIND
+      blockSumGroundedCalvingFlux = 0.0_RKIND
+      blockSumFloatingCalvingFlux = 0.0_RKIND
       blockSumFaceMeltingFlux = 0.0_RKIND
+      blockSumGroundedFaceMeltingFlux = 0.0_RKIND
+      blockSumFloatingFaceMeltingFlux = 0.0_RKIND
       blockGLflux = 0.0_RKIND
       blockGLMigrationFlux = 0.0_RKIND
       blockSumSubglacialWaterVolume = 0.0_RKIND
@@ -343,12 +359,19 @@ contains
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'floatingSfcMassBalApplied', floatingSfcMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedFaceMeltingThickness', groundedFaceMeltingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingFaceMeltingThickness', floatingFaceMeltingThickness)
          call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
          call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
@@ -372,20 +395,18 @@ contains
                 * areaCell(iCell)
             blockSumIceVolume = blockSumIceVolume + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
-
+            ! can we somehow incorporate non-dynamic floating fringe into VAF?
             blockSumVAF = blockSumVAF + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * areaCell(iCell) * &
                 ( thickness(iCell) + (rhow / rhoi) * min(0.0_RKIND, (bedTopography(iCell) - config_sea_level)) )
 
-            blockSumGroundedIceArea = blockSumGroundedIceArea + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
+            blockSumGroundedIceArea = blockSumGroundedIceArea + real(groundedMaskForMassBudget(iCell),RKIND) &
                  * areaCell(iCell)
-
-            blockSumGroundedIceVolume = blockSumGroundedIceVolume + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
+            blockSumGroundedIceVolume = blockSumGroundedIceVolume + real(groundedMaskForMassBudget(iCell),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
-            blockSumFloatingIceArea = blockSumFloatingIceArea + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
+            blockSumFloatingIceArea = blockSumFloatingIceArea + real(floatingMaskForMassBudget(iCell),RKIND) &
                 * areaCell(iCell)
-
-            blockSumFloatingIceVolume = blockSumFloatingIceVolume + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
+            blockSumFloatingIceVolume = blockSumFloatingIceVolume + real(floatingMaskForMassBudget(iCell),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
             ! max, min thickness values (m)
@@ -399,16 +420,26 @@ contains
             ! SMB (kg yr^{-1})
             blockSumSfcMassBal = blockSumSfcMassBal + areaCell(iCell) * sfcMassBalApplied(iCell) * scyr
             blockSumGroundedSfcMassBal = blockSumGroundedSfcMassBal + areaCell(iCell) * groundedSfcMassBalApplied(iCell) * scyr
-            blockSumFloatingSfcMassBal = blockSumFloatingSfcMassBal + &
-               (sfcMassBalApplied(iCell) - groundedSfcMassBalApplied(iCell)) * areaCell(iCell) * scyr
-
+            blockSumFloatingSfcMassBal = blockSumFloatingSfcMassBal + areaCell(iCell) * floatingSfcMassBalApplied(iCell) * scyr 
             ! BMB (kg yr-1)
             blockSumBasalMassBal = blockSumBasalMassBal + areaCell(iCell) * basalMassBalApplied(iCell) * scyr
             blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr
             blockSumFloatingBasalMassBal = blockSumFloatingBasalMassBal + areaCell(iCell) * floatingBasalMassBalApplied(iCell) * scyr
 
-            ! mass loss due do calving (kg yr^{-1})
+            ! mass loss due to calving (kg yr^{-1})
             blockSumCalvingFlux = blockSumCalvingFlux + calvingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+            blockSumGroundedCalvingFlux = blockSumGroundedCalvingFlux + groundedCalvingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+            blockSumFloatingCalvingFlux = blockSumFloatingCalvingFlux + floatingCalvingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+
+            ! mass loss due to calving (kg yr^{-1})
+            blockSumFaceMeltingFlux = blockSumFaceMeltingFlux + faceMeltingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+            blockSumGroundedFaceMeltingFlux = blockSumFaceMeltingFlux + groundedFaceMeltingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+            blockSumFloatingFaceMeltingFlux = blockSumFaceMeltingFlux + floatingFaceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
 
             ! mass loss due to face-melting (kg yr^{-1})
@@ -531,25 +562,29 @@ contains
       sums(11) = blockSumGroundedBasalMassBal
       sums(12) = blockSumFloatingBasalMassBal
       sums(13) = blockSumCalvingFlux
-      sums(14) = blockSumFaceMeltingFlux
-      sums(15) = blockSumVAF
-      sums(16) = blockGLflux
-      sums(17) = blockGLMigrationflux
+      sums(14) = blockSumGroundedCalvingFlux
+      sums(15) = blockSumFloatingCalvingFlux
+      sums(16) = blockSumFaceMeltingFlux
+      sums(17) = blockSumGroundedFaceMeltingFlux
+      sums(18) = blockSumFloatingFaceMeltingFlux
+      sums(19) = blockSumVAF
+      sums(20) = blockGLflux
+      sums(21) = blockGLMigrationflux 
       if (config_SGH) then
-         sums(18) = blockSumSubglacialWaterVolume
-         sums(19) = blockSumBasalMeltInput
-         sums(20) = blockSumExternalWaterInput
-         sums(21) = blockSumChannelMelt
-         sums(22) = blockSumLakeVolume
-         sums(23) = blockSumLakeArea
-         sums(24) = blockSumGLMeltFlux
-         sums(25) = blockSumTerrestrialMeltFlux
-         sums(26) = blockSumChannelGLMeltFlux
-         sums(27) = blockSumChannelTerrestrialMeltFlux
-         sums(28) = blockSumFlotationFraction
-         nVars = 28
+         sums(22) = blockSumSubglacialWaterVolume
+         sums(23) = blockSumBasalMeltInput
+         sums(24) = blockSumExternalWaterInput
+         sums(25) = blockSumChannelMelt
+         sums(26) = blockSumLakeVolume
+         sums(27) = blockSumLakeArea
+         sums(28) = blockSumGLMeltFlux
+         sums(29) = blockSumTerrestrialMeltFlux
+         sums(30) = blockSumChannelGLMeltFlux
+         sums(31) = blockSumChannelTerrestrialMeltFlux
+         sums(32) = blockSumFlotationFraction
+         nVars = 32
       else
-        nVars = 17
+        nVars = 21
       endif
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
@@ -576,7 +611,11 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'totalFloatingBasalMassBal', totalFloatingBasalMassBal)
          call mpas_pool_get_array(globalStatsAMPool, 'avgSubshelfMelt', avgSubshelfMelt)
          call mpas_pool_get_array(globalStatsAMPool, 'totalCalvingFlux', totalCalvingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalGroundedCalvingFlux', totalGroundedCalvingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalFloatingCalvingFlux', totalFloatingCalvingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalGroundedFaceMeltingFlux', totalGroundedFaceMeltingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalFloatingFaceMeltingFlux', totalFloatingFaceMeltingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
          if (config_SGH) then
@@ -606,22 +645,26 @@ contains
          totalGroundedBasalMassBal = reductions(11)
          totalFloatingBasalMassBal = reductions(12)
          totalCalvingFlux = reductions(13)
-         totalFaceMeltingFlux = reductions(14)
-         volumeAboveFloatation = reductions(15)
-         groundingLineFlux = reductions(16)
-         groundingLineMigrationFlux = reductions(17)
+         totalGroundedCalvingFlux = reductions(14)
+         totalFloatingCalvingFlux = reductions(15)
+         totalFaceMeltingFlux = reductions(16)
+         totalGroundedFaceMeltingFlux = reductions(17)
+         totalFloatingFaceMeltingFlux = reductions(18)
+         volumeAboveFloatation = reductions(19)
+         groundingLineFlux = reductions(20)
+         groundingLineMigrationFlux = reductions(21)
          if (config_SGH) then
-            totalSubglacialWaterVolume = reductions(18)
-            totalBasalMeltInput = reductions(19)
-            totalExternalWaterInput = reductions(20)
-            totalChannelMelt = reductions(21)
-            totalSubglacialLakeVolume = reductions(22)
-            totalSubglacialLakeArea = reductions(23)
-            totalDistWaterFluxMarineMargin = reductions(24)
-            totalDistWaterFluxTerrestrialMargin = reductions(25)
-            totalChnlWaterFluxMarineMargin = reductions(26)
-            totalChnlWaterFluxTerrestrialMargin = reductions(27)
-            totalFlotationFraction = reductions(28)
+            totalSubglacialWaterVolume = reductions(22)
+            totalBasalMeltInput = reductions(23)
+            totalExternalWaterInput = reductions(24)
+            totalChannelMelt = reductions(25)
+            totalSubglacialLakeVolume = reductions(26)
+            totalSubglacialLakeArea = reductions(27)
+            totalDistWaterFluxMarineMargin = reductions(28)
+            totalDistWaterFluxTerrestrialMargin = reductions(29)
+            totalChnlWaterFluxMarineMargin = reductions(30)
+            totalChnlWaterFluxTerrestrialMargin = reductions(31)
+            totalFlotationFraction = reductions(32)
          endif
 
          if (totalIceArea > 0.0_RKIND) then

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -433,16 +433,12 @@ contains
             blockSumFloatingCalvingFlux = blockSumFloatingCalvingFlux + floatingCalvingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
 
-            ! mass loss due to calving (kg yr^{-1})
+            ! mass loss due to face-melting (kg yr^{-1})
             blockSumFaceMeltingFlux = blockSumFaceMeltingFlux + faceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
             blockSumGroundedFaceMeltingFlux = blockSumGroundedFaceMeltingFlux + groundedFaceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
             blockSumFloatingFaceMeltingFlux = blockSumFloatingFaceMeltingFlux + floatingFaceMeltingThickness(iCell) * &
-               areaCell(iCell) * rhoi / ( deltat / scyr )
-
-            ! mass loss due to face-melting (kg yr^{-1})
-            blockSumFaceMeltingFlux = blockSumFaceMeltingFlux + faceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
 
             ! max surface speed

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -81,7 +81,6 @@ module li_advection
         geometryPool,           &
         thermalPool,            &
         scratchPool,            &
-        domain,                 &
         err,                    &
         advectTracersIn)
 
@@ -110,8 +109,6 @@ module li_advection
       !
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-
-      type (domain_type), intent(inout) :: domain
 
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -584,6 +584,10 @@ module li_advection
             enddo
          endif
 
+         ! Update halos after advection.
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'layerThickness')
+         call mpas_timer_stop("halo updates")
 
          ! Calculate dynamicThickening (layerThickness is updated by advection at this point, while thickness is still old)
          dynamicThickening = (sum(layerThickness, 1) - thickness) / dt * scyr  ! units of m/yr

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -149,6 +149,7 @@ module li_advection
            sfcMassBal,            & ! surface mass balance (potential forcing)
            sfcMassBalApplied,     & ! surface mass balance (actually applied)
            groundedSfcMassBalApplied,     & ! surface mass balance on grounded locations (actually applied)
+           floatingSfcMassBalApplied,     & ! surface mass balance on floating locations (actually applied)
            basalMassBal,          & ! basal mass balance
            groundedBasalMassBal,  & ! basal mass balance for grounded ice
            floatingBasalMassBal,  & ! basal mass balance for floating ice
@@ -206,7 +207,9 @@ module li_advection
            cellMask,              & ! integer bitmask for cells
            edgeMask,              & ! integer bitmask for edges
            vertexMask,            &
-           thermalCellMask
+           thermalCellMask,       &
+           groundedMaskForMassBudget, &
+           floatingMaskForMassBudget
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -285,6 +288,7 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
       call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
       call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
+      call mpas_pool_get_array(geometryPool, 'floatingSfcMassBalApplied', floatingSfcMassBalApplied)
       call mpas_pool_get_array(geometryPool, 'basalMassBal', basalMassBal)
       call mpas_pool_get_array(geometryPool, 'groundedBasalMassBal', groundedBasalMassBal)
       call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
@@ -298,7 +302,8 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel=1)
       call mpas_pool_get_array(geometryPool, 'dynamicThickening', dynamicThickening)
       call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
-
+      call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+      call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
       ! get arrays from the velocity pool
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
       call mpas_pool_get_array(velocityPool, 'layerThicknessEdgeFlux', layerThicknessEdgeFlux)
@@ -605,10 +610,13 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
+              floatingSfcMassBalApplied,   &
               basalMassBal,        &
               basalMassBalApplied, &
               groundedBasalMassBalApplied, &
               floatingBasalMassBalApplied, &
+              groundedMaskForMassBudget, &
+              floatingMaskForMassBudget, &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -858,10 +866,13 @@ module li_advection
               sfcMassBal,          &
               sfcMassBalApplied,   &
               groundedSfcMassBalApplied,   &
+              floatingSfcMassBalApplied,   &
               basalMassBal,        &
               basalMassBalApplied, &
               groundedBasalMassBalApplied, &
               floatingBasalMassBalApplied, &
+              groundedMaskForMassBudget, &
+              floatingMaskForMassBudget, &
               surfaceTracers,      &
               basalTracers,        &
               layerThickness,      &
@@ -875,7 +886,9 @@ module li_advection
            dt,                 & !< Input: time step (s)
            rhoi                  !< Input: ice density (kg/m^3)
 
-      integer, dimension(:), intent(in) :: cellMask !< Input: mask on cells
+      integer, dimension(:), intent(in) :: cellMask, & !< Input: mask on cells
+                                           groundedMaskForMassBudget, &
+                                           floatingMaskForMassBudget
 
       real (kind=RKIND), dimension(:), intent(in) ::  &
            bedTopography,      & !< Input: bed elevation (m)
@@ -904,7 +917,8 @@ module li_advection
            sfcMassBalApplied !< Output: surface mass balance actually applied on this time step (kg/m^2/s)
 
       real(kind=RKIND), dimension(:), intent(out) :: &
-           groundedSfcMassBalApplied !< Output: surface mass balance actually applied to grounded ice on this time step (kg/m^2/s)
+           groundedSfcMassBalApplied, &  !< Output: surface mass balance actually applied to grounded ice on this time step (kg/m^2/s)
+           floatingSfcMassBalApplied     !< Output: surface mass balance actually applied to floating ice on this time step (kg/m^2/s)
 
       real(kind=RKIND), dimension(:), intent(out) :: &
            basalMassBalApplied,         & !< Output: basal mass balance actually applied on this time step (kg/m^2/s)
@@ -1060,10 +1074,15 @@ module li_advection
       enddo   ! iCell
 
       ! Separate grounded and floating components, as necessary.
-      where (li_mask_is_grounded_ice(cellMask) .or. bedTopography > config_sea_level)
+      where ( (groundedMaskForMassBudget .eq. 1) .or. (bedTopography > config_sea_level) )
             groundedSfcMassBalApplied = sfcMassBalApplied
+            floatingSfcMassBalApplied = 0.0_RKIND
+      elsewhere (floatingMaskForMassBudget .eq. 1)
+            groundedSfcMassBalApplied = 0.0_RKIND
+            floatingSfcMassBalApplied = sfcMassBalApplied
       elsewhere
             groundedSfcMassBalApplied = 0.0_RKIND
+            floatingSfcMassBalApplied = 0.0_RKIND
       end where
 
       do iCell = 1, nCells

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -399,47 +399,6 @@ module li_advection
 
       if ( (trim(config_thickness_advection) .eq. 'fo') .or. &
           (trim(config_thickness_advection) .eq. 'fct') ) then
-         ! Calculate flux across grounding line
-         ! Do this after new thickness & mask have been calculated, including SMB/BMB
-         fluxAcrossGroundingLine(:) = 0.0_RKIND
-         fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
-         do iEdge = 1, nEdgesSolve
-            if (li_mask_is_grounding_line(edgeMask(iEdge))) then
-               iCell1 = cellsOnEdge(1,iEdge)
-               iCell2 = cellsOnEdge(2,iEdge)
-               if (li_mask_is_grounded_ice(cellMask(iCell1))) then
-                  GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
-                  theGroundedCell = iCell1
-               else
-                  GLfluxSign = -1.0_RKIND
-                  theGroundedCell = iCell2
-               endif
-               if (trim(config_thickness_advection) == 'fct') then
-                  do k = 1, nVertLevels
-                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
-                  enddo
-               else
-                  do k = 1, nVertLevels
-                     layerThicknessEdgeFlux(k,iEdge) = layerNormalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
-                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
-                  enddo
-               endif
-               ! assign to grounded cell in fluxAcrossGroundingLineOnCells
-               if (thickness(theGroundedCell) <= 0.0_RKIND) then
-                  ! This should never be the case, but checking to avoid possible divide by zero
-                  call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
-                  err = ior(err, 1)
-                  return
-               endif
-               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
-                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
-            endif
-         enddo ! edges
-
-         call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLine')
-         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLineOnCells')
-         call mpas_timer_stop("halo updates")
 
          if (config_print_thickness_advection_info) then
             call mpas_log_write('Using first-order upwind for thickness advection')
@@ -598,6 +557,48 @@ module li_advection
          ! Update halos after advection.
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'layerThickness')
+         call mpas_timer_stop("halo updates")
+
+         ! Calculate flux across grounding line
+         ! Do this before new masks and thickness have been calculated, and before SMB/BMB
+         fluxAcrossGroundingLine(:) = 0.0_RKIND
+         fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
+         do iEdge = 1, nEdgesSolve
+            if (li_mask_is_grounding_line(edgeMask(iEdge))) then
+               iCell1 = cellsOnEdge(1,iEdge)
+               iCell2 = cellsOnEdge(2,iEdge)
+               if (li_mask_is_grounded_ice(cellMask(iCell1))) then
+                  GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
+                  theGroundedCell = iCell1
+               else
+                  GLfluxSign = -1.0_RKIND
+                  theGroundedCell = iCell2
+               endif
+               if (trim(config_thickness_advection) == 'fct') then
+                  do k = 1, nVertLevels
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
+                  enddo
+               else
+                  do k = 1, nVertLevels
+                     layerThicknessEdgeFlux(k,iEdge) = layerNormalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
+                  enddo
+               endif
+               ! assign to grounded cell in fluxAcrossGroundingLineOnCells
+               if (thickness(theGroundedCell) <= 0.0_RKIND) then
+                  ! This should never be the case, but checking to avoid possible divide by zero
+                  call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
+                  err = ior(err, 1)
+                  return
+               endif
+               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
+                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
+            endif
+         enddo ! edges
+
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLine')
+         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLineOnCells')
          call mpas_timer_stop("halo updates")
 
          ! Calculate dynamicThickening (layerThickness is updated by advection at this point, while thickness is still old)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -46,8 +46,7 @@ module li_advection
    !--------------------------------------------------------------------
    public :: li_advection_thickness_tracers, &
              li_layer_normal_velocity, &
-             li_update_geometry, &
-             li_grounded_to_floating
+             li_update_geometry
 
    !--------------------------------------------------------------------
    !
@@ -392,10 +391,6 @@ module li_advection
       vertexMaskTemporaryField % array(:) = vertexMask(:)
 
       layerThicknessEdgeFlux(:,:) = 0.0_RKIND
-      ! save old mass budget masks for determining cells changing from grounded to floating and vice versa
-      groundedMaskForMassBudgetTemporaryField % array(:) = groundedMaskForMassBudget(:)
-      floatingMaskForMassBudgetTemporaryField % array(:) = floatingMaskForMassBudget(:)
-
       !-----------------------------------------------------------------
       ! Horizontal transport of thickness and tracers
       !-----------------------------------------------------------------
@@ -599,8 +594,6 @@ module li_advection
          ! before advection took place.
          thickness = sum(layerThickness, 1)
 
-
-
          !-----------------------------------------------------------------
          ! Add the surface and basal mass balance to the layer thickness
          !-----------------------------------------------------------------
@@ -690,15 +683,6 @@ module li_advection
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         ! Calculate volume converted from grounded to floating
-         ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
-         call grounded_to_floating(groundedMaskForMassBudgetTemporaryField % array, &
-                                   floatingMaskForMassBudgetTemporaryField % array, &
-                                   groundedMaskForMassBudget, &
-                                   floatingMaskForMassBudget, &
-                                   thickness, &
-                                   groundedToFloatingThickness, &
-                                   nCells)
          ! Remap tracers to the standard vertical sigma coordinate
          ! Note: If tracers are not being advected, then this subroutine simply restores the
          !       layer thickness to sigma coordinate values.
@@ -761,8 +745,6 @@ module li_advection
       call mpas_deallocate_scratch_field(edgeMaskTemporaryField, .true.)
       call mpas_deallocate_scratch_field(vertexMaskTemporaryField, .true.)
       call mpas_deallocate_scratch_field(thermalCellMaskField, .true.)
-      call mpas_deallocate_scratch_field(groundedMaskForMassBudgetTemporaryField, .true.)
-      call mpas_deallocate_scratch_field(floatingMaskForMassBudgetTemporaryField, .true.)
 
       ! === error check
       if (err > 0) then
@@ -2135,59 +2117,6 @@ module li_advection
       deallocate(hTsum)
 
     end subroutine vertical_remap
-
-    subroutine grounded_to_floating(groundedMaskForMassBudgetOrig, &
-                                    floatingMaskForMassBudgetOrig, &
-                                    groundedMaskForMassBudgetNew, &
-                                    floatingMaskForMassBudgetNew, &
-                                    thicknessNew, &
-                                    groundedToFloatingThickness, &
-                                    nCells)
-      !-----------------------------------------------------------------
-      ! input variables
-      !-----------------------------------------------------------------
-      integer, dimension(:), intent(in) :: &
-         groundedMaskForMassBudgetOrig, &          !< Input: mask for cells before advection
-         floatingMaskForMassBudgetOrig
-
-      integer, dimension(:), intent(in) :: &
-         groundedMaskForMassBudgetNew, &          !< Input: mask for cells after advection
-         floatingMaskForMassBudgetNew
-      real(kind=RKIND), dimension(:), intent(in) :: &
-         thicknessNew         !< Input: ice thickness after advection
-
-      integer, pointer, intent(in) :: &
-         nCells
-      !-----------------------------------------------------------------
-      ! input/output variables
-      !-----------------------------------------------------------------
-
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
-      real(kind=RKIND), dimension(:), intent(out) :: &
-         groundedToFloatingThickness         !< Input: ice thickness
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-      integer :: iCell
-
-      groundedToFloatingThickness(:) = 0.0_RKIND
-
-      do iCell = 1, nCells
-        ! find locations that had grounded ice before but now have floating ice
-        if ( (groundedMaskForMassBudgetOrig(iCell) .eq. 1) .and. &
-             (floatingMaskForMassBudgetNew(iCell) .eq. 1) ) then
-           groundedToFloatingThickness(iCell) = thicknessNew(iCell)
-        ! find locations that had floating ice before but now have grounded ice
-        else if ( (floatingMaskForMassBudgetOrig(iCell) .eq. 1) .and. &
-                  (groundedMaskForMassBudgetNew(iCell) .eq. 1) ) then
-           groundedToFloatingThickness(iCell) = -1.0_RKIND * thicknessNew(iCell)
-        endif
-      enddo
-
-    end subroutine li_grounded_to_floating
 
 !***********************************************************************
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -198,7 +198,9 @@ module li_advection
            cellMaskTemporaryField, & ! scratch field containing old values of cellMask
            edgeMaskTemporaryField, &
            vertexMaskTemporaryField, &
-           thermalCellMaskField
+           thermalCellMaskField,   &
+           groundedMaskForMassBudgetTemporaryField, & ! scratch field containing old values of groundedMaskForMassBudget
+           floatingMaskForMassBudgetTemporaryField    ! scratch field containing old values of floatingMaskForMassBudget
 
       ! Allocatable arrays need for flux-corrected transport advection
       real (kind=RKIND), dimension(:,:,:), allocatable :: tend
@@ -364,8 +366,10 @@ module li_advection
       call mpas_allocate_scratch_field(basalTracersField, .true.)
       basalTracers => basalTracersField % array
 
-      call mpas_pool_get_field(geometryPool, 'cellMaskTemporary', cellMaskTemporaryField)
-      call mpas_allocate_scratch_field(cellMaskTemporaryField, .true.)
+      call mpas_pool_get_field(geometryPool, 'groundedMaskForMassBudgetTemporary', groundedMaskForMassBudgetTemporaryField)
+      call mpas_pool_get_field(geometryPool, 'floatingMaskForMassBudgetTemporary', floatingMaskForMassBudgetTemporaryField)
+      call mpas_allocate_scratch_field(groundedMaskForMassBudgetTemporaryField, .true.)
+      call mpas_allocate_scratch_field(floatingMaskForMassBudgetTemporaryField, .true.)
 
       call mpas_pool_get_field(geometryPool, 'edgeMaskTemporary', edgeMaskTemporaryField)
       call mpas_allocate_scratch_field(edgeMaskTemporaryField, .true.)
@@ -388,6 +392,9 @@ module li_advection
       vertexMaskTemporaryField % array(:) = vertexMask(:)
 
       layerThicknessEdgeFlux(:,:) = 0.0_RKIND
+      ! save old mass budget masks for determining cells changing from grounded to floating and vice versa
+      groundedMaskForMassBudgetTemporaryField % array(:) = groundedMaskForMassBudget(:)
+      floatingMaskForMassBudgetTemporaryField % array(:) = floatingMaskForMassBudget(:)
 
       !-----------------------------------------------------------------
       ! Horizontal transport of thickness and tracers
@@ -651,6 +658,16 @@ module li_advection
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
+         ! Calculate volume converted from grounded to floating
+         ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
+         call grounded_to_floating(groundedMaskForMassBudgetTemporaryField % array, &
+                                   floatingMaskForMassBudgetTemporaryField % array, &
+                                   groundedMaskForMassBudget, &
+                                   floatingMaskForMassBudget, &
+                                   thickness, &
+                                   groundedToFloatingThickness, &
+                                   nCells)
+
          ! Calculate flux across grounding line
          ! Do this after new thickness & mask have been calculated, including SMB/BMB
          fluxAcrossGroundingLine(:) = 0.0_RKIND
@@ -756,6 +773,8 @@ module li_advection
       call mpas_deallocate_scratch_field(edgeMaskTemporaryField, .true.)
       call mpas_deallocate_scratch_field(vertexMaskTemporaryField, .true.)
       call mpas_deallocate_scratch_field(thermalCellMaskField, .true.)
+      call mpas_deallocate_scratch_field(groundedMaskForMassBudgetTemporaryField, .true.)
+      call mpas_deallocate_scratch_field(floatingMaskForMassBudgetTemporaryField, .true.)
 
       ! === error check
       if (err > 0) then
@@ -2129,16 +2148,23 @@ module li_advection
 
     end subroutine vertical_remap
 
-    subroutine li_grounded_to_floating(cellMaskOrig, cellMaskNew, thicknessNew, groundedToFloatingThickness, nCells)
+    subroutine grounded_to_floating(groundedMaskForMassBudgetOrig, &
+                                    floatingMaskForMassBudgetOrig, &
+                                    groundedMaskForMassBudgetNew, &
+                                    floatingMaskForMassBudgetNew, &
+                                    thicknessNew, &
+                                    groundedToFloatingThickness, &
+                                    nCells)
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
       integer, dimension(:), intent(in) :: &
-         cellMaskOrig          !< Input: mask for cells before advection
+         groundedMaskForMassBudgetOrig, &          !< Input: mask for cells before advection
+         floatingMaskForMassBudgetOrig
 
       integer, dimension(:), intent(in) :: &
-         cellMaskNew          !< Input: mask for cells after advection
-
+         groundedMaskForMassBudgetNew, &          !< Input: mask for cells after advection
+         floatingMaskForMassBudgetNew
       real(kind=RKIND), dimension(:), intent(in) :: &
          thicknessNew         !< Input: ice thickness after advection
 
@@ -2163,12 +2189,12 @@ module li_advection
 
       do iCell = 1, nCells
         ! find locations that had grounded ice before but now have floating ice
-        if (li_mask_is_grounded_ice(cellMaskOrig(iCell)) .and. &
-            li_mask_is_floating_ice(cellMaskNew(iCell)) ) then
+        if ( (groundedMaskForMassBudgetOrig(iCell) .eq. 1) .and. &
+             (floatingMaskForMassBudgetNew(iCell) .eq. 1) ) then
            groundedToFloatingThickness(iCell) = thicknessNew(iCell)
         ! find locations that had floating ice before but now have grounded ice
-        else if (li_mask_is_floating_ice(cellMaskOrig(iCell)) .and. &
-                 li_mask_is_grounded_ice(cellMaskNew(iCell)) ) then
+        else if ( (floatingMaskForMassBudgetOrig(iCell) .eq. 1) .and. &
+                  (groundedMaskForMassBudgetNew(iCell) .eq. 1) ) then
            groundedToFloatingThickness(iCell) = -1.0_RKIND * thicknessNew(iCell)
         endif
       enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -368,6 +368,9 @@ module li_advection
       call mpas_allocate_scratch_field(groundedMaskForMassBudgetTemporaryField, .true.)
       call mpas_allocate_scratch_field(floatingMaskForMassBudgetTemporaryField, .true.)
 
+      call mpas_pool_get_field(geometryPool, 'cellMaskTemporary', cellMaskTemporaryField)
+      call mpas_allocate_scratch_field(cellMaskTemporaryField, .true.)
+
       call mpas_pool_get_field(geometryPool, 'edgeMaskTemporary', edgeMaskTemporaryField)
       call mpas_allocate_scratch_field(edgeMaskTemporaryField, .true.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -389,38 +389,45 @@ module li_advection
       cellMaskTemporaryField % array(:) = cellMask(:)
       edgeMaskTemporaryField % array(:) = edgeMask(:)
       vertexMaskTemporaryField % array(:) = vertexMask(:)
+      ! Update halo on edgeMask for calculating flux across grounding line.
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
+      call mpas_timer_stop("halo updates")
 
-      layerThicknessEdgeFlux(:,:) = 0.0_RKIND
       !-----------------------------------------------------------------
       ! Horizontal transport of thickness and tracers
       !-----------------------------------------------------------------
 
       if ( (trim(config_thickness_advection) .eq. 'fo') .or. &
           (trim(config_thickness_advection) .eq. 'fct') ) then
-
-         ! Calculate flux across grounding line before applying
-         ! sfc/basal mass balance and advection
+         ! Calculate flux across grounding line
+         ! Do this after new thickness & mask have been calculated, including SMB/BMB
          fluxAcrossGroundingLine(:) = 0.0_RKIND
          fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
          do iEdge = 1, nEdges
-            if (li_mask_is_grounding_line(edgeMask(iEdge))) then 
+            if (li_mask_is_grounding_line(edgeMask(iEdge))) then
                iCell1 = cellsOnEdge(1,iEdge)
                iCell2 = cellsOnEdge(2,iEdge)
-               if (li_mask_is_grounded_ice(cellMask(iCell1))) then 
+               if (li_mask_is_grounded_ice(cellMask(iCell1))) then
                   GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
                   theGroundedCell = iCell1
-               else 
+               else
                   GLfluxSign = -1.0_RKIND
                   theGroundedCell = iCell2
                endif
-               do k = 1, nVertLevels
-                  thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
-                  fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
-               enddo
+               if (trim(config_thickness_advection) == 'fct') then
+                  do k = 1, nVertLevels
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
+                  enddo
+               else
+                  do k = 1, nVertLevels
+                     layerThicknessEdgeFlux(k,iEdge) = layerNormalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
+                  enddo
+               endif
                ! assign to grounded cell in fluxAcrossGroundingLineOnCells
-               if (thickness(theGroundedCell) <= 0.0_RKIND) then 
-                  ! This should never be the case, but checking to avoid
-                  ! possible divide by zero
+               if (thickness(theGroundedCell) <= 0.0_RKIND) then
+                  ! This should never be the case, but checking to avoid possible divide by zero
                   call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
                   err = ior(err, 1)
                   return
@@ -494,7 +501,7 @@ module li_advection
          ! copy old (input) values of layer thickness and tracers to scratch arrays
          layerThicknessOld(:,:) = layerThickness(:,:)
          advectedTracersOld(:,:,:) = advectedTracers(:,:,:)
-
+         layerThicknessEdgeFlux(:,:) = 0.0_RKIND
          ! compute new values of layer thickness and tracers
          if ((trim(config_thickness_advection) .eq. 'fo') .and. &
              ( (trim(config_tracer_advection) .eq. 'fo') .or. &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1070,26 +1070,19 @@ module li_advection
       where ( (groundedMaskForMassBudget .eq. 1) .or. (bedTopography > config_sea_level) )
             groundedSfcMassBalApplied = sfcMassBalApplied
             floatingSfcMassBalApplied = 0.0_RKIND
+            groundedBasalMassBalApplied = basalMassBalApplied
+            floatingBasalMassBalApplied = 0.0_RKIND
       elsewhere (floatingMaskForMassBudget .eq. 1)
             groundedSfcMassBalApplied = 0.0_RKIND
             floatingSfcMassBalApplied = sfcMassBalApplied
+            groundedBasalMassBalApplied = 0.0_RKIND
+            floatingBasalMassBalApplied = basalMassBalApplied
       elsewhere
             groundedSfcMassBalApplied = 0.0_RKIND
             floatingSfcMassBalApplied = 0.0_RKIND
+            groundedBasalMassBalApplied = 0.0_RKIND
+            floatingBasalMassBalApplied = 0.0_RKIND
       end where
-
-      do iCell = 1, nCells
-         if (li_mask_is_grounded_ice(cellMask(iCell))) then
-            groundedBasalMassBalApplied(iCell) = basalMassBalApplied(iCell)
-            floatingBasalMassBalApplied(iCell) = 0.0_RKIND
-         elseif (li_mask_is_floating_ice(cellMask(iCell))) then
-            floatingBasalMassBalApplied(iCell) = basalMassBalApplied(iCell)
-            groundedBasalMassBalApplied(iCell) = 0.0_RKIND
-         else
-            groundedBasalMassBalApplied(iCell) = 0.0_RKIND
-            floatingBasalMassBalApplied(iCell) = 0.0_RKIND
-         endif
-      enddo
 
       deallocate(thckTracerProducts)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -244,7 +244,7 @@ module li_advection
 
       !WHL - debug
       integer, dimension(:), pointer :: indexToCellID, indexToEdgeID
-      integer, pointer :: nCells, nEdges
+      integer, pointer :: nCells, nEdges, nEdgesSolve
       integer, pointer :: config_stats_cell_ID
       integer :: iEdge, iEdgeOnCell
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -328,6 +328,7 @@ module li_advection
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'maxEdges2', maxEdges2)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -389,6 +390,7 @@ module li_advection
       ! Update halo on edgeMask for calculating flux across grounding line.
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
+      call mpas_dmpar_field_halo_exch(domain, 'cellMask')
       call mpas_timer_stop("halo updates")
 
       !-----------------------------------------------------------------
@@ -401,7 +403,7 @@ module li_advection
          ! Do this after new thickness & mask have been calculated, including SMB/BMB
          fluxAcrossGroundingLine(:) = 0.0_RKIND
          fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
-         do iEdge = 1, nEdges
+         do iEdge = 1, nEdgesSolve
             if (li_mask_is_grounding_line(edgeMask(iEdge))) then
                iCell1 = cellsOnEdge(1,iEdge)
                iCell2 = cellsOnEdge(2,iEdge)
@@ -433,6 +435,11 @@ module li_advection
                        fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
             endif
          enddo ! edges
+
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLine')
+         call mpas_dmpar_field_halo_exch(domain, 'fluxAcrossGroundingLineOnCells')
+         call mpas_timer_stop("halo updates")
 
          if (config_print_thickness_advection_info) then
             call mpas_log_write('Using first-order upwind for thickness advection')

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -82,6 +82,7 @@ module li_advection
         geometryPool,           &
         thermalPool,            &
         scratchPool,            &
+        domain,                 &
         err,                    &
         advectTracersIn)
 
@@ -111,10 +112,11 @@ module li_advection
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
 
+      type (domain_type), intent(inout) :: domain
+
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information
                                   !                (needs to be inout for li_calculate_mask call
-
       type (mpas_pool_type), intent(inout) :: &
            geometryPool           !< Input/output: geometry information to be updated
 
@@ -376,10 +378,6 @@ module li_advection
       ! given the old thickness, compute the thickness in each layer
       call li_calculate_layerThickness(meshPool, thickness, layerThickness)
 
-      ! Save copies of masks because we need to preserve mask
-      ! states prior to advection for accurate time integration.
-      ! A mask update is necessary to calculate grounding line flux,
-      ! after which we will reset the masks to their previous states.
       cellMaskTemporaryField % array(:) = cellMask(:)
       edgeMaskTemporaryField % array(:) = edgeMask(:)
       vertexMaskTemporaryField % array(:) = vertexMask(:)
@@ -642,7 +640,7 @@ module li_advection
          ! We need an updated set of masks to calculate fluxAcrossGroundingLine,
          ! but we will reset this to the previous state below for accuracy of the
          ! time integration scheme.
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! Calculate flux across grounding line

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -603,18 +603,22 @@ module li_advection
 
          ! TODO: more complicated treatment at GL?
 
-         do iCell = 1, nCells
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then
-               basalMassBal(iCell) = groundedBasalMassBal(iCell)
-            elseif (li_mask_is_floating_ice(cellMask(iCell))) then
-               ! Currently, floating and grounded ice are mutually exclusive.
-               ! This could change if the GL is parameterized, in which case this logic may need adjustment.
-               basalMassBal(iCell) = floatingBasalMassBal(iCell)
-            elseif ( .not. (li_mask_is_ice(cellMask(iCell)))) then
-               ! We don't allow a positive basal mass balance where ice is not already present.
-               basalMassBal(iCell) = 0.0_RKIND
-            endif
-         enddo
+         where ( groundedMaskForMassBudget .eq. 1 )
+
+            basalMassBal = groundedBasalMassBal
+
+         elsewhere ( floatingMaskForMassBudget .eq. 1)
+
+            ! Currently, floating and grounded ice are mutually exclusive.
+            ! This could change if the GL is parameterized, in which case this logic may need adjustment.
+            basalMassBal = floatingBasalMassBal
+
+         elsewhere ( .not. (li_mask_is_ice(cellMask) ) )
+
+            ! We don't allow a positive basal mass balance where ice is not already present.
+            basalMassBal = 0.0_RKIND
+
+         end where
 
          ! It is possible that excess internal melting was computed and assigned
          ! to the drainedInternalMeltRate array in mpas_li_thermal.F.  If so, then add it to basalMassBal.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -403,6 +403,38 @@ module li_advection
       if ( (trim(config_thickness_advection) .eq. 'fo') .or. &
           (trim(config_thickness_advection) .eq. 'fct') ) then
 
+         ! Calculate flux across grounding line before applying
+         ! sfc/basal mass balance and advection
+         fluxAcrossGroundingLine(:) = 0.0_RKIND
+         fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
+         do iEdge = 1, nEdges
+            if (li_mask_is_grounding_line(edgeMask(iEdge))) then 
+               iCell1 = cellsOnEdge(1,iEdge)
+               iCell2 = cellsOnEdge(2,iEdge)
+               if (li_mask_is_grounded_ice(cellMask(iCell1))) then 
+                  GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
+                  theGroundedCell = iCell1
+               else 
+                  GLfluxSign = -1.0_RKIND
+                  theGroundedCell = iCell2
+               endif
+               do k = 1, nVertLevels
+                  thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
+                  fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
+               enddo
+               ! assign to grounded cell in fluxAcrossGroundingLineOnCells
+               if (thickness(theGroundedCell) <= 0.0_RKIND) then 
+                  ! This should never be the case, but checking to avoid
+                  ! possible divide by zero
+                  call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
+                  err = ior(err, 1)
+                  return
+               endif
+               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
+                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
+            endif
+         enddo ! edges
+
          if (config_print_thickness_advection_info) then
             call mpas_log_write('Using first-order upwind for thickness advection')
             call mpas_log_write('advectTracers = $l', logicArgs=(/advectTracers/))
@@ -667,50 +699,6 @@ module li_advection
                                    thickness, &
                                    groundedToFloatingThickness, &
                                    nCells)
-
-         ! Calculate flux across grounding line
-         ! Do this after new thickness & mask have been calculated, including SMB/BMB
-         fluxAcrossGroundingLine(:) = 0.0_RKIND
-         fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
-         do iEdge = 1, nEdges
-            if (li_mask_is_grounding_line(edgeMask(iEdge))) then
-               iCell1 = cellsOnEdge(1,iEdge)
-               iCell2 = cellsOnEdge(2,iEdge)
-               if (li_mask_is_grounded_ice(cellMask(iCell1))) then
-                  GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
-                  theGroundedCell = iCell1
-               else
-                  GLfluxSign = -1.0_RKIND
-                  theGroundedCell = iCell2
-               endif
-               if (trim(config_thickness_advection) == 'fct') then
-                  do k = 1, nVertLevels
-                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
-                  enddo
-               else
-                  do k = 1, nVertLevels
-                     layerThicknessEdgeFlux(k,iEdge) = layerNormalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
-                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
-                  enddo
-               endif
-               ! assign to grounded cell in fluxAcrossGroundingLineOnCells
-               if (thickness(theGroundedCell) <= 0.0_RKIND) then
-                  ! This should never be the case, but checking to avoid possible divide by zero
-                  call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
-                  err = ior(err, 1)
-                  return
-               endif
-               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
-                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
-            endif
-         enddo ! edges
-
-         ! Reset masks to state before advection and mass balance for
-         ! accuracy of time integration scheme.
-         cellMask(:) = cellMaskTemporaryField % array(:)
-         edgeMask(:) = edgeMaskTemporaryField % array(:)
-         vertexMask(:) = vertexMaskTemporaryField % array(:)
-
          ! Remap tracers to the standard vertical sigma coordinate
          ! Note: If tracers are not being advected, then this subroutine simply restores the
          !       layer thickness to sigma coordinate values.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -251,7 +251,7 @@ contains
             bedTopography(:) = bedTopography(:) + upliftRate(:) * deltat
 
             call li_update_geometry(geometryPool)
-            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+            call  li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
             block => block % next
          end do
@@ -761,7 +761,7 @@ contains
       ! Perform Halo exchange update
       call mpas_dmpar_field_halo_exch(domain,'bedTopography')
       call li_update_geometry(geometryPool)
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call  li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
       ! deallocate memory

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1119,6 +1119,7 @@ module li_calving
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
@@ -1596,8 +1597,7 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         call update_calving_budget(domain)
-         call remove_icebergs(domain)
+         call li_remove_icebergs(domain)
 
          block => block % next
       enddo
@@ -2153,7 +2153,7 @@ module li_calving
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
 
-          call remove_icebergs(domain)
+          call li_remove_icebergs(domain)
 
           block => block % next
 
@@ -3481,7 +3481,7 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         call remove_icebergs(domain)
+         call li_remove_icebergs(domain)
 
          block => block % next
 
@@ -4403,8 +4403,7 @@ module li_calving
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
       call mpas_timer_stop("iceberg detection")
 
-   end subroutine remove_icebergs
->>>>>>> a5bee82292 (Update calving budget incrementally)
+   end subroutine li_remove_icebergs
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -332,7 +332,7 @@ module li_calving
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
 
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
       ! Consider mask calving as a possible additional step
       ! Mask calving can occur by itself or in conjunction with a physical calving law
@@ -341,16 +341,16 @@ module li_calving
          err = ior(err, err_tmp)
       endif
 
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
       call remove_small_islands(domain, err_tmp)
 
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
       ! now also remove any icebergs
       call li_remove_icebergs(domain)
 
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
       ! Parse grounded vs floating calving for budgets
       block => domain % blocklist
@@ -410,7 +410,7 @@ module li_calving
          endif   ! config_print_calving_info
 
          ! Update mask and geometry
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
          call li_update_geometry(geometryPool)
 
@@ -1001,7 +1001,6 @@ module li_calving
          thickness(:) = thickness(:) - dCalvingThickness(:)
 
          call update_calving_budget(geometryPool, dCalvingThickness)
-         call remove_small_islands(meshPool, geometryPool)
          block => block % next
       enddo
 
@@ -1084,7 +1083,6 @@ module li_calving
          thickness(:) = thickness(:) - dCalvingThickness(:)
 
          call update_calving_budget(geometryPool, dCalvingThickness)
-         call remove_small_islands(meshPool, geometryPool)
 
          deallocate(dCalvingThickness)
          block => block % next
@@ -1296,7 +1294,7 @@ module li_calving
       call mpas_dmpar_field_halo_exch(domain, 'thickness')
       call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
       call mpas_timer_stop("halo updates")
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err)
 
       call mpas_dmpar_sum_int(domain % dminfo, nIslandCellsLocal, nIslandCellsGlobal)
 
@@ -1411,7 +1409,6 @@ module li_calving
          thickness(:) = thickness(:) - dCalvingThickness(:)
 
          call update_calving_budget(geometryPool, dCalvingThickness)
-         call remove_small_islands(meshPool, geometryPool)
 
          deallocate(dCalvingThickness)
 
@@ -1630,7 +1627,6 @@ module li_calving
 
          call update_calving_budget(domain)
          call remove_icebergs(domain)
-         call remove_small_islands(meshPool, geometryPool)
 
          deallocate(dCalvingThickness)
          block => block % next
@@ -1796,9 +1792,6 @@ module li_calving
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
-
-         ! TODO: global reduce & reporting on amount of calving generated in this step
-         call update_calving_budget(domain)
 
          block => block % next
 
@@ -2188,6 +2181,8 @@ module li_calving
           ! update mask
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
+
+          call remove_icebergs(domain)
 
           deallocate(dCalvingThickness)
           block => block % next
@@ -3514,6 +3509,10 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
+         call remove_icebergs(domain)
+
+         deallocate(dCalvingThickness)
+
          block => block % next
 
       enddo
@@ -4177,7 +4176,6 @@ module li_calving
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
-
 
          deallocate(dCalvingThickness)
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -664,6 +664,7 @@ module li_calving
 
          ! Now check for marine regions that have advanced
          allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
 
          ! loop over locally owned cells
          do iCell = 1, nCells
@@ -1147,7 +1148,6 @@ module li_calving
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
@@ -1160,7 +1160,6 @@ module li_calving
 
       allocate(connectedCellsList((maxEdges+1)**2), &
                islandMask(nCells+1))
-      allocate(dCalvingThickness(nCellsSolve+1))
       dCalvingThickness(:) = 0.0_RKIND
       islandMask(:) = 0
       nIslandCellsLocal = 0

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -247,6 +247,24 @@ module li_calving
          end do
       endif
       
+      ! Zero calvingThickness here instead of or in addition to in individual subroutines.
+      ! This is necessary when using damage threshold calving with other calving
+      ! routines. Some individual routines still set calvingThickness to zero, but 
+      ! this is redundant. li_apply_front_ablation_velocity will zero 
+      ! calvingThickness, so any routines that use that should not be applied 
+      ! after other calving routines.
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+         calvingThickness(:) = 0.0_RKIND
+         groundedCalvingThickness(:) = 0.0_RKIND
+         floatingCalvingThickness(:) = 0.0_RKIND
+   
+         block => block % next
+      end do
       ! compute calvingThickness based on the calving_config option
       if (trim(config_calving) == 'none') then
 
@@ -366,8 +384,6 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
-         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
          ! In data calving mode we just calculate what should be calved but don't actually calve it.
@@ -668,6 +684,7 @@ module li_calving
          block => block % next
       enddo
 
+      call update_calving_budget(domain)
       ! Update mask and geometry
       block => domain % blocklist
       do while (associated(block))
@@ -972,6 +989,12 @@ module li_calving
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
 
+<<<<<<< HEAD
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
       enddo
 
@@ -1046,6 +1069,12 @@ module li_calving
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
 
+<<<<<<< HEAD
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
       enddo
 
@@ -1071,11 +1100,20 @@ module li_calving
       integer, intent(inout) :: err
       type (mpas_pool_type), pointer :: scratchPool, meshPool, geometryPool, velocityPool
       logical, pointer :: config_remove_small_islands
+<<<<<<< HEAD
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
+=======
+      real(kind=RKIND), pointer :: config_sea_level
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness, &   ! thickness of ice that calves (computed in this subroutine)
+                                                  groundedCalvingThickness, &
+                                                  floatingCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: cellMask, &
+                                        groundedMaskForMassBudget, &
+                                        floatingMaskForMassBudget
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, pointer :: nCells, maxEdges
@@ -1105,6 +1143,10 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
+      call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+      call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+      call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+      call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
@@ -1170,6 +1212,7 @@ module li_calving
                   exit
                endif
             enddo
+<<<<<<< HEAD
          endif
       enddo
 
@@ -1219,6 +1262,30 @@ module li_calving
                        (.not. any(connectedCellsList == kCell)) ) then
                         removeIsland = .false.
                         exit
+=======
+            if ((nIceNeighbors == 0) .and. (nOpenOceanNeighbors == nEdgesOnCell(iCell))) then
+               ! If this is a single cell of ice surrounded by open ocean, kill this location
+               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
+               thickness(iCell) = 0.0_RKIND
+               ! Update calving budgets
+               if (groundedMaskForMassBudget(iCell) .eq. 1) then
+                  groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
+               elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
+                  floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
+               endif
+            elseif (nIceNeighbors == 1) then
+               ! check if this neighbor has any additional neighbors with ice
+               nIceNeighbors2 = 0
+               nOpenOceanNeighbors2 = 0
+               do n = 1, nEdgesOnCell(neighborWithIce)
+                  jCell = cellsOnCell(n, neighborWithIce)
+                  if (li_mask_is_ice(cellMask(jCell))) then
+                     nIceNeighbors2 = nIceNeighbors2 + 1
+                  endif
+                  if (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) then
+                     nOpenOceanNeighbors2 = nOpenOceanNeighbors2 + 1
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
                   endif
                enddo
             enddo
@@ -1268,6 +1335,7 @@ module li_calving
                   calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
                   calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
+<<<<<<< HEAD
             endif
          enddo
          call mpas_log_write("***Finished cleaning up after removing small islands***")
@@ -1276,6 +1344,30 @@ module li_calving
                  islandMask)
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
+=======
+                  ! Update calving budgets
+                  if (groundedMaskForMassBudget(iCell) .eq. 1) then
+                     groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
+                  elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
+                     floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
+                  endif
+
+                  calvingThickness(neighborWithIce) = calvingThickness(neighborWithIce) + thickness(neighborWithIce)
+                  calvingThicknessFromThreshold(neighborWithIce) = calvingThicknessFromThreshold(neighborWithIce) + thickness(neighborWithIce)
+                  thickness(neighborWithIce) = 0.0_RKIND
+                  ! Update calving budgets
+                  if (groundedMaskForMassBudget(neighborWithIce) .eq. 1) then
+                     groundedCalvingThickness(neighborWithIce) = groundedCalvingThickness(neighborWithIce) + thickness(neighborWithIce)
+                  elseif (floatingMaskForMassBudget(neighborWithIce) .eq. 1) then
+                     floatingCalvingThickness(neighborWithIce) = floatingCalvingThickness(neighborWithIce) + thickness(neighborWithIce)
+                  endif
+               endif
+
+            endif ! check on nIceNeighbors
+
+         endif ! check if iCell has ice
+      end do ! loop over cells
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
 
    end subroutine remove_small_islands
 
@@ -1353,6 +1445,12 @@ module li_calving
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
 
+<<<<<<< HEAD
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
       enddo
 
@@ -1533,6 +1631,7 @@ module li_calving
          call mpas_timer_stop("halo updates")
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
+         call update_calving_budget(domain)
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
@@ -1557,7 +1656,7 @@ module li_calving
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-
+         call update_calving_budget(domain)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1582,6 +1681,11 @@ module li_calving
            endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
+<<<<<<< HEAD
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
 
          block => block % next
       enddo
@@ -1715,7 +1819,7 @@ module li_calving
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
-
+         call update_calving_budget(domain)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1739,7 +1843,7 @@ module li_calving
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-
+         call update_calving_budget(domain)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1764,6 +1868,11 @@ module li_calving
            endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
+<<<<<<< HEAD
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
 
          block => block % next
       enddo
@@ -2147,11 +2256,16 @@ module li_calving
 
           ! === apply calving ===
           thickness(:) = thickness(:) - calvingThickness(:)
-
+          call update_calving_budget(domain)
           ! update mask
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
 
+<<<<<<< HEAD
+=======
+          call remove_small_islands(meshPool, geometryPool)
+
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
           block => block % next
 
       enddo ! associated(block)
@@ -2417,7 +2531,7 @@ module li_calving
 
       ! === apply calving ===
       thickness(:) = thickness(:) - calvingThickness(:)
-
+      call update_calving_budget(domain)
       ! update mask
       call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
@@ -3448,7 +3562,7 @@ module li_calving
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
-
+         call update_calving_budget(domain)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -3464,7 +3578,7 @@ module li_calving
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
-
+         call update_calving_budget(domain)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -3489,7 +3603,12 @@ module li_calving
            endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
+<<<<<<< HEAD
 
+=======
+         call update_calving_budget(domain)
+         call remove_small_islands(meshPool, geometryPool)
+>>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
 
       enddo
@@ -4257,10 +4376,14 @@ module li_calving
       integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
       !integer, dimension(:), allocatable :: seedMaskOld !mask of where icebergs are removed, for debugging
 
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
+      real (kind=RKIND), dimension(:), pointer :: calvingThickness, &    ! thickness of ice that calves (computed in this subroutine)
+                                                  groundedCalvingThickness, &
+                                                  floatingCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
-      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: cellMask, &
+                                        groundedMaskForMassBudget, &
+                                        floatingMaskForMassBudget
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
 
@@ -4358,6 +4481,10 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
+         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
          call mpas_pool_get_dimension(geometryPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
          !allocate(seedMaskOld(nCells+1)) ! debug: make this a mask of where icebergs were removed
@@ -4369,6 +4496,11 @@ module li_calving
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)  ! remove any remaining ice here
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
+               if (groundedMaskForMassBudget(iCell) .eq. 1) then
+                  groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
+               elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
+                  floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
+               endif
                localIcebergCellCount = localIcebergCellCount + 1
                !seedMaskOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
             endif
@@ -4543,6 +4675,50 @@ module li_calving
       call mpas_log_write("Flood fill complete.")
 
    end subroutine li_flood_fill
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!    routine update_calving_budget
+!
+!> \brief Keep a running total of calving applied to grounded and floating
+!> ice, respectively. 
+!> \author Trevor Hillebrand
+!> \date   May 2022
+!> \details This routine should be called after each time time calvingThickness
+!> is applied, but before masks are updated which often happens multiple times
+!> in a timestep.
+!-----------------------------------------------------------------------
+   subroutine update_calving_budget(domain)
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer :: meshPool, geometryPool
+      integer, dimension(:), pointer :: groundedMaskForMassBudget, & ! binary masks for mass budget
+                                        floatingMaskForMassBudget
+      real (kind=RKIND), dimension(:), pointer ::  calvingThickness, &
+                                                   groundedCalvingThickness, & ! Grounded and floating components for mass budget
+                                                   floatingCalvingThickness
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+      call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
+      call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+      call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+
+      where (groundedMaskForMassBudget .eq. 1)
+          groundedCalvingThickness = calvingThickness
+      elsewhere (floatingMaskForMassBudget .eq. 1)
+          floatingCalvingThickness = calvingThickness
+      end where      
+
+   end subroutine update_calving_budget
 
 end module li_calving
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -352,29 +352,6 @@ module li_calving
 
       call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
 
-      ! Parse grounded vs floating calving for budgets
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
-         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
-         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
-         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
-
-         groundedCalvingThickness(:) = 0.0_RKIND
-         floatingCalvingThickness(:) = 0.0_RKIND
-         where (groundedMaskForMassBudget .eq. 1)
-             groundedCalvingThickness = calvingThickness
-         elsewhere (floatingMaskForMassBudget .eq. 1)
-             floatingCalvingThickness = calvingThickness
-         elsewhere
-             groundedCalvingThickness = 0.0_RKIND
-             floatingCalvingThickness = 0.0_RKIND
-         end where
-
-         block => block % next
-      end do
-
       ! Final operations after calving has been applied, including removal
       ! of small islands
       block => domain % blocklist

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -200,7 +200,7 @@ module li_calving
       ! Update mask and geometry before calling any calving routines.  May not be necessary, but best be safe.
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
       call li_update_geometry(geometryPool)
 
@@ -575,7 +575,7 @@ module li_calving
          restoreThicknessMin = 0.1_RKIND * config_dynamic_thickness
 
          ! calculate masks - so we know where the calving front was located initially
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! initialize
@@ -646,7 +646,7 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next
@@ -1506,7 +1506,7 @@ module li_calving
          thickness(:) = thickness(:) - calvingThickness(:)
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
@@ -1530,7 +1530,7 @@ module li_calving
          ! TODO: global reduce & reporting on amount of calving generated in this step
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
@@ -1688,7 +1688,7 @@ module li_calving
          thickness(:) = thickness(:) - calvingThickness(:)
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
@@ -1712,7 +1712,7 @@ module li_calving
          ! TODO: global reduce & reporting on amount of calving generated in this step
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
@@ -2120,7 +2120,7 @@ module li_calving
           thickness(:) = thickness(:) - calvingThickness(:)
 
           ! update mask
-          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
 
           block => block % next
@@ -2390,7 +2390,7 @@ module li_calving
       thickness(:) = thickness(:) - calvingThickness(:)
 
       ! update mask
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
       deallocate(submergedArea)
@@ -3421,7 +3421,7 @@ module li_calving
          thickness(:) = thickness(:) - calvingThickness(:)
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! Now also remove thin floating, dynamic ice (based on chosen thickness threshold) after mask is updated.
@@ -3437,7 +3437,7 @@ module li_calving
          enddo
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
@@ -4115,7 +4115,7 @@ module li_calving
          call mpas_log_write("Mask calving applied.  Removed $i floating cells with mask.", intArgs=(/globalMaskCellCount/))
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          block => block % next
@@ -4286,7 +4286,7 @@ module li_calving
 
          ! make sure masks are up to date.  May not be necessary, but safer to
          ! do anyway.
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          call mpas_log_write("Iceberg-detection flood-fill: updated masks.")
@@ -4425,7 +4425,7 @@ module li_calving
 
          ! make sure masks are up to date.  May not be necessary, but safer to
          ! do anyway.
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          !call mpas_log_write("Flood-fill: updated masks.")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4155,7 +4155,7 @@ module li_calving
          dCalvingThickness(:) = 0.0_RKIND
 
          ! update mask
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          localMaskCellCount = 0

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -334,6 +334,29 @@ module li_calving
 
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
+      ! Parse grounded vs floating calving for budgets
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
+
+         groundedCalvingThickness(:) = 0.0_RKIND
+         floatingCalvingThickness(:) = 0.0_RKIND
+         where (groundedMaskForMassBudget .eq. 1)
+             groundedCalvingThickness = calvingThickness
+         elsewhere (floatingMaskForMassBudget .eq. 1)
+             floatingCalvingThickness = calvingThickness
+         elsewhere
+             groundedCalvingThickness = 0.0_RKIND
+             floatingCalvingThickness = 0.0_RKIND
+         end where
+
+         block => block % next
+      end do
+
       ! Final operations after calving has been applied, including removal
       ! of small islands
       block => domain % blocklist
@@ -374,20 +397,6 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
          call li_update_geometry(geometryPool)
-         ! necessary to get these after masks have been updated
-         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
-         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
-
-         groundedCalvingThickness(:) = 0.0_RKIND
-         floatingCalvingThickness(:) = 0.0_RKIND
-         where (groundedMaskForMassBudget .eq. 1)
-             groundedCalvingThickness = calvingThickness
-         elsewhere (floatingMaskForMassBudget .eq. 1)
-             floatingCalvingThickness = calvingThickness
-         elsewhere
-             groundedCalvingThickness = 0.0_RKIND
-             floatingCalvingThickness = 0.0_RKIND
-         end where
 
          block => block % next
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -516,6 +516,8 @@ module li_calving
                                ! > 0 for cells below sea level that were initially ice-free and now have ice
            restoreThickness    ! thickness of ice that is added to restore the calving front to its initial position
                                ! > 0 for cells below sea level that were initially ice-covered and now have very thin or no ice
+      real (kind=RKIND), dimension(:), allocatable:: &
+           dCalvingThickness ! incremental calving thickness
 
       real (kind=RKIND) ::  &
            restoreThicknessMin  ! small thickness to which ice is restored should it fall below this thickness
@@ -661,6 +663,9 @@ module li_calving
          endif ! if preventing retreat
 
          ! Now check for marine regions that have advanced
+         allocate(dCalvingThickness(nCellsSolve+1))
+
+         ! loop over locally owned cells
          do iCell = 1, nCells
             if (bedTopography(iCell) < config_sea_level) then
                ! The bed is below sea level; test for calving-front advance and retreat.
@@ -673,7 +678,7 @@ module li_calving
                      call mpas_log_write('Remove ice:  indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
                   endif
 
-                  calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+                  dCalvingThickness(iCell) = thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
                   ! Assign flow speed to calving speed - this allows calculation of licalvf in ISMIP6 postprocessing
                   calvingVelocity(iCell) = surfaceSpeed(iCell)
@@ -681,10 +686,12 @@ module li_calving
             endif    ! bedTopography < config_sea_level
          enddo   ! iCell
 
+         call update_calving_budget(geometryPool, dCalvingThickness)
+
+         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
-      call update_calving_budget(domain)
       ! Update mask and geometry
       block => domain % blocklist
       do while (associated(block))
@@ -825,6 +832,8 @@ module li_calving
 
       real (kind=RKIND), dimension(:), pointer :: &
            calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), allocatable :: &
+           dCalvingThickness
 
       integer, pointer :: nCells
       integer :: iCell, iCellOnCell, iCellNeighbor
@@ -892,7 +901,8 @@ module li_calving
 
          ! Initialize
          calvingThickness = 0.0_RKIND
-
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
          ! Identify cells that are active-for-calving:
          ! (1) Grounded ice with thickness > config_dynamic_thickness
          ! (2) Floating ice with thickness > config_calving_thickness
@@ -982,19 +992,15 @@ module li_calving
          ! Calve ice in ocean cells that are not on the protected inactive margin
 
          where (oceanMask == 1 .and. inactiveMarginMask == 0 .and. thickness > 0.0_RKIND)
-            calvingThickness = thickness * calvingFraction
+            dCalvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
 
-<<<<<<< HEAD
-=======
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          call remove_small_islands(meshPool, geometryPool)
-
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
       enddo
 
@@ -1002,6 +1008,7 @@ module li_calving
       call mpas_deallocate_scratch_field(activeForCalvingMaskField, .true.)
       call mpas_deallocate_scratch_field(inactiveMarginMaskField, .true.)
       call mpas_deallocate_scratch_field(oceanMaskField, .true.)
+      deallocate(dCalvingThickness)
 
    end subroutine thickness_calving
 
@@ -1041,9 +1048,11 @@ module li_calving
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: floatingMaskForMassBudget
+      integer, pointer :: nCells
 
       err = 0
 
@@ -1059,25 +1068,24 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
+         call mpas_pool_get_array(meshPool, 'nCells', nCells)
 
-         calvingThickness = 0.0_RKIND
-
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
          ! Note: The floating_ice mask does not include floating
          ! non-dynamic cells adjacent to grounded cells.
          where ( floatingMaskForMassBudget .eq. 1 )
-            calvingThickness = thickness * calvingFraction
+            dCalvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
 
-<<<<<<< HEAD
-=======
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          call remove_small_islands(meshPool, geometryPool)
 
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
+         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -1103,15 +1111,12 @@ module li_calving
       integer, intent(inout) :: err
       type (mpas_pool_type), pointer :: scratchPool, meshPool, geometryPool, velocityPool
       logical, pointer :: config_remove_small_islands
-<<<<<<< HEAD
-      real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
-=======
       real(kind=RKIND), pointer :: config_sea_level
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, &   ! thickness of ice that calves (computed in this subroutine)
                                                   groundedCalvingThickness, &
                                                   floatingCalvingThickness
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: cellMask, &
@@ -1155,7 +1160,8 @@ module li_calving
 
       allocate(connectedCellsList((maxEdges+1)**2), &
                islandMask(nCells+1))
-
+      allocate(dCalvingThickness(nCellsSolve+1))
+      dCalvingThickness(:) = 0.0_RKIND
       islandMask(:) = 0
       nIslandCellsLocal = 0
       nIslandCellsGlobal = 0
@@ -1215,7 +1221,6 @@ module li_calving
                   exit
                endif
             enddo
-<<<<<<< HEAD
          endif
       enddo
 
@@ -1265,30 +1270,6 @@ module li_calving
                        (.not. any(connectedCellsList == kCell)) ) then
                         removeIsland = .false.
                         exit
-=======
-            if ((nIceNeighbors == 0) .and. (nOpenOceanNeighbors == nEdgesOnCell(iCell))) then
-               ! If this is a single cell of ice surrounded by open ocean, kill this location
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-               calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
-               thickness(iCell) = 0.0_RKIND
-               ! Update calving budgets
-               if (groundedMaskForMassBudget(iCell) .eq. 1) then
-                  groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
-               elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
-                  floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
-               endif
-            elseif (nIceNeighbors == 1) then
-               ! check if this neighbor has any additional neighbors with ice
-               nIceNeighbors2 = 0
-               nOpenOceanNeighbors2 = 0
-               do n = 1, nEdgesOnCell(neighborWithIce)
-                  jCell = cellsOnCell(n, neighborWithIce)
-                  if (li_mask_is_ice(cellMask(jCell))) then
-                     nIceNeighbors2 = nIceNeighbors2 + 1
-                  endif
-                  if (.not. li_mask_is_ice(cellMask(jCell)) .and. bedTopography(jCell) < config_sea_level) then
-                     nOpenOceanNeighbors2 = nOpenOceanNeighbors2 + 1
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
                   endif
                enddo
             enddo
@@ -1335,10 +1316,9 @@ module li_calving
          call li_flood_fill(seedMask, growMask, domain)
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. seedMask(iCell) == 0) then
-                  calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
                   calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
+                  dCalvingThickness(iCell) = thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
-<<<<<<< HEAD
             endif
          enddo
          call mpas_log_write("***Finished cleaning up after removing small islands***")
@@ -1347,31 +1327,10 @@ module li_calving
                  islandMask)
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
-=======
-                  ! Update calving budgets
-                  if (groundedMaskForMassBudget(iCell) .eq. 1) then
-                     groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
-                  elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
-                     floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
-                  endif
 
-                  calvingThickness(neighborWithIce) = calvingThickness(neighborWithIce) + thickness(neighborWithIce)
-                  calvingThicknessFromThreshold(neighborWithIce) = calvingThicknessFromThreshold(neighborWithIce) + thickness(neighborWithIce)
-                  thickness(neighborWithIce) = 0.0_RKIND
-                  ! Update calving budgets
-                  if (groundedMaskForMassBudget(neighborWithIce) .eq. 1) then
-                     groundedCalvingThickness(neighborWithIce) = groundedCalvingThickness(neighborWithIce) + thickness(neighborWithIce)
-                  elseif (floatingMaskForMassBudget(neighborWithIce) .eq. 1) then
-                     floatingCalvingThickness(neighborWithIce) = floatingCalvingThickness(neighborWithIce) + thickness(neighborWithIce)
-                  endif
-               endif
-
-            endif ! check on nIceNeighbors
-
-         endif ! check if iCell has ice
-      end do ! loop over cells
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
-
+      call update_calving_budget(geometryPool, dCalvingThickness)
+      
+      deallocate(dCalvingThickness)
    end subroutine remove_small_islands
 
 
@@ -1409,11 +1368,13 @@ module li_calving
       type (mpas_pool_type), pointer :: geometryPool, meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real(kind=RKIND), pointer :: config_calving_topography
       real(kind=RKIND), pointer :: config_sea_level
       logical, pointer :: config_print_calving_info
       real (kind=RKIND), dimension(:), pointer :: bedTopography, thickness
       integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nCells
 
       err = 0
 
@@ -1437,23 +1398,24 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(meshPool, 'nCells', nCells)
 
-         calvingThickness = 0.0_RKIND
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
 
          where ( (li_mask_is_floating_ice(cellMask)) .and. (bedTopography < config_calving_topography + config_sea_level) )
-            calvingThickness = thickness * calvingFraction
+            dCalvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
 
-<<<<<<< HEAD
-=======
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          call remove_small_islands(meshPool, geometryPool)
 
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
+         deallocate(dCalvingThickness)
+
          block => block % next
       enddo
 
@@ -1511,6 +1473,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1592,6 +1555,8 @@ module li_calving
                     realArgs=(/minval(eigencalvingParameter), maxval(eigencalvingParameter)/))
          endif
 
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
@@ -1599,7 +1564,7 @@ module li_calving
          call mpas_log_write("calling li_apply_front_ablation_velocity from eigencalving")
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
-                                              calvingThickness, calvingVelocity, applyToGrounded, &
+                                              dCalvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, calvingCFLdt, dtCalvingCFLratio, &
                                               totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
          err = ior(err, err_tmp)
@@ -1611,7 +1576,7 @@ module li_calving
             call mpas_log_write('config_damage_calving_method == threshold; &
                                  removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
 
-            call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
+            call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
             err = ior(err, err_tmp)
          elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
              call mpas_log_write('config_damage_calving_method == calving_rate &
@@ -1633,8 +1598,8 @@ module li_calving
          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
          call mpas_timer_stop("halo updates")
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
-         call update_calving_budget(domain)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
+         call update_calving_budget(geometryPool, dCalvingThickness)
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
@@ -1654,42 +1619,21 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               dCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-         calvingSubtotal = 0.0_RKIND
-         do iCell = 1, nCells
-           if (li_mask_is_floating_ice(cellMask(iCell))) then
-              ! check neighbors for dynamic ice (floating or grounded)
-              dynamicNeighbor = .false.
-              do iNeighbor = 1, nEdgesOnCell(iCell)
-                 jCell = cellsOnCell(iNeighbor, iCell)
-                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-              enddo
-              if (.not. dynamicNeighbor) then  ! calve this ice
-                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-                 thickness(iCell) = 0.0_RKIND
-                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
-              endif
-           endif
-         enddo
-         ! TODO: global reduce & reporting on amount of calving generated in this step
-<<<<<<< HEAD
-=======
          call update_calving_budget(domain)
+         call remove_icebergs(domain)
          call remove_small_islands(meshPool, geometryPool)
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
 
+         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -1741,6 +1685,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness ! Incremental calving thickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1794,6 +1739,8 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
 
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
 
          ! get parameter value
          if (trim(config_calving_specified_source) == 'const') then
@@ -1812,7 +1759,7 @@ module li_calving
          endif
 
          ! Convert calvingVelocity to calvingThickness
-         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
+         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, dCalvingThickness, calvingVelocity, &
                                               applyToGrounded=.true., applyToFloating=.true., applyToGroundingLine=.false., &
                                               domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
                                               totalAblatedVolume=totalRatebasedCalvedVolume, &
@@ -1821,8 +1768,8 @@ module li_calving
          err = ior(err, err_tmp)
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
-         call update_calving_budget(domain)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1841,43 +1788,22 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               dCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-         calvingSubtotal = 0.0_RKIND
-         do iCell = 1, nCells
-           if (li_mask_is_floating_ice(cellMask(iCell))) then
-              ! check neighbors for dynamic ice (floating or grounded)
-              dynamicNeighbor = .false.
-              do iNeighbor = 1, nEdgesOnCell(iCell)
-                 jCell = cellsOnCell(iNeighbor, iCell)
-                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-              enddo
-              if (.not. dynamicNeighbor) then  ! calve this ice
-                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-                 thickness(iCell) = 0.0_RKIND
-                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
-              endif
-           endif
-         enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-<<<<<<< HEAD
-=======
          call update_calving_budget(domain)
-         call remove_small_islands(meshPool, geometryPool)
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
 
          block => block % next
+
+         deallocate(dCalvingThickness)
       enddo
 
    end subroutine specified_calving_velocity
@@ -1938,6 +1864,7 @@ module li_calving
                                         floatingVonMisesThresholdStress, &
                                         groundedVonMisesThresholdStress, &
                                         surfaceSpeed
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA, &
                                         temperature, layerThickness
       real (kind=RKIND), pointer :: config_default_flowParamA
@@ -2050,7 +1977,9 @@ module li_calving
           endif
 
           vonMisesStress(:) = 0.0_RKIND
-          
+          allocate(dCalvingThickness(nCells+1))
+          dCalvingThickness(:) = 0.0_RKIND
+
           ! get flowParamA from MPAS or use Albany-like equation
           if ( config_use_Albany_flowA_eqn_for_vM ) then
           !calculate Albany-type flowParamA
@@ -2186,7 +2115,7 @@ module li_calving
           call mpas_log_write("calling li_apply_front_ablation_velocity from von Mises stress calving routine")
          ! Convert calvingVelocity to calvingThickness
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
-                                              calvingThickness, calvingVelocity, applyToGrounded, &
+                                              dCalvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, &
                                               calvingCFLdt, dtCalvingCFLratio, &
                                               totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
@@ -2210,7 +2139,7 @@ module li_calving
              do iCell = 1,nCells
                 if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
                      li_mask_is_dynamic_ice(cellMask(iCell)) ) then
-                     calvingThickness(iCell) = thickness(iCell)
+                     dCalvingThickness(iCell) = thickness(iCell)
                 elseif ( li_mask_is_floating_ice(cellMask(icell)) .and. &
                     (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
                     nGroundedNeighbors = 0
@@ -2221,11 +2150,18 @@ module li_calving
                        endif
                     enddo
                     if ( nGroundedNeighbors == 0 ) then
-                       calvingThickness(iCell) = thickness(iCell)
+                       dCalvingThickness(iCell) = thickness(iCell)
                     endif
                 endif
              enddo
           endif
+
+          ! === apply calving velocity before damage threshold calving ===
+          thickness(:) = thickness(:) - dCalvingThickness(:)
+          call update_calving_budget(geometryPool, dCalvingThickness)
+          ! update mask
+          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
+          err = ior(err, err_tmp)
 
           if ( trim(config_damage_calving_method) == 'none' ) then
              ! do nothing
@@ -2234,7 +2170,7 @@ module li_calving
              call mpas_log_write('config_damage_calving_method == threshold; &
                                   removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
             
-             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
              err = ior(err, err_tmp)
           elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
               call mpas_log_write('config_damage_calving_method == calving_rate &
@@ -2247,28 +2183,14 @@ module li_calving
               return
           endif
 
-          ! Update halos on calvingThickness or faceMeltingThickness before
-          ! applying it.
-          ! Testing seemed to indicate this is not necessary, but I don't
-          ! understand
-          ! why not, so leaving it.
-          ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
-          call mpas_timer_start("halo updates")
-          call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
-          call mpas_timer_stop("halo updates")
-
-          ! === apply calving ===
-          thickness(:) = thickness(:) - calvingThickness(:)
-          call update_calving_budget(domain)
+           ! === apply calving velocity before damage threshold calving ===
+          thickness(:) = thickness(:) - dCalvingThickness(:)
+          call update_calving_budget(geometryPool, dCalvingThickness)
           ! update mask
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
 
-<<<<<<< HEAD
-=======
-          call remove_small_islands(meshPool, geometryPool)
-
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
+          deallocate(dCalvingThickness)
           block => block % next
 
       enddo ! associated(block)
@@ -2335,6 +2257,7 @@ module li_calving
                                         calvingVelocity, thickness, &
                                         xvelmean, yvelmean, calvingThickness, &
                                         bedTopography
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, pointer :: nCells, timestepNumber
@@ -2395,6 +2318,9 @@ module li_calving
       
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
+      submergedArea(:) = 0.0_RKIND
+      allocate(dCalvingThickness(nCells+1))
+      dCalvingThickness(:) = 0.0_RKIND
 
       streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error
       stream_cursor => domain % streamManager % streams % head
@@ -2518,7 +2444,7 @@ module li_calving
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
       ! Convert calvingVelocity to calvingThickness
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
-                                              calvingThickness, calvingVelocity, applyToGrounded=.true., &
+                                              dCalvingThickness, calvingVelocity, applyToGrounded=.true., &
                                               applyToFloating=.true., applyToGroundingLine=.false., &
                                               domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
                                               totalAblatedVolume=totalRatebasedCalvedVolume, &
@@ -2533,14 +2459,14 @@ module li_calving
       call mpas_timer_stop("halo updates")
 
       ! === apply calving ===
-      thickness(:) = thickness(:) - calvingThickness(:)
-      call update_calving_budget(domain)
+      thickness(:) = thickness(:) - dCalvingThickness(:)
+      call update_calving_budget(geometryPool, dCalvingThickness)
       ! update mask
       call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
       deallocate(submergedArea)
-
+      deallocate(dCalvingThickness)
    end subroutine ismip6_retreat
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -3473,6 +3399,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
@@ -3536,6 +3463,8 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
          call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
 
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
 
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
@@ -3557,15 +3486,15 @@ module li_calving
                                               err=err_tmp)
              err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
-             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
              err = ior(err, err_tmp)
          else
              call mpas_log_write("Unknown value for config_damage_calving_method was specified!", MPAS_LOG_ERR)
          endif
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - calvingThickness(:)
-         call update_calving_budget(domain)
+         thickness(:) = thickness(:) - dCalvingThickness(:)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -3577,41 +3506,15 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               dCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
-         call update_calving_budget(domain)
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         ! remove abandoned floating ice (i.e. icebergs) and add it to the calving flux
-         ! Defined as: floating ice (dynamic or non-dynamic) that is not adjacent to dynamic ice (floating or grounded)
-         ! This won't necessarily find all abandoned ice, but in practice it does a pretty good job at general cleanup
-         calvingSubtotal = 0.0_RKIND
-         do iCell = 1, nCells
-           if (li_mask_is_floating_ice(cellMask(iCell))) then
-              ! check neighbors for dynamic ice (floating or grounded)
-              dynamicNeighbor = .false.
-              do iNeighbor = 1, nEdgesOnCell(iCell)
-                 jCell = cellsOnCell(iNeighbor, iCell)
-                 if (li_mask_is_dynamic_ice(cellMask(jCell))) dynamicNeighbor = .true.
-              enddo
-              if (.not. dynamicNeighbor) then  ! calve this ice
-                 calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
-                 thickness(iCell) = 0.0_RKIND
-                 calvingSubtotal = calvingSubtotal + calvingThickness(iCell) * areaCell(iCell)
-              endif
-           endif
-         enddo
-         ! TODO: global reduce & reporting on amount of calving generated in this step
-<<<<<<< HEAD
-
-=======
-         call update_calving_budget(domain)
-         call remove_small_islands(meshPool, geometryPool)
->>>>>>> d85d0dc7a7 (Account for multiple updates of calvingThickness within a timestep)
          block => block % next
 
       enddo
@@ -4085,7 +3988,7 @@ module li_calving
 !> value exceeds a specified threshold, assuming the ice is connected to the calving
 !> front.
 !-----------------------------------------------------------------------
-   subroutine apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err)
+   subroutine apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err)
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -4097,12 +4000,11 @@ module li_calving
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain          !< Input/Output: domain object
       type (mpas_pool_type), pointer, intent(inout) :: geometryPool !< Input: geometry pool
-
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-
+      real (kind=RKIND), dimension(:), intent(out) :: dCalvingThickness ! incremental calving thickness
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -4143,6 +4045,8 @@ module li_calving
       growMask => growMaskField % array
       growMask(:) = 0
 
+      dCalvingThickness(:) = 0.0_RKIND
+
       ! define seed and grow masks for flood fill.
       where ( li_mask_is_dynamic_margin(cellMask) .and. (damage .ge. config_damage_calving_threshold) )
               seedMask = 1
@@ -4162,13 +4066,13 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! this is a thin neighbor - remove the whole cell volume
-                  calvingThickness(jCell) = thickness(jCell)
+                  dCalvingThickness(jCell) = thickness(jCell)
                   calvingThicknessFromThreshold(jCell) = calvingThicknessFromThreshold(jCell) + thickness(jCell)
                endif
             enddo
 
-            calvingThickness(iCell) = thickness(iCell)
             calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
+            dCalvingThickness(iCell) = thickness(iCell)
          endif ! if cell is calving margin
 
       enddo ! cell loop
@@ -4223,6 +4127,7 @@ module li_calving
       integer, pointer :: nCells, nCellsSolve
       integer :: iCell
       integer :: localMaskCellCount, globalMaskCellCount
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       integer :: err_tmp
 
       err = 0
@@ -4244,6 +4149,10 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingMask', calvingMask)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(meshPool, 'nCells', nCells)
+
+         allocate(dCalvingThickness(nCells+1))
+         dCalvingThickness(:) = 0.0_RKIND
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
@@ -4255,7 +4164,7 @@ module li_calving
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. (calvingMask(iCell) >= 1)) then
                !call mpas_log_write("Found masked cell at $i", intArgs=(/iCell/))
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               dCalvingThickness(iCell) = thickness(iCell)
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                thickness(iCell) = 0.0_RKIND
                if (iCell <= nCellsSolve) localMaskCellCount = localMaskCellCount + 1
@@ -4265,10 +4174,13 @@ module li_calving
          call mpas_dmpar_sum_int(domain % dminfo, localMaskCellCount, globalMaskCellCount)
          call mpas_log_write("Mask calving applied.  Removed $i floating cells with mask.", intArgs=(/globalMaskCellCount/))
 
+         call update_calving_budget(geometryPool, dCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
+
+         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -4383,6 +4295,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, &    ! thickness of ice that calves (computed in this subroutine)
                                                   groundedCalvingThickness, &
                                                   floatingCalvingThickness
+      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask, &
                                         groundedMaskForMassBudget, &
@@ -4423,6 +4336,9 @@ module li_calving
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       
+      allocate(dCalvingThickness(nCells+1))
+      dCalvingThickness(:) = 0.0_RKIND
+
       seedMask(:) = 0
       growMask(:) = 0
 
@@ -4496,19 +4412,15 @@ module li_calving
          localIcebergCellCount = 0
          do iCell = 1, nCellsSolve
             if (seedMask(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
-               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)  ! remove any remaining ice here
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)  ! remove any remaining ice here
+               dCalvingThickness(iCell) = thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
-               if (groundedMaskForMassBudget(iCell) .eq. 1) then
-                  groundedCalvingThickness(iCell) = groundedCalvingThickness(iCell) + thickness(iCell)
-               elseif (floatingMaskForMassBudget(iCell) .eq. 1) then
-                  floatingCalvingThickness(iCell) = floatingCalvingThickness(iCell) + thickness(iCell)
-               endif
                localIcebergCellCount = localIcebergCellCount + 1
                !seedMaskOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
             endif
          enddo
 
+         call update_calving_budget(geometryPool, dCalvingThickness)
          block => block % next
       end do
 
@@ -4526,7 +4438,10 @@ module li_calving
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.false.)
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
       call mpas_timer_stop("iceberg detection")
-   end subroutine li_remove_icebergs
+
+      deallocate(dCalvingThickness)
+   end subroutine remove_icebergs
+>>>>>>> a5bee82292 (Update calving budget incrementally)
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -4692,23 +4607,22 @@ module li_calving
 !> is applied, but before masks are updated which often happens multiple times
 !> in a timestep.
 !-----------------------------------------------------------------------
-   subroutine update_calving_budget(domain)
+   subroutine update_calving_budget(geometryPool, dCalvingThickness)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
-      type (domain_type), intent(inout) :: domain
+      type (mpas_pool_type), pointer, intent(inout) :: geometryPool
+      real (kind=RKIND), dimension(:), intent(inout) :: dCalvingThickness
 
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer :: meshPool, geometryPool
       integer, dimension(:), pointer :: groundedMaskForMassBudget, & ! binary masks for mass budget
                                         floatingMaskForMassBudget
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness, &
                                                    groundedCalvingThickness, & ! Grounded and floating components for mass budget
                                                    floatingCalvingThickness
 
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
       call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
       call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
@@ -4716,10 +4630,13 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
 
       where (groundedMaskForMassBudget .eq. 1)
-          groundedCalvingThickness = calvingThickness
+          groundedCalvingThickness = dCalvingThickness
       elsewhere (floatingMaskForMassBudget .eq. 1)
-          floatingCalvingThickness = calvingThickness
-      end where      
+          floatingCalvingThickness = dCalvingThickness
+      end where
+
+      calvingThickness(:) = calvingThickness(:) + dCalvingThickness(:)
+      dCalvingThickness(:) = 0.0_RKIND
 
    end subroutine update_calving_budget
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4630,9 +4630,9 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
 
       where (groundedMaskForMassBudget .eq. 1)
-          groundedCalvingThickness = dCalvingThickness
+          groundedCalvingThickness = groundedCalvingThickness + dCalvingThickness
       elsewhere (floatingMaskForMassBudget .eq. 1)
-          floatingCalvingThickness = dCalvingThickness
+          floatingCalvingThickness = floatingCalvingThickness + dCalvingThickness
       end where
 
       calvingThickness(:) = calvingThickness(:) + dCalvingThickness(:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -129,9 +129,13 @@ module li_calving
            bedTopography       ! bed topography (negative below sea level)
 
       real (kind=RKIND), dimension(:), pointer :: &
-           calvingThickness    ! thickness of ice that calves (computed in this subroutine)
-                               ! typically the entire ice thickness, but will be a fraction of the thickness
-                               ! if calving_timescale > dt
+           calvingThickness, &    ! thickness of ice that calves (computed in this subroutine)
+                                  ! typically the entire ice thickness, but will be a fraction of the thickness
+                                  ! if calving_timescale > dt
+           groundedCalvingThickness, & ! Grounded and floating components for mass budget
+           floatingCalvingThickness
+      integer, dimension(:), pointer :: groundedMaskForMassBudget, & ! binary masks for mass budget
+                                        floatingMaskForMassBudget
 
       real (kind=RKIND), dimension(:), pointer :: &
            calvingThicknessFromThreshold   ! thickness of ice that calves from threshold processes (computed in this subroutine)
@@ -339,6 +343,8 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
+         call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
          ! In data calving mode we just calculate what should be calved but don't actually calve it.
@@ -368,6 +374,20 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
          call li_update_geometry(geometryPool)
+         ! necessary to get these after masks have been updated
+         call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
+
+         groundedCalvingThickness(:) = 0.0_RKIND
+         floatingCalvingThickness(:) = 0.0_RKIND
+         where (groundedMaskForMassBudget .eq. 1)
+             groundedCalvingThickness = calvingThickness
+         elsewhere (floatingMaskForMassBudget .eq. 1)
+             floatingCalvingThickness = calvingThickness
+         elsewhere
+             groundedCalvingThickness = 0.0_RKIND
+             floatingCalvingThickness = 0.0_RKIND
+         end where
 
          block => block % next
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -493,8 +493,8 @@ module li_calving
                                ! > 0 for cells below sea level that were initially ice-free and now have ice
            restoreThickness    ! thickness of ice that is added to restore the calving front to its initial position
                                ! > 0 for cells below sea level that were initially ice-covered and now have very thin or no ice
-      real (kind=RKIND), dimension(:), allocatable:: &
-           dCalvingThickness ! incremental calving thickness
+      real (kind=RKIND), dimension(:), pointer :: &
+           incrementalCalvingThickness ! incremental calving thickness
 
       real (kind=RKIND) ::  &
            restoreThicknessMin  ! small thickness to which ice is restored should it fall below this thickness
@@ -548,6 +548,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'restoreThickness', restoreThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
@@ -640,8 +641,7 @@ module li_calving
          endif ! if preventing retreat
 
          ! Now check for marine regions that have advanced
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
 
          ! loop over locally owned cells
          do iCell = 1, nCells
@@ -656,7 +656,7 @@ module li_calving
                      call mpas_log_write('Remove ice:  indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
                   endif
 
-                  dCalvingThickness(iCell) = thickness(iCell)
+                  incrementalCalvingThickness(iCell) = thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
                   ! Assign flow speed to calving speed - this allows calculation of licalvf in ISMIP6 postprocessing
                   calvingVelocity(iCell) = surfaceSpeed(iCell)
@@ -664,9 +664,8 @@ module li_calving
             endif    ! bedTopography < config_sea_level
          enddo   ! iCell
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
 
-         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -709,7 +708,7 @@ module li_calving
       if (err > 0) then
           call mpas_log_write("An error has occurred in li_restore_calving_front.", MPAS_LOG_ERR)
       endif
-
+      call mpas_log_write("finished with li_restore_calving_front")
 
     end subroutine li_restore_calving_front
 
@@ -810,8 +809,8 @@ module li_calving
 
       real (kind=RKIND), dimension(:), pointer :: &
            calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
-      real (kind=RKIND), dimension(:), allocatable :: &
-           dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: &
+           incrementalCalvingThickness
 
       integer, pointer :: nCells
       integer :: iCell, iCellOnCell, iCellNeighbor
@@ -879,8 +878,7 @@ module li_calving
 
          ! Initialize
          calvingThickness = 0.0_RKIND
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
          ! Identify cells that are active-for-calving:
          ! (1) Grounded ice with thickness > config_dynamic_thickness
          ! (2) Floating ice with thickness > config_calving_thickness
@@ -970,14 +968,15 @@ module li_calving
          ! Calve ice in ocean cells that are not on the protected inactive margin
 
          where (oceanMask == 1 .and. inactiveMarginMask == 0 .and. thickness > 0.0_RKIND)
-            dCalvingThickness = thickness * calvingFraction
+            incrementalCalvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
+
          block => block % next
       enddo
 
@@ -985,7 +984,6 @@ module li_calving
       call mpas_deallocate_scratch_field(activeForCalvingMaskField, .true.)
       call mpas_deallocate_scratch_field(inactiveMarginMaskField, .true.)
       call mpas_deallocate_scratch_field(oceanMaskField, .true.)
-      deallocate(dCalvingThickness)
 
    end subroutine thickness_calving
 
@@ -1025,7 +1023,7 @@ module li_calving
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: floatingMaskForMassBudget
@@ -1047,21 +1045,19 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
          call mpas_pool_get_array(meshPool, 'nCells', nCells)
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
          ! Note: The floating_ice mask does not include floating
          ! non-dynamic cells adjacent to grounded cells.
          where ( floatingMaskForMassBudget .eq. 1 )
-            dCalvingThickness = thickness * calvingFraction
+            incrementalCalvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
 
-         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -1092,7 +1088,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, &   ! thickness of ice that calves (computed in this subroutine)
                                                   groundedCalvingThickness, &
                                                   floatingCalvingThickness
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: cellMask, &
@@ -1125,6 +1121,7 @@ module li_calving
       call mpas_pool_get_dimension(meshPool, 'maxEdges', maxEdges)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
       call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
       call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
@@ -1135,7 +1132,7 @@ module li_calving
 
       allocate(connectedCellsList((maxEdges+1)**2), &
                islandMask(nCells+1))
-      dCalvingThickness(:) = 0.0_RKIND
+      incrementalCalvingThickness(:) = 0.0_RKIND
       islandMask(:) = 0
       nIslandCellsLocal = 0
       nIslandCellsGlobal = 0
@@ -1291,7 +1288,7 @@ module li_calving
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. seedMask(iCell) == 0) then
                   calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
-                  dCalvingThickness(iCell) = thickness(iCell)
+                  incrementalCalvingThickness(iCell) = thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
             endif
          enddo
@@ -1302,9 +1299,8 @@ module li_calving
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
 
-      call update_calving_budget(geometryPool, dCalvingThickness)
+      call update_calving_budget(geometryPool, incrementalCalvingThickness)
       
-      deallocate(dCalvingThickness)
    end subroutine remove_small_islands
 
 
@@ -1342,7 +1338,7 @@ module li_calving
       type (mpas_pool_type), pointer :: geometryPool, meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real(kind=RKIND), pointer :: config_calving_topography
       real(kind=RKIND), pointer :: config_sea_level
       logical, pointer :: config_print_calving_info
@@ -1368,26 +1364,24 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(meshPool, 'nCells', nCells)
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
 
          where ( (li_mask_is_floating_ice(cellMask)) .and. (bedTopography < config_calving_topography + config_sea_level) )
-            dCalvingThickness = thickness * calvingFraction
+            incrementalCalvingThickness = thickness * calvingFraction
          endwhere
-         calvingThicknessFromThreshold = calvingThickness
+         calvingThicknessFromThreshold = incrementalCalvingThickness
 
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
-
-         deallocate(dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
 
          block => block % next
       enddo
@@ -1446,7 +1440,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1504,6 +1498,7 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'eMin', eMin)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
          call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
@@ -1528,8 +1523,7 @@ module li_calving
                     realArgs=(/minval(eigencalvingParameter), maxval(eigencalvingParameter)/))
          endif
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
          calvingVelocity(:) = 0.0_RKIND
          ! First calculate the front retreat rate (Levermann eq. 1)
          calvingVelocity(:) = eigencalvingParameter(:) * max(0.0_RKIND, eMax(:)) * max(0.0_RKIND, eMin(:)) ! m/s
@@ -1537,7 +1531,7 @@ module li_calving
          call mpas_log_write("calling li_apply_front_ablation_velocity from eigencalving")
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
-                                              dCalvingThickness, calvingVelocity, applyToGrounded, &
+                                              incrementalCalvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, calvingCFLdt, dtCalvingCFLratio, &
                                               totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
          err = ior(err, err_tmp)
@@ -1549,7 +1543,7 @@ module li_calving
             call mpas_log_write('config_damage_calving_method == threshold; &
                                  removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
 
-            call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
+            call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, incrementalCalvingThickness, err_tmp)
             err = ior(err, err_tmp)
          elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
              call mpas_log_write('config_damage_calving_method == calving_rate &
@@ -1568,11 +1562,11 @@ module li_calving
          ! why not, so leaving it.
          ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
          call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+         call mpas_dmpar_field_halo_exch(domain, 'incrementalCalvingThickness')
          call mpas_timer_stop("halo updates")
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
@@ -1592,12 +1586,12 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               dCalvingThickness(iCell) = thickness(iCell)
+               incrementalCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1605,7 +1599,6 @@ module li_calving
          call update_calving_budget(domain)
          call remove_icebergs(domain)
 
-         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -1657,7 +1650,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: angleEdge
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness ! Incremental calving thickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -1703,6 +1696,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingVelocityData', calvingVelocityData)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
          call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
@@ -1711,8 +1705,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
 
          ! get parameter value
          if (trim(config_calving_specified_source) == 'const') then
@@ -1731,17 +1724,19 @@ module li_calving
          endif
 
          ! Convert calvingVelocity to calvingThickness
-         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, dCalvingThickness, calvingVelocity, &
+         call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, incrementalCalvingThickness, calvingVelocity, &
                                               applyToGrounded=.true., applyToFloating=.true., applyToGroundingLine=.false., &
                                               domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
                                               totalAblatedVolume=totalRatebasedCalvedVolume, &
                                               totalUnablatedVolume=totalRatebasedUncalvedVolume, &
                                               err=err_tmp)
          err = ior(err, err_tmp)
-
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'incrementalCalvingThickness')
+         call mpas_timer_stop("halo updates")
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -1760,19 +1755,18 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               dCalvingThickness(iCell) = thickness(iCell)
+               incrementalCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          block => block % next
 
-         deallocate(dCalvingThickness)
       enddo
 
    end subroutine specified_calving_velocity
@@ -1833,7 +1827,7 @@ module li_calving
                                         floatingVonMisesThresholdStress, &
                                         groundedVonMisesThresholdStress, &
                                         surfaceSpeed
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA, &
                                         temperature, layerThickness
       real (kind=RKIND), pointer :: config_default_flowParamA
@@ -1898,6 +1892,7 @@ module li_calving
           call mpas_pool_get_array(velocityPool, 'yvelmean', yvelmean)
           call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
           call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+          call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
           call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
           call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
           call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
@@ -1946,8 +1941,7 @@ module li_calving
           endif
 
           vonMisesStress(:) = 0.0_RKIND
-          allocate(dCalvingThickness(nCells+1))
-          dCalvingThickness(:) = 0.0_RKIND
+          incrementalCalvingThickness(:) = 0.0_RKIND
 
           ! get flowParamA from MPAS or use Albany-like equation
           if ( config_use_Albany_flowA_eqn_for_vM ) then
@@ -2084,7 +2078,7 @@ module li_calving
           call mpas_log_write("calling li_apply_front_ablation_velocity from von Mises stress calving routine")
          ! Convert calvingVelocity to calvingThickness
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
-                                              dCalvingThickness, calvingVelocity, applyToGrounded, &
+                                              incrementalCalvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, &
                                               calvingCFLdt, dtCalvingCFLratio, &
                                               totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
@@ -2096,7 +2090,7 @@ module li_calving
          ! why not, so leaving it.
          ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
          call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+         call mpas_dmpar_field_halo_exch(domain, 'incrementalCalvingThickness')
          call mpas_timer_stop("halo updates")
 
           ! If floating VM threshold is zero, remove floating ice. Remove
@@ -2108,7 +2102,7 @@ module li_calving
              do iCell = 1,nCells
                 if ( li_mask_is_floating_ice(cellMask(iCell)) .and. &
                      li_mask_is_dynamic_ice(cellMask(iCell)) ) then
-                     dCalvingThickness(iCell) = thickness(iCell)
+                     incrementalCalvingThickness(iCell) = thickness(iCell)
                 elseif ( li_mask_is_floating_ice(cellMask(icell)) .and. &
                     (.not. li_mask_is_dynamic_ice(cellMask(iCell))) ) then
                     nGroundedNeighbors = 0
@@ -2119,15 +2113,15 @@ module li_calving
                        endif
                     enddo
                     if ( nGroundedNeighbors == 0 ) then
-                       dCalvingThickness(iCell) = thickness(iCell)
+                       incrementalCalvingThickness(iCell) = thickness(iCell)
                     endif
                 endif
              enddo
           endif
 
           ! === apply calving velocity before damage threshold calving ===
-          thickness(:) = thickness(:) - dCalvingThickness(:)
-          call update_calving_budget(geometryPool, dCalvingThickness)
+          thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+          call update_calving_budget(geometryPool, incrementalCalvingThickness)
           ! update mask
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
@@ -2139,7 +2133,7 @@ module li_calving
              call mpas_log_write('config_damage_calving_method == threshold; &
                                   removing ice with damage > $r', realArgs=(/config_damage_calving_threshold/))
             
-             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, incrementalCalvingThickness, err_tmp)
              err = ior(err, err_tmp)
           elseif ( trim(config_damage_calving_method) == 'calving_rate' ) then
               call mpas_log_write('config_damage_calving_method == calving_rate &
@@ -2153,15 +2147,14 @@ module li_calving
           endif
 
            ! === apply calving velocity before damage threshold calving ===
-          thickness(:) = thickness(:) - dCalvingThickness(:)
-          call update_calving_budget(geometryPool, dCalvingThickness)
+          thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+          call update_calving_budget(geometryPool, incrementalCalvingThickness)
           ! update mask
           call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
           err = ior(err, err_tmp)
 
           call remove_icebergs(domain)
 
-          deallocate(dCalvingThickness)
           block => block % next
 
       enddo ! associated(block)
@@ -2228,7 +2221,7 @@ module li_calving
                                         calvingVelocity, thickness, &
                                         xvelmean, yvelmean, calvingThickness, &
                                         bedTopography
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
       integer, pointer :: nCells, timestepNumber
@@ -2272,6 +2265,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
       call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
       call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
@@ -2290,8 +2284,7 @@ module li_calving
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
       submergedArea(:) = 0.0_RKIND
-      allocate(dCalvingThickness(nCells+1))
-      dCalvingThickness(:) = 0.0_RKIND
+      incrementalCalvingThickness(:) = 0.0_RKIND
 
       streamFound = .false. ! Changed to true if ismip6-gis stream is found, otherwise throws error
       stream_cursor => domain % streamManager % streams % head
@@ -2415,7 +2408,7 @@ module li_calving
       call mpas_log_write("calling li_apply_front_ablation_velocity from ismip6 retreat routine")
       ! Convert calvingVelocity to calvingThickness
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
-                                              dCalvingThickness, calvingVelocity, applyToGrounded=.true., &
+                                              incrementalCalvingThickness, calvingVelocity, applyToGrounded=.true., &
                                               applyToFloating=.true., applyToGroundingLine=.false., &
                                               domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
                                               totalAblatedVolume=totalRatebasedCalvedVolume, &
@@ -2426,18 +2419,17 @@ module li_calving
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
       call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'calvingThickness')
+      call mpas_dmpar_field_halo_exch(domain, 'incrementalCalvingThickness')
       call mpas_timer_stop("halo updates")
 
       ! === apply calving ===
-      thickness(:) = thickness(:) - dCalvingThickness(:)
-      call update_calving_budget(geometryPool, dCalvingThickness)
+      thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+      call update_calving_budget(geometryPool, incrementalCalvingThickness)
       ! update mask
       call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
       deallocate(submergedArea)
-      deallocate(dCalvingThickness)
    end subroutine ismip6_retreat
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -3370,7 +3362,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), pointer :: calvingCFLdt
       real (kind=RKIND), pointer :: dtCalvingCFLratio
@@ -3423,6 +3415,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -3434,8 +3427,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
          call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
 
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
 
@@ -3457,15 +3449,18 @@ module li_calving
                                               err=err_tmp)
              err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
-             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err_tmp)
+             call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, incrementalCalvingThickness, err_tmp)
              err = ior(err, err_tmp)
          else
              call mpas_log_write("Unknown value for config_damage_calving_method was specified!", MPAS_LOG_ERR)
          endif
 
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'incrementalCalvingThickness')
+         call mpas_timer_stop("halo updates")
          ! === apply calving ===
-         thickness(:) = thickness(:) - dCalvingThickness(:)
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         thickness(:) = thickness(:) - incrementalCalvingThickness(:)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
@@ -3477,18 +3472,16 @@ module li_calving
          ! Tests of the current implementation show reasonable behavior.
          do iCell = 1, nCells
             if (calvingFrontMask(iCell) == 1 .and. thickness(iCell) < config_calving_thickness) then
-               dCalvingThickness(iCell) = thickness(iCell)
+               incrementalCalvingThickness(iCell) = thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             endif
          enddo
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          call remove_icebergs(domain)
-
-         deallocate(dCalvingThickness)
 
          block => block % next
 
@@ -3963,7 +3956,7 @@ module li_calving
 !> value exceeds a specified threshold, assuming the ice is connected to the calving
 !> front.
 !-----------------------------------------------------------------------
-   subroutine apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, dCalvingThickness, err)
+   subroutine apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, incrementalCalvingThickness, err)
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -3979,7 +3972,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-      real (kind=RKIND), dimension(:), intent(out) :: dCalvingThickness ! incremental calving thickness
+      real (kind=RKIND), dimension(:), intent(out) :: incrementalCalvingThickness ! incremental calving thickness
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -4020,7 +4013,7 @@ module li_calving
       growMask => growMaskField % array
       growMask(:) = 0
 
-      dCalvingThickness(:) = 0.0_RKIND
+      incrementalCalvingThickness(:) = 0.0_RKIND
 
       ! define seed and grow masks for flood fill.
       where ( li_mask_is_dynamic_margin(cellMask) .and. (damage .ge. config_damage_calving_threshold) )
@@ -4041,13 +4034,13 @@ module li_calving
                jCell = cellsOnCell(iNeighbor, iCell)
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! this is a thin neighbor - remove the whole cell volume
-                  dCalvingThickness(jCell) = thickness(jCell)
+                  incrementalCalvingThickness(jCell) = thickness(jCell)
                   calvingThicknessFromThreshold(jCell) = calvingThicknessFromThreshold(jCell) + thickness(jCell)
                endif
             enddo
 
             calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
-            dCalvingThickness(iCell) = thickness(iCell)
+            incrementalCalvingThickness(iCell) = thickness(iCell)
          endif ! if cell is calving margin
 
       enddo ! cell loop
@@ -4102,7 +4095,7 @@ module li_calving
       integer, pointer :: nCells, nCellsSolve
       integer :: iCell
       integer :: localMaskCellCount, globalMaskCellCount
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       integer :: err_tmp
 
       err = 0
@@ -4120,14 +4113,14 @@ module li_calving
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'calvingMask', calvingMask)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(meshPool, 'nCells', nCells)
 
-         allocate(dCalvingThickness(nCells+1))
-         dCalvingThickness(:) = 0.0_RKIND
+         incrementalCalvingThickness(:) = 0.0_RKIND
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
@@ -4139,7 +4132,7 @@ module li_calving
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. (calvingMask(iCell) >= 1)) then
                !call mpas_log_write("Found masked cell at $i", intArgs=(/iCell/))
-               dCalvingThickness(iCell) = thickness(iCell)
+               incrementalCalvingThickness(iCell) = thickness(iCell)
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                thickness(iCell) = 0.0_RKIND
                if (iCell <= nCellsSolve) localMaskCellCount = localMaskCellCount + 1
@@ -4149,12 +4142,11 @@ module li_calving
          call mpas_dmpar_sum_int(domain % dminfo, localMaskCellCount, globalMaskCellCount)
          call mpas_log_write("Mask calving applied.  Removed $i floating cells with mask.", intArgs=(/globalMaskCellCount/))
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
-         deallocate(dCalvingThickness)
          block => block % next
       enddo
 
@@ -4269,7 +4261,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThickness, &    ! thickness of ice that calves (computed in this subroutine)
                                                   groundedCalvingThickness, &
                                                   floatingCalvingThickness
-      real (kind=RKIND), dimension(:), allocatable :: dCalvingThickness
+      real (kind=RKIND), dimension(:), pointer :: incrementalCalvingThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask, &
                                         groundedMaskForMassBudget, &
@@ -4310,9 +4302,6 @@ module li_calving
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       
-      allocate(dCalvingThickness(nCells+1))
-      dCalvingThickness(:) = 0.0_RKIND
-
       seedMask(:) = 0
       growMask(:) = 0
 
@@ -4373,6 +4362,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'incrementalCalvingThickness', incrementalCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'groundedCalvingThickness', groundedCalvingThickness)
          call mpas_pool_get_array(geometryPool, 'floatingCalvingThickness', floatingCalvingThickness)
@@ -4387,14 +4377,14 @@ module li_calving
          do iCell = 1, nCellsSolve
             if (seedMask(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)  ! remove any remaining ice here
-               dCalvingThickness(iCell) = thickness(iCell)  ! remove any remaining ice here
+               incrementalCalvingThickness(iCell) = thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
                localIcebergCellCount = localIcebergCellCount + 1
                !seedMaskOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
             endif
          enddo
 
-         call update_calving_budget(geometryPool, dCalvingThickness)
+         call update_calving_budget(geometryPool, incrementalCalvingThickness)
          block => block % next
       end do
 
@@ -4413,7 +4403,6 @@ module li_calving
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
       call mpas_timer_stop("iceberg detection")
 
-      deallocate(dCalvingThickness)
    end subroutine remove_icebergs
 >>>>>>> a5bee82292 (Update calving budget incrementally)
 
@@ -4581,12 +4570,12 @@ module li_calving
 !> is applied, but before masks are updated which often happens multiple times
 !> in a timestep.
 !-----------------------------------------------------------------------
-   subroutine update_calving_budget(geometryPool, dCalvingThickness)
+   subroutine update_calving_budget(geometryPool, incrementalCalvingThickness)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer, intent(inout) :: geometryPool
-      real (kind=RKIND), dimension(:), intent(inout) :: dCalvingThickness
+      real (kind=RKIND), dimension(:), intent(inout) :: incrementalCalvingThickness
 
       !-----------------------------------------------------------------
       ! local variables
@@ -4604,13 +4593,13 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
 
       where (groundedMaskForMassBudget .eq. 1)
-          groundedCalvingThickness = groundedCalvingThickness + dCalvingThickness
+          groundedCalvingThickness = groundedCalvingThickness + incrementalCalvingThickness
       elsewhere (floatingMaskForMassBudget .eq. 1)
-          floatingCalvingThickness = floatingCalvingThickness + dCalvingThickness
+          floatingCalvingThickness = floatingCalvingThickness + incrementalCalvingThickness
       end where
 
-      calvingThickness(:) = calvingThickness(:) + dCalvingThickness(:)
-      dCalvingThickness(:) = 0.0_RKIND
+      calvingThickness(:) = calvingThickness(:) + incrementalCalvingThickness(:)
+      incrementalCalvingThickness(:) = 0.0_RKIND
 
    end subroutine update_calving_budget
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1043,6 +1043,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: floatingMaskForMassBudget
 
       err = 0
 
@@ -1057,11 +1058,13 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
 
          calvingThickness = 0.0_RKIND
 
-         ! Note: The floating_ice mask includes all floating ice, both inactive and active
-         where (li_mask_is_floating_ice(cellMask))
+         ! Note: The floating_ice mask does not include floating
+         ! non-dynamic cells adjacent to grounded cells.
+         where ( floatingMaskForMassBudget .eq. 1 )
             calvingThickness = thickness * calvingFraction
          endwhere
          calvingThicknessFromThreshold = calvingThickness

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -663,7 +663,7 @@ module li_calving
          endif ! if preventing retreat
 
          ! Now check for marine regions that have advanced
-         allocate(dCalvingThickness(nCellsSolve+1))
+         allocate(dCalvingThickness(nCells+1))
 
          ! loop over locally owned cells
          do iCell = 1, nCells

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -803,7 +803,7 @@ module li_core
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -300,7 +300,7 @@ module li_core
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
          call li_update_geometry(geometryPool)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -106,8 +106,12 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: &
               faceMeltSpeed, &
               faceMeltingThickness, &
+              groundedFaceMeltingThickness, &
+              floatingFaceMeltingThickness, &
               thickness
-      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: cellMask, &
+                                        groundedMaskForMassBudget, &
+                                        floatingMaskForMassBudget
       integer :: err_tmp
       logical :: applyToFloating, applyToGrounded, applyToGroundingLine
 
@@ -141,6 +145,10 @@ module li_iceshelf_melt
             call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
             call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
             call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
+            call mpas_pool_get_array(geometryPool, 'groundedFaceMeltingThickness', groundedFaceMeltingThickness)
+            call mpas_pool_get_array(geometryPool, 'floatingFaceMeltingThickness', floatingFaceMeltingThickness)
+            call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+            call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
             call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
             ! Update halos on calvingThickness or faceMeltingThickness before applying it.
@@ -153,6 +161,16 @@ module li_iceshelf_melt
 
             ! Apply facemelt: open the Ark
             thickness(:) = thickness(:) - faceMeltingThickness(:)
+            where (groundedMaskForMassBudget .eq. 1)
+                  groundedFaceMeltingThickness = faceMeltingThickness
+                  floatingFaceMeltingThickness = 0.0_RKIND
+            elsewhere (floatingMaskForMassBudget .eq. 1)
+                  groundedFaceMeltingThickness = 0.0_RKIND
+                  floatingFaceMeltingThickness = faceMeltingThickness
+            elsewhere
+                  groundedFaceMeltingThickness = 0.0_RKIND
+                  floatingFaceMeltingThickness = 0.0_RKIND
+            end where
 
             ! update mask
             call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
@@ -170,9 +188,13 @@ module li_iceshelf_melt
             call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
             call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
             call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
+            call mpas_pool_get_array(geometryPool, 'groundedFaceMeltingThickness', groundedFaceMeltingThickness)
+            call mpas_pool_get_array(geometryPool, 'floatingFaceMeltingThickness', floatingFaceMeltingThickness)
 
             faceMeltSpeed(:) = 0.0_RKIND
             faceMeltingThickness(:) = 0.0_RKIND
+            groundedFaceMeltingThickness(:) = 0.0_RKIND
+            floatingfaceMeltingThickness(:) = 0.0_RKIND
 
             block => block % next
          enddo   ! associated(block)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -155,7 +155,7 @@ module li_iceshelf_melt
             thickness(:) = thickness(:) - faceMeltingThickness(:)
 
             ! update mask
-            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+            call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
             err = ior(err, err_tmp)
 
             block => block % next
@@ -390,7 +390,7 @@ module li_iceshelf_melt
             thermalCellMask => thermalCellMaskField % array
 
             ! calculate masks - so we know where the ice is floating
-            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+            call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
             err = ior(err, err_tmp)
 
             ! calculate a mask to identify ice that is thick enough to be thermally active

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -172,7 +172,7 @@ module li_subglacial_hydro
          endif
 
          ! Mask needs to be initialized for pressure calcs to be correct
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          call calc_hydro_mask(domain)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -858,7 +858,7 @@ module li_thermal
          endif
 
          ! calculate masks - so we know where the ice is floating
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          err = ior(err, err_tmp)
 
          ! calculate a mask to identify ice that is thick enough to be thermally active

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -697,6 +697,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
       real (kind=RKIND), pointer :: calvingCFLdt, faceMeltingCFLdt
       integer, pointer :: processLimitingTimestep, config_rk_order, config_rk3_stages
+      real (kind=RKIND), dimension(:), pointer :: groundedToFloatingThickness
       integer, dimension(:), pointer :: edgeMask
 
       logical, pointer :: config_print_thickness_advection_info
@@ -790,8 +791,13 @@ module li_time_integration_fe_rk
 
          call mpas_pool_get_array(velocityPool, 'normalVelocity', normalVelocity)
          call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+         call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
          call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
 
+         ! groundedToFloatingThickness is updated throughout
+         ! the timestep, so necessary to zero it at
+         ! the beginning of every timestep.
+         groundedToFloatingThickness(:) = 0.0_RKIND
          ! compute normal velocities and advective CFL limit for this block
 
          call li_layer_normal_velocity( &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -244,18 +244,11 @@ module li_time_integration_fe_rk
       err = ior(err, err_tmp)
       call mpas_timer_stop("advancing clock")
 
-!TODO: Determine whether grounded melting should in fact be called first
 ! === Ocean forcing extrapolation into ice-shelf cavities ===========
       call mpas_timer_start("ocean forcing extrapolation")
       call li_ocean_extrap_solve(domain, err_tmp)
       err = ior(err, err_tmp)
       call mpas_timer_stop("ocean forcing extrapolation")
-
-! === Face melting for grounded ice ===========
-      call mpas_timer_start("face melting for grounded ice")
-      call li_face_melt_grounded_ice(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("face melting for grounded ice")
 
 ! === Basal melting for floating ice ===========
       call mpas_timer_start("basal melting for floating ice")
@@ -593,6 +586,12 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
       call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
+
+! === Face melting for grounded ice ===========
+      call mpas_timer_start("face melting for grounded ice")
+      call li_face_melt_grounded_ice(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("face melting for grounded ice")
 
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -514,7 +514,7 @@ module li_time_integration_fe_rk
 
 ! Finalize budget updates
       ! Update masks after RK integration
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
@@ -525,10 +525,6 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
       call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
-
-      ! Calculate volume converted from grounded to floating
-      ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
-      call li_grounded_to_floating(cellMaskPrev, cellMask, thickness, groundedToFloatingThickness, nCells)
 
       sfcMassBalApplied(:) = sfcMassBalAccum(:)
       groundedSfcMassBalApplied(:) = groundedSfcMassBalAccum(:)
@@ -1166,7 +1162,6 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
-                 domain,                 &
                  err_tmp,                &
                  advectTracersIn = .true.)
 
@@ -1186,7 +1181,6 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
-                 domain,                 &
                  err_tmp,                &
                  advectTracersIn = .false.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -1161,6 +1161,7 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 domain,                 &
                  err_tmp,                &
                  advectTracersIn = .true.)
 
@@ -1180,6 +1181,7 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 domain,                 &
                  err_tmp,                &
                  advectTracersIn = .false.)
 
@@ -1259,7 +1261,7 @@ module li_time_integration_fe_rk
             call li_calculate_layerThickness(meshPool, thickness, layerThickness)
          endif
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -87,7 +87,7 @@ module li_time_integration_fe_rk
       use li_velocity
       use li_bedtopo
       use li_mask
-      use li_advection, only: li_grounded_to_floating
+      use li_advection
       use li_ocean_extrap
 
       !-----------------------------------------------------------------
@@ -366,7 +366,7 @@ module li_time_integration_fe_rk
 
       ! Calculate masks prior to RK loop, but do not update masks within the loop
       ! to preserve the accuracy of time integration.
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
       err = ior(err, err_tmp)
 
 ! *** Start RK loop ***

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -333,7 +333,7 @@ contains
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -875,7 +875,7 @@ subroutine li_velocity_external_write_albany_mesh(domain)
       ! We could call diagnostic_solve_before_velocity to do all that, but the way
       ! code is currently organized, that would be a circular dependency.a
 
-      call li_calculate_mask(meshPool, velocityPool, geometryPool, err)
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err)
 
       ! Lower surface is based on floatation for floating ice.  For grounded ice (and non-ice areas) it is the bed.
       where ( li_mask_is_floating_ice(cellMask) )

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -376,6 +376,8 @@ contains
       ! For now floating ice and grounded ice are mutually exclusive.
       ! This may change if a grounding line parameterization is added.
       ! Initialize grounded and floating masks for mass budget as well.
+      floatingMaskForMassBudget(:) = 0
+      groundedMaskForMassBudget(:) = 0
       where (  li_mask_is_ice(cellMask) .and. (config_ice_density / config_ocean_density * thickness) <= &
                (config_sea_level - bedTopography) )
           cellMask = ior(cellMask, li_mask_ValueFloating)

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -297,7 +297,7 @@ contains
       !-----------------------------------------------------------------
       integer, pointer :: nCells, nVertices, nEdges, vertexDegree
       integer, pointer :: nVertInterfaces
-      real(KIND=RKIND), dimension(:), pointer :: thickness, bedTopography
+      real(KIND=RKIND), dimension(:), pointer :: thickness, bedTopography, groundedToFloatingThickness
       integer, dimension(:), pointer :: nEdgesOnCell, cellMask, vertexMask, edgeMask, &
                                         groundedMaskForMassBudget, floatingMaskForMassBudget
       integer, dimension(:,:), pointer :: cellsOnCell, cellsOnVertex, cellsOnEdge, dirichletVelocityMask
@@ -322,6 +322,9 @@ contains
       integer :: iCellNeighbor
       logical :: openOceanNeighbor
       logical :: updateMassBudgetMasks=.true.
+      type (field1DInteger), pointer :: & ! used to calculate groundedToFloatingThickness
+           groundedMaskForMassBudgetTemporaryField, & ! scratch field containing old values of groundedMaskForMassBudget
+           floatingMaskForMassBudgetTemporaryField    ! scratch field containing old values of floatingMaskForMassBudget
 
       call mpas_timer_start('calculate mask')
 
@@ -344,8 +347,14 @@ contains
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel=1)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
       call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
       call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
+
+      call mpas_pool_get_field(geometryPool, 'groundedMaskForMassBudgetTemporary', groundedMaskForMassBudgetTemporaryField)
+      call mpas_pool_get_field(geometryPool, 'floatingMaskForMassBudgetTemporary', floatingMaskForMassBudgetTemporaryField)
+      call mpas_allocate_scratch_field(groundedMaskForMassBudgetTemporaryField, .true.)
+      call mpas_allocate_scratch_field(floatingMaskForMassBudgetTemporaryField, .true.)
 
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -372,6 +381,11 @@ contains
           cellMask = ior(cellMask, li_mask_ValueIce)
       end where
 
+
+      ! save old mass budget masks for determining cells changing from grounded
+      ! to floating and vice versa
+      groundedMaskForMassBudgetTemporaryField % array(:) = groundedMaskForMassBudget(:)
+      floatingMaskForMassBudgetTemporaryField % array(:) = floatingMaskForMassBudget(:)
       ! Is it floating? (ice thickness equal to floatation is considered floating)
       ! For now floating ice and grounded ice are mutually exclusive.
       ! This may change if a grounding line parameterization is added.
@@ -540,6 +554,18 @@ contains
              endif
          enddo
 
+      ! Update groundedToFloatingThickness based on new masks
+      do iCell = 1, nCells
+        ! find locations that had grounded ice before but now have floating ice
+        if ( (groundedMaskForMassBudgetTemporaryField % array(iCell) .eq. 1) .and. &
+             (floatingMaskForMassBudget(iCell) .eq. 1) ) then
+           groundedToFloatingThickness(iCell) = groundedToFloatingThickness(iCell) + thickness(iCell)
+        ! find locations that had floating ice before but now have grounded ice
+        else if ( (floatingMaskForMassBudgetTemporaryField % array(iCell) .eq. 1) .and. &
+                  (groundedMaskForMassBudget(iCell) .eq. 1) ) then
+           groundedToFloatingThickness(iCell) = groundedToFloatingThickness(iCell) - thickness(iCell)
+        endif
+      enddo
          ! Now use flood fill to identify all floating ice connected to the open
          ! ocean. Subglacial lakes are any floating ice that are not in the
          ! resulting flood fill mask. Commented code below does not yet work

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -258,7 +258,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_mask(meshPool, velocityPool, geometryPool, err)
+   subroutine li_calculate_mask(meshPool, velocityPool, geometryPool, domain, err)
 
       !-----------------------------------------------------------------
       !
@@ -277,6 +277,8 @@ contains
       ! input/output variables
       !
       !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain
+
       type (mpas_pool_type), intent(inout) :: &
          geometryPool          !< Input/Output: geometry information
 
@@ -296,7 +298,8 @@ contains
       integer, pointer :: nCells, nVertices, nEdges, vertexDegree
       integer, pointer :: nVertInterfaces
       real(KIND=RKIND), dimension(:), pointer :: thickness, bedTopography
-      integer, dimension(:), pointer :: nEdgesOnCell, cellMask, vertexMask, edgeMask
+      integer, dimension(:), pointer :: nEdgesOnCell, cellMask, vertexMask, edgeMask, &
+                                        groundedMaskForMassBudget, floatingMaskForMassBudget
       integer, dimension(:,:), pointer :: cellsOnCell, cellsOnVertex, cellsOnEdge, dirichletVelocityMask
       real (kind=RKIND), pointer :: config_ice_density, config_ocean_density, &
             config_sea_level, config_dynamic_thickness
@@ -318,6 +321,7 @@ contains
       real (kind=RKIND) :: thinnestNeighborHeight
       integer :: iCellNeighbor
       logical :: openOceanNeighbor
+      logical :: updateMassBudgetMasks=.true.
 
       call mpas_timer_start('calculate mask')
 
@@ -340,6 +344,8 @@ contains
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel=1)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'groundedMaskForMassBudget', groundedMaskForMassBudget)
+      call mpas_pool_get_array(geometryPool, 'floatingMaskForMassBudget', floatingMaskForMassBudget)
 
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -369,9 +375,14 @@ contains
       ! Is it floating? (ice thickness equal to floatation is considered floating)
       ! For now floating ice and grounded ice are mutually exclusive.
       ! This may change if a grounding line parameterization is added.
+      ! Initialize grounded and floating masks for mass budget as well.
       where (  li_mask_is_ice(cellMask) .and. (config_ice_density / config_ocean_density * thickness) <= &
                (config_sea_level - bedTopography) )
           cellMask = ior(cellMask, li_mask_ValueFloating)
+          floatingMaskForMassBudget = 1
+      elsewhere (  li_mask_is_ice(cellMask) .and. (config_ice_density / config_ocean_density * thickness) > &
+               (config_sea_level - bedTopography) )
+          groundedMaskForMassBudget = 1
       end where
 
       ! Identify the margin
@@ -495,6 +506,52 @@ contains
           enddo
       enddo
 
+      ! For mass budget calculations, add floating ice over subglacial lakes and 
+      ! floating non-dynamic cells bordering grounded ice to the grounded mask
+      ! and remove them from floating mask. Need the following if statement to
+      ! avoid circularity between li_flood_fill and this routine.
+      if (updateMassBudgetMasks) then
+         do i=1,nCells
+             if (li_mask_is_floating_ice(cellMask(i))) then
+                if (.not. li_mask_is_dynamic_ice(cellMask(i))) then
+                   do j=1,nEdgesOnCell(i) ! Check if any neighbors are grounded
+                      iCellNeighbor = cellsOnCell(j,i)
+                      if (li_mask_is_grounded_ice(cellMask(iCellNeighbor))) then
+                          groundedMaskForMassBudget(i) = 1
+                          floatingMaskForMassBudget(i) = 0
+                      endif
+                      cycle ! no need to look at additional neighbors
+                   enddo
+                endif
+ 
+                ! Seed mask with floating cells with open ocean neighbors.
+                ! Currently commented because flood fill is not yet available
+                ! here.
+                ! do j=1,nEdgesOnCell(i) ! Check if any neighbors are open ocean
+                !    iCellNeighbor = cellsOnCell(j,i)
+                !    if ( (.not. li_mask_is_ice(cellMask(iCellNeighbor))) .and. &
+                !         (bedTopography(iCellNeighbor) < config_sea_level) ) then
+                !       seedMask = 1
+                !    endif
+                !    cycle ! no need to look at additional neighbors
+                ! enddo 
+             endif
+         enddo
+
+         ! Now use flood fill to identify all floating ice connected to the open
+         ! ocean. Subglacial lakes are any floating ice that are not in the
+         ! resulting flood fill mask. Commented code below does not yet work
+         ! because flood fill needs to be moved from li_calving to a shared
+         ! routine.
+         ! call li_flood_fill(seedMask=seedMask, growMask=li_mask_is_floating_ice(cellMask), domain)
+
+         !where (li_mask_is_floating(cellMask) and seedMask .eq. 0)
+         !      groundedMaskForBudget = 1
+         !      gloatingMaskForMassBudget = 0
+         !end where
+
+      endif
+      
       !call mpas_timer_stop('calculate mask cell')
 
       ! ====

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -535,8 +535,8 @@ contains
                       if (li_mask_is_grounded_ice(cellMask(iCellNeighbor))) then
                           groundedMaskForMassBudget(i) = 1
                           floatingMaskForMassBudget(i) = 0
+                          cycle ! no need to look at additional neighbors
                       endif
-                      cycle ! no need to look at additional neighbors
                    enddo
                 endif
  
@@ -548,8 +548,8 @@ contains
                 !    if ( (.not. li_mask_is_ice(cellMask(iCellNeighbor))) .and. &
                 !         (bedTopography(iCellNeighbor) < config_sea_level) ) then
                 !       seedMask = 1
+                !       cycle ! no need to look at additional neighbors
                 !    endif
-                !    cycle ! no need to look at additional neighbors
                 ! enddo 
              endif
          enddo


### PR DESCRIPTION
This builds on PR #37 to calculate mass budgets online rather than estimating them in arduous post-processing that requires verbose output. This adds binary masks `groundedMaskForMassBudget` and `floatingMaskForMassBudget`, which are used to calculate the grounded and floating components of the mass budget. Currently, non-dynamic floating cells adjacent to at least one grounded cell are added to the grounded mask and removed from the floating mask. 

We also will eventually want to add ice floating over subglacial lakes to the grounded mask, which is not done in this PR. However, that likely requires moving the flood fill routine out of `li_calving` and into its own module in `src/shared`, or perhaps into a subroutine of `mpas_li_masks.F`. Calling the flood fill routine many times during a timestep may be rather expensive, so I think that can wait until these changes are tested and merged. The subglacial lakes correction is likely small for most cases, and may not be worth the extra expense in the end.

Finally, this does not account for flux through the lateral boundaries of the domain. In use cases to-date, this has been zero, but that is not necessarily the case in general. I think that can be added when it is needed, and therefore I have not included it here.