### PR TITLE
Add calving metrics

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1495,6 +1495,10 @@ is the value of that variable from the *previous* time level!
                      units="none"  description="flag needed by external velocity solvers that indicates if the Dirichlet boundary condition mask has changed (treated as a logical)"
                         packages="higherOrderVelocity"
                 />
+                <var name="albanyVelocityError"              type="integer"  dimensions="Time"
+                        units="none"  description="0/1 flag indicating if Albany external velocity solver returned an error.  This typically means it did not converge.  0=converged. 1=unconverged"
+                        packages="higherOrderVelocity"
+                />
         </var_struct>
 
 <!-- ================ -->

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1200,6 +1200,12 @@ is the value of that variable from the *previous* time level!
                 <var name="dtCalvingCFLratio" type="real" dimensions="Time" units="none" time_levs="1" default_value="0.0"
                         description="ratio of timestep being used to the maximum timestep calculated for the calving CFL condition.  This metric can be used to assess the accuracy of the calving CFL calculation being lagged by a timestep."
                 />
+                <var name="totalRatebasedCalvedVolume" type="real" dimensions="Time" units="m^3" time_levs="1"
+                        description="total calved volume calculated by li_apply_front_ablation_velocity for a rate-based calving law"
+                />
+                <var name="totalRatebasedUncalvedVolume" type="real" dimensions="Time" units="m^3" time_levs="1"
+                        description="total uncalved volume calculated by li_apply_front_ablation_velocity for a rate-based calving law"
+                />
                 <var name="eigencalvingParameter" type="real" dimensions="nCells Time" units="m s" time_levs="1"
                      description="proportionality constant K2+- used in eigencalving formulation"
                 />

--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -117,6 +117,9 @@
                         <var name="calvingCFLdt"/>
                         <var name="dtCalvingCFLratio"/>
                         <var name="processLimitingTimestep"/>
+                        <var name="totalRatebasedCalvedVolume"/>
+                        <var name="totalRatebasedUncalvedVolume"/>
+                        <var name="albanyVelocityError"/>
                         <var_struct name="globalStatsAM"/>
 		</stream>
 	</streams>

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3853,7 +3853,10 @@ module li_calving
       where ( seedMask == 0 .and. li_mask_is_floating_ice(cellMask(:)) )
              growMask = 1
       endwhere
-      call flood_fill(seedMask, growMask, domain)
+
+      ! Call flood fill.  We also want to exclude hinged peninsulas, because they will also be
+      ! ill-defined for the velocity solver.
+      call flood_fill(seedMask, growMask, domain, detectHinges=.false.)
       
       ! Now remove any ice that was not flood-filled - these are icebergs
       block => domain % blocklist
@@ -3910,13 +3913,14 @@ module li_calving
 !> \date   March 2021
 !> \details 
 !-----------------------------------------------------------------------
-   subroutine flood_fill(seedMask, growMask, domain)
+   subroutine flood_fill(seedMask, growMask, domain, detectHinges)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain !< Input/Output: domain object
       integer, dimension(:), intent(inout) :: seedMask
       integer, dimension(:), intent(in) :: growMask
+      logical, intent(in), optional :: detectHinges
       ! Local variables
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: meshPool
@@ -3932,8 +3936,15 @@ module li_calving
       integer :: newMaskCountLocal, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: err_tmp, err
       integer :: globalLoopCount, localLoopCount
+      logical :: detectHingesLoc
 
       err = 0
+
+      if (present(detectHinges)) then
+         detectHingesLoc = detectHinges
+      else
+         detectHingesLoc = .false.
+      endif
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
@@ -4011,19 +4022,61 @@ module li_calving
                newMaskCountLocal = 0
                seedMaskOld(:) = seedMask(:)
 
-               do iCell = 1, nCellsSolve ! this gives owned cells only
-                  if ( growMask(iCell)>0 ) then
-                     ! If it has a marked neighbor, then add it to the mask
-                     do n = 1, nEdgesOnCell(iCell)
-                        jCell = cellsOnCell(n, iCell)
-                        if ( (seedMaskOld(jCell) == 1) .and. (seedMask(iCell) .ne. 1) ) then
-                           seedMask(iCell) = 1
-                           newMaskCountLocal = newMaskCountLocal + 1
-                           exit ! skip the rest of this do-loop - no need to check additional neighbors
-                        endif
-                     enddo
-                  endif ! if not already marked
-               enddo ! loop over cells
+               if (detectHingesLoc) then
+
+                  ! Note: As written the with-hinge version will stop whenever it finds a hinge.  Thus a region that is attached
+                  ! by two or more hinges will not be included in the flood fill, even though it is probably desireable to
+                  ! include such regions.  The algorithm would need additional work to detect such regions and flood them.
+                  do iCell = 1, nCellsSolve ! this gives owned cells only
+                     if ((growMask(iCell) == 1) .and. (seedMask(iCell) == 0)) then
+                        ! This cell is a valid grow zone and hasn't been flooeded yet
+                        ! Check that this cell has TWO adjacent neighbors in the seed mask
+                        ! to also eliminate hinged peninsulas
+                        do n = 1, nEdgesOnCell(iCell)
+                           jCell = cellsOnCell(n, iCell)
+                           if (seedMaskOld(jCell) == 1) then ! First valid neighbor
+                              ! Now check adjacent neighbor in forward-index direction
+                              if (n < nEdgesOnCell(iCell)) then
+                                 if (seedMaskOld(cellsOnCell(n+1, iCell)) == 1) then
+                                    ! We found two adjacent neigbhors in the seed mask.  No need to look further
+                                    seedMask(iCell) = 1
+                                    newMaskCountLocal = newMaskCountLocal + 1
+                                    exit ! skip the rest of this do-loop - no need to check additional neighbors
+                                 endif
+                              else if (n == nEdgesOnCell(iCell)) then
+                                 if (seedMaskOld(cellsOnCell(1, iCell)) == 1) then ! ring around the rosie
+                                    ! We found two adjacent neigbhors in the seed mask.  No need to look further
+                                    seedMask(iCell) = 1
+                                    newMaskCountLocal = newMaskCountLocal + 1
+                                    exit ! skip the rest of this do-loop - no need to check additional neighbors
+                                 endif
+                              else
+                                 ! This should never happen but check
+                                 call mpas_log_write("Unexpected index in mpas_li_calving.F:flood_fill!", MPAS_LOG_ERR)
+                                 err = ior(err, 1)
+                              endif ! if final neighbor
+                           endif ! if there was a first valid neighbor
+                        enddo ! Loop over neighbors
+                     endif ! if not already marked
+                  enddo ! loop over cells
+
+               else ! don't detect hinges
+
+                  do iCell = 1, nCellsSolve ! this gives owned cells only
+                     if ( growMask(iCell)>0 ) then
+                        ! If it has a marked neighbor, then add it to the mask
+                        do n = 1, nEdgesOnCell(iCell)
+                           jCell = cellsOnCell(n, iCell)
+                           if ( (seedMaskOld(jCell) == 1) .and. (seedMask(iCell) .ne. 1) ) then
+                              seedMask(iCell) = 1
+                              newMaskCountLocal = newMaskCountLocal + 1
+                              exit ! skip the rest of this do-loop - no need to check additional neighbors
+                           endif
+                        enddo
+                     endif ! if not already marked
+                  enddo ! loop over cells
+
+               endif ! if detect hinges
 
                ! Accumulate cells added locally until we do the next global
                ! reduce

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1585,6 +1585,7 @@ module li_calving
       integer, pointer :: nCells
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), dimension(:), pointer :: vonMisesStress, damage
+      real (kind=RKIND), pointer :: totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
 
       err = 0
@@ -1636,6 +1637,8 @@ module li_calving
           call mpas_pool_get_array(geometryPool, 'thickness', thickness)
           call mpas_pool_get_array(geometryPool, 'groundedVonMisesThresholdStress', groundedVonMisesThresholdStress)
           call mpas_pool_get_array(geometryPool, 'floatingVonMisesThresholdStress', floatingVonMisesThresholdStress)
+          call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
+          call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
           call mpas_pool_get_array(thermalPool, 'temperature', temperature)
 
           ! get parameter value and check that values are valid
@@ -1723,7 +1726,8 @@ module li_calving
           call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, &
-                                              calvingCFLdt, dtCalvingCFLratio, err_tmp)
+                                              calvingCFLdt, dtCalvingCFLratio, &
+                                              totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
           err = ior(err, err_tmp)
          ! Update halos on calvingThickness or faceMeltingThickness before
          ! applying it.
@@ -2117,7 +2121,8 @@ module li_calving
 !-----------------------------------------------------------------------
 
    subroutine li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, ablationThickness, ablationVelocity, &
-                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, maxDt, CFLratio, err)
+                   applyToGrounded, applyToFloating, applyToGroundingLine, domain, maxDt, CFLratio, &
+                   totalAblatedVolume, totalUnablatedVolume, err)
 
       use ieee_arithmetic, only : ieee_is_nan
 
@@ -2142,6 +2147,10 @@ module li_calving
           !< Output: an approximation of the max allowable dt based on a CFL-like condition calculated from ablation velocity
       real (kind=RKIND), optional :: CFLratio
           !< Output: the ratio of the actual timestep being applied to the maximum allowable timestep from the CFL-like condition
+      real (kind=RKIND), optional :: totalAblatedVolume
+          !< Output: the total ablated volume
+      real (kind=RKIND), optional :: totalUnablatedVolume
+          !< Output: the total unablated volume
       integer, intent(out) :: err !< Output: error flag
 
       integer, pointer :: nEdges, nEdgesSolve, nCells, nCellsSolve, maxEdges
@@ -2805,6 +2814,13 @@ module li_calving
                  "  Try using a smaller timestep or li_apply_front_ablation_velocity may need improvements for this simulation.")
          err_tmp = 1
          err = ior(err, err_tmp)
+      endif
+
+      if (present(totalAblatedVolume)) then
+         totalAblatedVolume = globalInfo(4)
+      endif
+      if (present(totalUnablatedVolume)) then
+         totalUnablatedVolume = globalInfo(5) + globalInfo(6)
       endif
 
       deallocate(cellVolume)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3853,10 +3853,7 @@ module li_calving
       where ( seedMask == 0 .and. li_mask_is_floating_ice(cellMask(:)) )
              growMask = 1
       endwhere
-
-      ! Call flood fill.  We also want to exclude hinged peninsulas, because they will also be
-      ! ill-defined for the velocity solver.
-      call flood_fill(seedMask, growMask, domain, detectHinges=.false.)
+      call flood_fill(seedMask, growMask, domain)
       
       ! Now remove any ice that was not flood-filled - these are icebergs
       block => domain % blocklist
@@ -3913,14 +3910,13 @@ module li_calving
 !> \date   March 2021
 !> \details 
 !-----------------------------------------------------------------------
-   subroutine flood_fill(seedMask, growMask, domain, detectHinges)
+   subroutine flood_fill(seedMask, growMask, domain)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain !< Input/Output: domain object
       integer, dimension(:), intent(inout) :: seedMask
       integer, dimension(:), intent(in) :: growMask
-      logical, intent(in), optional :: detectHinges
       ! Local variables
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: meshPool
@@ -3936,15 +3932,8 @@ module li_calving
       integer :: newMaskCountLocal, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: err_tmp, err
       integer :: globalLoopCount, localLoopCount
-      logical :: detectHingesLoc
 
       err = 0
-
-      if (present(detectHinges)) then
-         detectHingesLoc = detectHinges
-      else
-         detectHingesLoc = .false.
-      endif
 
       block => domain % blocklist
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
@@ -4022,61 +4011,19 @@ module li_calving
                newMaskCountLocal = 0
                seedMaskOld(:) = seedMask(:)
 
-               if (detectHingesLoc) then
-
-                  ! Note: As written the with-hinge version will stop whenever it finds a hinge.  Thus a region that is attached
-                  ! by two or more hinges will not be included in the flood fill, even though it is probably desireable to
-                  ! include such regions.  The algorithm would need additional work to detect such regions and flood them.
-                  do iCell = 1, nCellsSolve ! this gives owned cells only
-                     if ((growMask(iCell) == 1) .and. (seedMask(iCell) == 0)) then
-                        ! This cell is a valid grow zone and hasn't been flooeded yet
-                        ! Check that this cell has TWO adjacent neighbors in the seed mask
-                        ! to also eliminate hinged peninsulas
-                        do n = 1, nEdgesOnCell(iCell)
-                           jCell = cellsOnCell(n, iCell)
-                           if (seedMaskOld(jCell) == 1) then ! First valid neighbor
-                              ! Now check adjacent neighbor in forward-index direction
-                              if (n < nEdgesOnCell(iCell)) then
-                                 if (seedMaskOld(cellsOnCell(n+1, iCell)) == 1) then
-                                    ! We found two adjacent neigbhors in the seed mask.  No need to look further
-                                    seedMask(iCell) = 1
-                                    newMaskCountLocal = newMaskCountLocal + 1
-                                    exit ! skip the rest of this do-loop - no need to check additional neighbors
-                                 endif
-                              else if (n == nEdgesOnCell(iCell)) then
-                                 if (seedMaskOld(cellsOnCell(1, iCell)) == 1) then ! ring around the rosie
-                                    ! We found two adjacent neigbhors in the seed mask.  No need to look further
-                                    seedMask(iCell) = 1
-                                    newMaskCountLocal = newMaskCountLocal + 1
-                                    exit ! skip the rest of this do-loop - no need to check additional neighbors
-                                 endif
-                              else
-                                 ! This should never happen but check
-                                 call mpas_log_write("Unexpected index in mpas_li_calving.F:flood_fill!", MPAS_LOG_ERR)
-                                 err = ior(err, 1)
-                              endif ! if final neighbor
-                           endif ! if there was a first valid neighbor
-                        enddo ! Loop over neighbors
-                     endif ! if not already marked
-                  enddo ! loop over cells
-
-               else ! don't detect hinges
-
-                  do iCell = 1, nCellsSolve ! this gives owned cells only
-                     if ( growMask(iCell)>0 ) then
-                        ! If it has a marked neighbor, then add it to the mask
-                        do n = 1, nEdgesOnCell(iCell)
-                           jCell = cellsOnCell(n, iCell)
-                           if ( (seedMaskOld(jCell) == 1) .and. (seedMask(iCell) .ne. 1) ) then
-                              seedMask(iCell) = 1
-                              newMaskCountLocal = newMaskCountLocal + 1
-                              exit ! skip the rest of this do-loop - no need to check additional neighbors
-                           endif
-                        enddo
-                     endif ! if not already marked
-                  enddo ! loop over cells
-
-               endif ! if detect hinges
+               do iCell = 1, nCellsSolve ! this gives owned cells only
+                  if ( growMask(iCell)>0 ) then
+                     ! If it has a marked neighbor, then add it to the mask
+                     do n = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(n, iCell)
+                        if ( (seedMaskOld(jCell) == 1) .and. (seedMask(iCell) .ne. 1) ) then
+                           seedMask(iCell) = 1
+                           newMaskCountLocal = newMaskCountLocal + 1
+                           exit ! skip the rest of this do-loop - no need to check additional neighbors
+                        endif
+                     enddo
+                  endif ! if not already marked
+               enddo ! loop over cells
 
                ! Accumulate cells added locally until we do the next global
                ! reduce

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1183,6 +1183,7 @@ module li_calving
       real(kind=RKIND) :: calvingSubtotal
       integer :: err_tmp
       logical :: applyToGrounded, applyToFloating, applyToGroundingLine
+      real (kind=RKIND), pointer :: totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume
 
       err = 0
 
@@ -1226,6 +1227,8 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1255,7 +1258,7 @@ module li_calving
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded, &
                                               applyToFloating, applyToGroundingLine, domain, calvingCFLdt, dtCalvingCFLratio, &
-                                              err=err_tmp)
+                                              totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume, err_tmp)
          err = ior(err, err_tmp)
 
          if ( trim(config_damage_calving_method) == 'none' ) then
@@ -1404,6 +1407,7 @@ module li_calving
       integer :: iCell, jCell, iNeighbor
       logical :: dynamicNeighbor
       real(kind=RKIND) :: calvingSubtotal
+      real (kind=RKIND), pointer :: totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume
       integer :: err_tmp
 
       err = 0
@@ -1437,6 +1441,8 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -1461,7 +1467,10 @@ module li_calving
          ! Convert calvingVelocity to calvingThickness
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.true., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
+                                              totalAblatedVolume=totalRatebasedCalvedVolume, &
+                                              totalUnablatedVolume=totalRatebasedUncalvedVolume, &
+                                              err=err_tmp)
          err = ior(err, err_tmp)
 
          ! === apply calving ===
@@ -1887,6 +1896,7 @@ module li_calving
       character(len=StrKIND) :: forcingTimeOldStamp
       type (MPAS_stream_list_type), pointer :: stream_cursor
       logical :: streamFound ! used to throw an error if required stream is not found
+      real (kind=RKIND), pointer :: totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume
 
       call mpas_pool_get_config(liConfigs, 'config_ismip6_retreat_k', config_ismip6_retreat_k)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
@@ -1924,6 +1934,8 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'ismip6RunoffPrevious', ismip6RunoffPrevious)
       call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcingCurrent', TFoceanCurrent)
       call mpas_pool_get_array(geometryPool, 'ismip6RunoffCurrent', ismip6RunoffCurrent)
+      call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
+      call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
       
       ! submergedArea used in runoff unit conversion 
       allocate(submergedArea(nCells+1))
@@ -2052,7 +2064,11 @@ module li_calving
       call li_apply_front_ablation_velocity(meshPool, geometryPool,velocityPool, &
                                               calvingThickness, calvingVelocity, applyToGrounded=.true., &
                                               applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
+                                              totalAblatedVolume=totalRatebasedCalvedVolume, &
+                                              totalUnablatedVolume=totalRatebasedUncalvedVolume, &
+                                              err=err_tmp)
+      err = ior(err, err_tmp)
 
       ! Update halos on calvingThickness before applying it.
       ! NOTE: THIS WILL NOT WORK ON MULTIPLE BLOCKS PER PROCESSOR
@@ -2920,6 +2936,7 @@ module li_calving
       real(kind=RKIND) :: calvingSubtotal
       character (len=StrKIND), pointer :: config_damage_calving_method
       real(kind=RKIND), pointer :: config_damage_calving_threshold
+      real (kind=RKIND), pointer :: totalRatebasedCalvedVolume, totalRatebasedUncalvedVolume
 
       err = 0
 
@@ -2957,6 +2974,8 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingFrontMask', calvingFrontMask)
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
          call mpas_pool_get_array(geometryPool, 'dtCalvingCFLratio', dtCalvingCFLratio)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedCalvedVolume', totalRatebasedCalvedVolume)
+         call mpas_pool_get_array(geometryPool, 'totalRatebasedUncalvedVolume', totalRatebasedUncalvedVolume)
 
 
          call calculate_calving_front_mask(meshPool, geometryPool, calvingFrontMask)
@@ -2973,7 +2992,10 @@ module li_calving
                 * real(li_mask_is_floating_ice_int(cellMask(:)), kind=RKIND) ! calculate only for floating ice
              call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, calvingThickness, calvingVelocity, &
                                               applyToGrounded=.false., applyToFloating=.true., applyToGroundingLine=.false., &
-                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, err=err_tmp)
+                                              domain=domain, maxDt=calvingCFLdt, CFLratio=dtCalvingCFLratio, &
+                                              totalAblatedVolume=totalRatebasedCalvedVolume, &
+                                              totalUnablatedVolume=totalRatebasedUncalvedVolume, &
+                                              err=err_tmp)
              err = ior(err, err_tmp)
          elseif (trim(config_damage_calving_method) == 'threshold') then
              call apply_calving_damage_threshold(meshPool, geometryPool, scratchPool, domain, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2792,10 +2792,9 @@ module li_calving
       endif
       if (((globalInfo(5) + globalInfo(6)) / (globalInfo(4) + 1.0e-30_RKIND) > config_calving_error_threshold) .and. &
           (globalInfo(4) > 1000.0_RKIND**2)) then ! Include some small amount of total calving for comparison
-         call mpas_log_write("Failed to ablate an amount greater than 10% of the ice ablated.  " // &
+         call mpas_log_write("Failed to ablate an amount greater than $r% of the ice ablated.  " // &
                  "Try reducing time step or li_apply_front_ablation_velocity may need improvements.", &
-                 MPAS_LOG_ERR, realArgs=(/globalInfo(5) + globalInfo(6), &
-                 100.0_RKIND * (globalInfo(5) + globalInfo(6)) / (globalInfo(4)+1.0e-30_RKIND)/))
+                 MPAS_LOG_ERR, realArgs=(/config_calving_error_threshold * 100.0_RKIND/))
          err_tmp = 1
          err = ior(err, err_tmp)
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -473,11 +473,9 @@ contains
       integer :: iCell
       real(kind=RKIND), parameter :: secondsInYear = 365.0_RKIND * 24.0_RKIND * 3600.0_RKIND
          !< The value of seconds in a year assumed by external dycores
-      integer, target :: err_tmp
-      integer, pointer :: err_albany
+      integer, pointer :: albanyVelocityError
 
       err = 0
-      err_tmp = 0
 
       ! configs
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
@@ -522,6 +520,8 @@ contains
       call mpas_pool_get_array(velocityPool, 'dirichletMaskChanged', dirichletMaskChanged)
       call mpas_pool_get_array(velocityPool, 'dirichletVelocityMask', dirichletVelocityMask, timeLevel = 1)
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
+      call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
+      albanyVelocityError = 0
 
       ! Hydro variables
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
@@ -595,26 +595,24 @@ contains
 
 
           call mpas_timer_start("velocity_solver_solve_FO")
-          err_albany => err_tmp
           call velocity_solver_solve_FO(bedTopography, lowerSurface, thickness, &
                 betaSolve, sfcMassBal, temperature, stiffnessFactor, &
                 effectivePressureLimited, muFriction, &
                 uReconstructX, uReconstructY,  &  ! Dirichlet boundary values to apply where dirichletVelocityMask=1
                 normalVelocity, drivingStressVert, dissipationVertexField % array, uReconstructX, uReconstructY, &  ! return values
-                deltat, err_albany)  ! return values
+                deltat, albanyVelocityError)  ! return values
           call mpas_timer_stop("velocity_solver_solve_FO")
 
-          if (err_tmp == 1) then
+          if (albanyVelocityError == 1) then
              if (config_nonconvergence_error) then
                 call mpas_log_write("Albany velocity solve failed to converge!  " // &
                    "Check log.albany.0000.out for more information.", MPAS_LOG_ERR)
+                err = ior(err, albanyVelocityError)
              else
                 call mpas_log_write("Albany velocity solve failed to converge!  " // &
                    "Check log.albany.0000.out for more information.", MPAS_LOG_WARN)
-                err_tmp = 0
              endif
           endif
-          err = ior(err,err_tmp)
 
 
           ! Now interpolate from vertices to cell centers


### PR DESCRIPTION
This merge adds two new additional calving metrics that can be output.  It also fixes a minor error in the unablated volume error message and adds a new output variable for if Albany converged or not.  Finally, there is a commit to make the flood fill detect hinges that is reverted, because it was decided to not be helpful.  But I wanted to keep it in the history in case there was a need to resurrect it sometime in the future.

The three new scalar metrics are added to the default global stats stream definition so they would be generally available.