### PR TITLE
Do not modify floatingBasalMassBal

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1534,7 +1534,7 @@ is the value of that variable from the *previous* time level!
                 <var name="waterFrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="interior ice water fraction"
                 />
-                <var name="internalMeltRate" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-2} s^{-1}"
+                <var name="drainedInternalMeltRate" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-2} s^{-1}"
                      description="Excess internal melting drained to bed."
                 />
                 <var name="enthalpy" type="real" dimensions="nVertLevels nCells Time" units="J m^{-3}"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1534,6 +1534,9 @@ is the value of that variable from the *previous* time level!
                 <var name="waterFrac" type="real" dimensions="nVertLevels nCells Time" units="unitless"
                      description="interior ice water fraction"
                 />
+                <var name="internalMeltRate" type="real" dimensions="nVertLevels nCells Time" units="kg m^{-2} s^{-1}"
+                     description="Excess internal melting drained to bed."
+                />
                 <var name="enthalpy" type="real" dimensions="nVertLevels nCells Time" units="J m^{-3}"
                      description="interior ice enthalpy"
                 />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -200,7 +200,8 @@ module li_advection
 
       logical, pointer :: &
            config_print_thickness_advection_info, &  !TODO - change to config_print_advection_info?
-           config_print_thermal_info
+           config_print_thermal_info, &
+           config_thermal_calculate_bmb
 
       real (kind=RKIND), pointer :: &
            config_ice_density,    & ! rhoi
@@ -287,6 +288,7 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_print_thickness_advection_info', config_print_thickness_advection_info)
       call mpas_pool_get_config(liConfigs, 'config_print_thermal_info', config_print_thermal_info)
+      call mpas_pool_get_config(liConfigs, 'config_thermal_calculate_bmb', config_thermal_calculate_bmb)
       call mpas_pool_get_config(liConfigs, 'config_thermal_thickness', config_thermal_thickness)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
@@ -475,21 +477,23 @@ module li_advection
 
          end where
 
-         ! It is possible that internal melting was computed for floating ice and assigned
-         ! to the groundedBasalMassBal array in mpas_li_thermal.F.  If so, then add it to basalMassBal.
+         ! It is possible that excess internal melting was computed and assigned
+         ! to the drainedInternalMeltRate array in mpas_li_thermal.F.  If so, then add it to basalMassBal.
          ! floatingBasalMassBal should never be altered because it is an input variable.
          ! Note: Subroutine basal_melt_floating_ice should be called earlier in the time step, before adding this term.
                   ! calculate a mask to identify ice that is thick enough to be thermally active
-         do iCell = 1, nCells
-            if (thickness(iCell) > config_thermal_thickness) then
-               thermalCellMask(iCell) = 1
-               do k = 1, nVertLevels
-                  basalMassBal(iCell) = basalMassBal(iCell) - drainedInternalMeltRate(k, iCell)
-               enddo
-            else
-               thermalCellMask(iCell) = 0
-            endif
-         enddo
+         if (config_thermal_calculate_bmb) then
+            do iCell = 1, nCells
+               if (thickness(iCell) > config_thermal_thickness) then
+                  thermalCellMask(iCell) = 1
+                  do k = 1, nVertLevels
+                     basalMassBal(iCell) = basalMassBal(iCell) - drainedInternalMeltRate(k, iCell)
+                  enddo
+               else
+                  thermalCellMask(iCell) = 0
+               endif
+            enddo
+         endif
 
          call apply_mass_balance(&
               dt,                  &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -154,6 +154,7 @@ module li_advection
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,           & ! interior ice temperature
            waterFrac,             & ! interior water fraction
+           internalMeltRate,      & ! excess internal melt drained to the bed
            enthalpy                 ! interior ice enthalpy
 
       real (kind=RKIND), dimension(:,:), pointer :: &
@@ -280,6 +281,7 @@ module li_advection
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
+      call mpas_pool_get_array(thermalPool, 'internalMeltRate', internalMeltRate)
 
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
@@ -293,6 +295,7 @@ module li_advection
       !WHL - debug
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
@@ -480,23 +483,12 @@ module li_advection
          do iCell = 1, nCells
             if (thickness(iCell) > config_thermal_thickness) then
                thermalCellMask(iCell) = 1
+               do k = 1, nVertLevels
+                  basalMassBal(iCell) = basalMassBal(iCell) - internalMeltRate(k, iCell)
+               enddo
             else
                thermalCellMask(iCell) = 0
             endif
-         enddo
-
-         do iCell = 1, nCells
-            if (thermalCellMask(iCell) == 1 .and. li_mask_is_floating_ice(cellMask(iCell)) .and. &
-                 groundedBasalMassBal(iCell) /= 0.0_RKIND) then
-               basalMassBal(iCell) = basalMassBal(iCell) + groundedBasalMassBal(iCell)
-               groundedBasalMassBal(iCell) = 0.0_RKIND
-            endif
-
-            if (config_print_thermal_info .and. indexToCellID(iCell) == config_stats_cell_ID) then
-               call mpas_log_write('indexToCellID=$i, basal mass balance (m/yr): $r', &
-                    intArgs=(/indexToCellID(iCell)/), realArgs=(/basalMassBal(iCell)*scyr/config_ice_density/) ) 
-            endif
-
          enddo
 
          call apply_mass_balance(&

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -204,7 +204,8 @@ module li_advection
       real (kind=RKIND), pointer :: &
            config_ice_density,    & ! rhoi
            config_ocean_density,  & ! rhoo
-           config_sea_level         ! sea level relative to z = 0
+           config_sea_level,      & ! sea level relative to z = 0
+           config_thermal_thickness
 
       logical :: advectTracers     ! if true, then advect tracers as well as thickness
 
@@ -284,6 +285,7 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_print_thickness_advection_info', config_print_thickness_advection_info)
       call mpas_pool_get_config(liConfigs, 'config_print_thermal_info', config_print_thermal_info)
+      call mpas_pool_get_config(liConfigs, 'config_thermal_thickness', config_thermal_thickness)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
@@ -474,6 +476,15 @@ module li_advection
          ! to the groundedBasalMassBal array in mpas_li_thermal.F.  If so, then add it to basalMassBal.
          ! floatingBasalMassBal should never be altered because it is an input variable.
          ! Note: Subroutine basal_melt_floating_ice should be called earlier in the time step, before adding this term.
+                  ! calculate a mask to identify ice that is thick enough to be thermally active
+         do iCell = 1, nCells
+            if (thickness(iCell) > config_thermal_thickness) then
+               thermalCellMask(iCell) = 1
+            else
+               thermalCellMask(iCell) = 0
+            endif
+         enddo
+
          do iCell = 1, nCells
             if (thermalCellMask(iCell) == 1 .and. li_mask_is_floating_ice(cellMask(iCell)) .and. &
                  groundedBasalMassBal(iCell) /= 0.0_RKIND) then
@@ -609,6 +620,7 @@ module li_advection
       call mpas_deallocate_scratch_field(basalTracersField, .true.)
       call mpas_deallocate_scratch_field(surfaceTracersField, .true.)
       call mpas_deallocate_scratch_field(cellMaskTemporaryField, .true.)
+      call mpas_deallocate_scratch_field(thermalCellMaskField, .true.)
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -182,11 +182,13 @@ module li_advection
            basalTracersField        ! scratch field containing values of basal tracers
 
       type (field1DInteger), pointer :: &
-           cellMaskTemporaryField ! scratch field containing old values of cellMask
+           cellMaskTemporaryField, & ! scratch field containing old values of cellMask
+           thermalCellMaskField
 
       integer, dimension(:), pointer :: &
            cellMask,              & ! integer bitmask for cells
-           edgeMask                 ! integer bitmask for edges
+           edgeMask,              & ! integer bitmask for edges
+           thermalCellMask
 
       integer, dimension(:,:), pointer :: cellsOnEdge
 
@@ -196,7 +198,8 @@ module li_advection
            config_thickness_advection   ! method for advecting thickness and tracers
 
       logical, pointer :: &
-           config_print_thickness_advection_info   !TODO - change to config_print_advection_info?
+           config_print_thickness_advection_info, &  !TODO - change to config_print_advection_info?
+           config_print_thermal_info
 
       real (kind=RKIND), pointer :: &
            config_ice_density,    & ! rhoi
@@ -280,6 +283,7 @@ module li_advection
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_print_thickness_advection_info', config_print_thickness_advection_info)
+      call mpas_pool_get_config(liConfigs, 'config_print_thermal_info', config_print_thermal_info)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
@@ -322,6 +326,9 @@ module li_advection
       call mpas_pool_get_field(geometryPool, 'cellMaskTemporary', cellMaskTemporaryField)
       call mpas_allocate_scratch_field(cellMaskTemporaryField, .true.)
 
+      call mpas_pool_get_field(scratchPool, 'iceCellMask', thermalCellMaskField)
+      call mpas_allocate_scratch_field(thermalCellMaskField, .true.)
+      thermalCellMask => thermalCellMaskField % array
 
       ! given the old thickness, compute the thickness in each layer
       call li_calculate_layerThickness(meshPool, thickness, layerThickness)
@@ -462,6 +469,24 @@ module li_advection
             basalMassBal = 0.0_RKIND
 
          end where
+
+         ! It is possible that internal melting was computed for floating ice and assigned
+         ! to the groundedBasalMassBal array in mpas_li_thermal.F.  If so, then add it to basalMassBal.
+         ! floatingBasalMassBal should never be altered because it is an input variable.
+         ! Note: Subroutine basal_melt_floating_ice should be called earlier in the time step, before adding this term.
+         do iCell = 1, nCells
+            if (thermalCellMask(iCell) == 1 .and. li_mask_is_floating_ice(cellMask(iCell)) .and. &
+                 groundedBasalMassBal(iCell) /= 0.0_RKIND) then
+               basalMassBal(iCell) = basalMassBal(iCell) + groundedBasalMassBal(iCell)
+               groundedBasalMassBal(iCell) = 0.0_RKIND
+            endif
+
+            if (config_print_thermal_info .and. indexToCellID(iCell) == config_stats_cell_ID) then
+               call mpas_log_write('indexToCellID=$i, basal mass balance (m/yr): $r', &
+                    intArgs=(/indexToCellID(iCell)/), realArgs=(/basalMassBal(iCell)*scyr/config_ice_density/) ) 
+            endif
+
+         enddo
 
          call apply_mass_balance(&
               dt,                  &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -154,7 +154,7 @@ module li_advection
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,           & ! interior ice temperature
            waterFrac,             & ! interior water fraction
-           internalMeltRate,      & ! excess internal melt drained to the bed
+           drainedInternalMeltRate,      & ! excess internal melt drained to the bed
            enthalpy                 ! interior ice enthalpy
 
       real (kind=RKIND), dimension(:,:), pointer :: &
@@ -281,7 +281,7 @@ module li_advection
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
-      call mpas_pool_get_array(thermalPool, 'internalMeltRate', internalMeltRate)
+      call mpas_pool_get_array(thermalPool, 'drainedInternalMeltRate', drainedInternalMeltRate)
 
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
@@ -484,7 +484,7 @@ module li_advection
             if (thickness(iCell) > config_thermal_thickness) then
                thermalCellMask(iCell) = 1
                do k = 1, nVertLevels
-                  basalMassBal(iCell) = basalMassBal(iCell) - internalMeltRate(k, iCell)
+                  basalMassBal(iCell) = basalMassBal(iCell) - drainedInternalMeltRate(k, iCell)
                enddo
             else
                thermalCellMask(iCell) = 0

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -724,7 +724,7 @@ module li_thermal
            temperature,              & ! interior ice temperature (K)
            waterFrac,                & ! interior water fraction (unitless)
            enthalpy,                 & ! interior ice enthalpy (J m^{-3})
-           internalMeltRate,         & ! excess internal melt drained to the bed
+           drainedInternalMeltRate,         & ! excess internal melt drained to the bed
            heatDissipation             ! interior heat dissipation (deg/s)
 
       real(kind=RKIND), dimension(:), allocatable :: &
@@ -830,7 +830,7 @@ module li_thermal
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
          call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
          call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
-         call mpas_pool_get_array(thermalPool, 'internalMeltRate', internalMeltRate)
+         call mpas_pool_get_array(thermalPool, 'drainedInternalMeltRate', drainedInternalMeltRate)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature',   basalTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
@@ -1287,7 +1287,7 @@ module li_thermal
                  basalHeatFlux,                &
                  basalConductiveFlux,          &
                  basalWaterThickness,          &
-                 internalMeltRate,             &
+                 drainedInternalMeltRate,             &
                  groundedBasalMassBal)
 
             ! Convert temperatures from Celsius back to Kelvin
@@ -2705,7 +2705,7 @@ module li_thermal
          basalHeatFlux,               &
          basalConductiveFlux,         &
          basalWaterThickness,         &
-         internalMeltRate,            &
+         drainedInternalMeltRate,            &
          groundedBasalMassBal)
 
       !-----------------------------------------------------------------
@@ -2772,7 +2772,7 @@ module li_thermal
       real(kind=RKIND), dimension(:), intent(out):: &
            groundedBasalMassBal  !< Output: basal mass balance for grounded ice (kg/m^2/s): < 0 for melting, > 0 for freeze-on
       real(kind=RKIND), dimension(:,:), intent(out):: &
-           internalMeltRate         !< Output: excess internal melt drained to the bed
+           drainedInternalMeltRate         !< Output: excess internal melt drained to the bed
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -2802,7 +2802,7 @@ module li_thermal
       ! Compute melt rate for grounded ice
 
       groundedBasalMassBal(:) = 0.0_RKIND
-      internalMeltRate(:,:) = 0.0_RKIND
+      drainedInternalMeltRate(:,:) = 0.0_RKIND
 
       do iCell = 1, nCellsSolve
 
@@ -2869,7 +2869,7 @@ module li_thermal
                      ! compute melt rate associated with excess water
                      excessWater = (waterFrac(k,iCell) - maxwaterFrac) * thickness(iCell) * (layerInterfaceSigma(k+1) &
                         - layerInterfaceSigma(k))  ! m
-                     internalMeltRate(k, iCell) = excessWater / deltat
+                     drainedInternalMeltRate(k, iCell) = excessWater / deltat
                      ! transfer meltwater to the bed in mpas_li_advection.F
 
                      ! reset waterFrac to max value
@@ -2893,7 +2893,7 @@ module li_thermal
                      ! compute excess energy available for melting
                      layerThickness = thickness(iCell) * (layerInterfaceSigma(k+1) - layerInterfaceSigma(k))     ! m
                      meltEnergy = rhoi*cp_ice * (temperature(k,iCell) - pmpTemperature(k)) * layerThickness    ! J/m^2
-                     internalMeltRate(k, iCell) = meltEnergy / (rhoi * latent_heat_ice * deltat)  ! m/s
+                     drainedInternalMeltRate(k, iCell) = meltEnergy / (rhoi * latent_heat_ice * deltat)  ! m/s
 
                      ! transfer meltwater to the bed in mpas_li_advection.F
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -724,6 +724,7 @@ module li_thermal
            temperature,              & ! interior ice temperature (K)
            waterFrac,                & ! interior water fraction (unitless)
            enthalpy,                 & ! interior ice enthalpy (J m^{-3})
+           internalMeltRate,         & ! excess internal melt drained to the bed
            heatDissipation             ! interior heat dissipation (deg/s)
 
       real(kind=RKIND), dimension(:), allocatable :: &
@@ -829,6 +830,7 @@ module li_thermal
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
          call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
          call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
+         call mpas_pool_get_array(thermalPool, 'internalMeltRate', internalMeltRate)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature',   basalTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
@@ -1285,6 +1287,7 @@ module li_thermal
                  basalHeatFlux,                &
                  basalConductiveFlux,          &
                  basalWaterThickness,          &
+                 internalMeltRate,             &
                  groundedBasalMassBal)
 
             ! Convert temperatures from Celsius back to Kelvin
@@ -2702,6 +2705,7 @@ module li_thermal
          basalHeatFlux,               &
          basalConductiveFlux,         &
          basalWaterThickness,         &
+         internalMeltRate,            &
          groundedBasalMassBal)
 
       !-----------------------------------------------------------------
@@ -2766,8 +2770,9 @@ module li_thermal
       !-----------------------------------------------------------------
 
       real(kind=RKIND), dimension(:), intent(out):: &
-           groundedBasalMassBal     !< Output: basal mass balance for grounded ice (kg/m^2/s): < 0 for melting, > 0 for freeze-on
-
+           groundedBasalMassBal  !< Output: basal mass balance for grounded ice (kg/m^2/s): < 0 for melting, > 0 for freeze-on
+      real(kind=RKIND), dimension(:,:), intent(out):: &
+           internalMeltRate         !< Output: excess internal melt drained to the bed
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -2782,7 +2787,6 @@ module li_thermal
       real(kind=RKIND) :: netBasalFlux          ! heat flux available for basal melting (W/m^2)
       real(kind=RKIND) :: layerThickness        ! layer thickness (m)
       real(kind=RKIND) :: meltEnergy            ! energy available for internal melting (J/m^2)
-      real(kind=RKIND) :: internalMeltRate      ! internal melt rate, transferred to bed (m/s)
       real(kind=RKIND) :: excessWater           ! thickness of excess meltwater (m)
 
       real(kind=RKIND) :: maxwaterFrac          ! maximum allowed water fraction; excess drains to bed
@@ -2798,6 +2802,7 @@ module li_thermal
       ! Compute melt rate for grounded ice
 
       groundedBasalMassBal(:) = 0.0_RKIND
+      internalMeltRate(:,:) = 0.0_RKIND
 
       do iCell = 1, nCellsSolve
 
@@ -2864,12 +2869,8 @@ module li_thermal
                      ! compute melt rate associated with excess water
                      excessWater = (waterFrac(k,iCell) - maxwaterFrac) * thickness(iCell) * (layerInterfaceSigma(k+1) &
                         - layerInterfaceSigma(k))  ! m
-                     internalMeltRate = excessWater / deltat
-
-                     ! transfer meltwater to the bed
-                     ! Note: It is possible to have internal melting for floating ice.
-                     !       If so, then this melting will later be switched from groundedBasalMassBall to floatingBasalMassBal.
-                     groundedBasalMassBal(iCell) = groundedBasalMassBal(iCell) - internalMeltRate      ! m/s
+                     internalMeltRate(k, iCell) = excessWater / deltat
+                     ! transfer meltwater to the bed in mpas_li_advection.F
 
                      ! reset waterFrac to max value
                      waterFrac(k,iCell) = maxwaterFrac
@@ -2892,12 +2893,9 @@ module li_thermal
                      ! compute excess energy available for melting
                      layerThickness = thickness(iCell) * (layerInterfaceSigma(k+1) - layerInterfaceSigma(k))     ! m
                      meltEnergy = rhoi*cp_ice * (temperature(k,iCell) - pmpTemperature(k)) * layerThickness    ! J/m^2
-                     internalMeltRate = meltEnergy / (rhoi * latent_heat_ice * deltat)  ! m/s
+                     internalMeltRate(k, iCell) = meltEnergy / (rhoi * latent_heat_ice * deltat)  ! m/s
 
-                     ! transfer meltwater to the bed
-                     ! Note: It is possible to have internal melting for floating ice.
-                     !       If so, then this melting will later be switched from groundedBasalMassBall to floatingBasalMassBal.
-                     groundedBasalMassBal(iCell) = groundedBasalMassBal(iCell) - internalMeltRate      ! m/s
+                     ! transfer meltwater to the bed in mpas_li_advection.F
 
                      ! reset T to Tpmp
                      temperature(k,iCell) = pmpTemperature(k)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -1331,23 +1331,9 @@ module li_thermal
          end select   ! config_thermal_solver
 
          ! It is possible that internal melting was computed above for floating ice and assigned
-         !  to the groundedBasalMassBal array.  If so, then add it to floatingBasalMassBal.
+         ! to the groundedBasalMassBal array.  If so, then this is added to basalMassBal for floating cells in
+         ! mpas_li_advection.F. floatingBasalMassBal should never be altered because it is an input variable.
          ! Note: Subroutine basal_melt_floating_ice should be called earlier in the time step, before adding this term.
-
-         do iCell = 1, nCellsSolve
-
-            if (thermalCellMask(iCell) == 1 .and. li_mask_is_floating_ice(cellMask(iCell)) .and. &
-                 groundedBasalMassBal(iCell) /= 0.0_RKIND) then
-               floatingBasalMassBal(iCell) = floatingBasalMassBal(iCell) + groundedBasalMassBal(iCell)
-               groundedBasalMassBal(iCell) = 0.0_RKIND
-            endif
-
-            if (config_print_thermal_info .and. indexToCellID(iCell) == config_stats_cell_ID) then
-               call mpas_log_write('indexToCellID=$i, basal mass balance (m/yr): grounded=$r, floating=$r', &
-                    intArgs=(/indexToCellID(iCell)/), realArgs=(/groundedBasalMassBal(iCell)*scyr/rhoi, floatingBasalMassBal(iCell)*scyr/rhoi/) )
-            endif
-
-         enddo
 
          ! clean up
          call mpas_deallocate_scratch_field(thermalCellMaskField, .true.)


### PR DESCRIPTION
The field floatingBasalMassBal should not be modified based on internal melting because it is an input variable. Instead assigning internal melting directly to floatingBasalMassBal, assign internal melting to a new drainedInternalMeltRate field that later gets added to the basalMassBal field instead. This involves moving this reassignment from mpas_li_thermal.F to mpas_li_advection.F before mass balance fields are applied to the ice thickness.