### PR TITLE
Check for dynamic ice that is at the end of non-dynamic peninsula

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1396,8 +1396,8 @@ module li_advection
            thicknessTracerTendency, &! net thickness*tracer tendency for a cell
            newThicknessTracers       ! new values of thickness*tracer
 
-      real (kind=RKIND), parameter :: bigNumber = 1.0e16_RKIND
-      ! This is ~300 million years in seconds, but it is small enough not to overflow
+      real (kind=RKIND), parameter :: bigNumber = 1.0e11_RKIND
+      ! This is ~5000 years in seconds, but it is small enough not to overflow
 
       real(kind=RKIND) :: velSign     ! = 1.0_RKIND or -1.0_RKIND depending on sign of velocity
       real(kind=RKIND) :: GLfluxSign
@@ -1675,8 +1675,8 @@ module li_advection
 
       integer :: iEdge, k
 
-      real (kind=RKIND), parameter :: bigNumber = 1.0e16_RKIND
-      ! This is ~300 million years in seconds, but is small enough not to overflow
+      real (kind=RKIND), parameter :: bigNumber = 1.0e11_RKIND
+      ! This is ~5000 years in seconds, but is small enough not to overflow
 
       err = 0
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3835,8 +3835,20 @@ module li_calving
 
       call mpas_log_write("Iceberg-detection flood-fill initialization complete.")
       
-      where ( seedMask == 0 .and. li_mask_is_floating_ice(cellMask(:)) )
+      where ( (seedMask == 0) .and. li_mask_is_floating_ice(cellMask(:)) .and. li_mask_is_dynamic_ice(cellMask(:)) )
              growMask = 1
+      endwhere
+      call flood_fill(seedMask, growMask, domain)
+
+      ! Add floating non-dynamic fringe, but exclude dynamic ice isolated by
+      ! non-dynamic ice, which can cause velocity solver to fail to converge.
+      ! This is a bit of an expensive solution to this problem
+      ! that may only occur once in a while, so we might need to revisit this.
+      
+      where ( li_mask_is_floating_ice(cellMask(:)) .and. .not. li_mask_is_dynamic_ice(cellMask(:)) )
+             growMask = 1
+      elsewhere
+             growMask = 0
       endwhere
       call flood_fill(seedMask, growMask, domain)
       

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_diagnostic_vars.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_diagnostic_vars.F
@@ -235,8 +235,8 @@ contains
       real (kind=RKIND) :: slopeCellMagnitude
       real (kind=RKIND) :: dCell
       integer :: iCell, iEdge, iLevel
-      real (kind=RKIND), parameter :: bigNumber = 1.0e16_RKIND
-      !<- This is ~300 million years in seconds, but it is small enough not too overflow
+      real (kind=RKIND), parameter :: bigNumber = 1.0e11_RKIND
+      !<- This is 5000 years in seconds.  Small enough to avoid timekeeping overflow
       real (kind=RKIND), parameter :: smallNumber = 1.0e-36_RKIND
       logical :: divideSingularityFound
 


### PR DESCRIPTION
Do the flood-fill in two steps in subroutine remove_icebergs. First, fill from grounded ice into the dynamic ice shelf. Then, fill from the dynamic shelf into the non-dynamic cells. This will eliminate the case in which an iceberg of dynamic cells is connected to the rest of the ice shelf by non-dynamic cells. For some cases, this may be an overly expensive solution to an issue that only happens once in a while, but for a test run on Thwaites_1to8km_r03_20220719 mesh with active von Mises and damage threshold calving and ISMIP6 sub-shelf melting (UKESM forcing), this increased throughput from 5 SYPH to >7.25 SYPH and prevented the velocity solver from failing to converge.