### PR TITLE
Fix regionalStats GL migration flux bug

### DIFF
--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -411,6 +411,7 @@ contains
 
             ! GL migration flux
             blockRegionGLMigrationFlux(iRegion) = blockRegionGLMigrationFlux(iRegion) + &
+               real(regionCellMasks(iRegion,iCell),RKIND) * &
                groundedToFloatingThickness(iCell) * areaCell(iCell) * rhoi / (deltat / scyr)
 
            end do ! end loop over regions


### PR DESCRIPTION
This merge fixes a bug in the calculation of regional grounding line migration flux.
