### PR TITLE
Initialize variables that are used when MALI is coupled to the SLM

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -461,6 +461,12 @@ contains
          allocate(globalArrayThickness(nCellsGlobal), gatheredArrayThickness(nCellsGlobal))
          allocate(globalArrayBedTopography(nCellsGlobal), gatheredArrayBedTopography(nCellsGlobal))
          allocate(meshMask(nCellsGlobal))
+         ismIceload(:,:) = 0.0
+         ismBedtopo(:,:) = 0.0
+         ismMask(:,:) = 0.0
+         bedtopoSLgrid1D(:) = 0.0
+         thicknessSLgrid1D(:) = 0.0
+         maskSLgrid1D(:) = 0.0
       else
          ! Intel requires these be allocated even though they are not meaningful on the non-destination procs
          allocate(globalArrayThickness(1), gatheredArrayThickness(1))
@@ -619,6 +625,12 @@ contains
          allocate(globalArrayThickness(nCellsGlobal), gatheredArrayThickness(nCellsGlobal))
          allocate(globalArrayTopoChange(nCellsGlobal), gatheredArrayTopoChange(nCellsGlobal))
          allocate(meshMask(nCellsGlobal))
+         ismIceload(:,:) = 0.0
+         ismMask(:,:) = 0.0
+         slmSLchange(:,:) = 0.0
+         slChangeSLgrid1D(:) = 0.0
+         thicknessSLgrid1D(:) = 0.0
+         maskSLgrid1D(:) = 0.0
       else
          ! Intel requires these be allocated even though they are not meaningful on the non-destination procs
          allocate(globalArrayThickness(1), gatheredArrayThickness(1))


### PR DESCRIPTION
Previously, the variables defined in `mpas_li_bedtopo.F` that are used when MALI is coupled to the sea-level model were not initialized. This caused the the variables to contain garbage values that resulted in incorrect outputs from coupled MALI-SLM simulations. This PR fixes the problem by initializing the values of the variables to zero before every time MALI calls the SLM. 