### PR TITLE
Bug fixes for evolving calving simulations

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1151,6 +1151,9 @@ is the value of that variable from the *previous* time level!
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on cells.  cellMask only needs to be a restart field if config_allow_additional_advance = false (to keep the mask of initial ice extent)"
                 />
+                <var name="cellMaskPrevious" type="integer" dimensions="nCells Time" units="none"
+                     description="cellMask from the previous timestep"
+                />
                 <var name="edgeMask" type="integer" dimensions="nEdges Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on edges."
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -792,6 +792,7 @@
                         <var name="heatDissipation" packages="thermal"/>
                         <var name="betaSolve" packages="thermal"/>
 			<var name="cellMask"/>
+			<var name="cellMaskPrevious"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>
                         <var name="floatingBasalMassBal"/>

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -384,7 +384,7 @@ module li_calving
       type (mpas_pool_type), pointer :: scratchPool
       type (mpas_pool_type), pointer :: velocityPool
 
-      integer, pointer :: nCellsSolve, nVertLevels
+      integer, pointer :: nCells, nVertLevels
 
       logical, pointer :: &
            config_print_calving_info
@@ -448,7 +448,7 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
 
          ! get dimensions
-         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
          ! get required fields from the mesh pool
@@ -514,7 +514,7 @@ module li_calving
          restoreThickness = 0.0_RKIND
 
          ! loop over locally owned cells
-         do iCell = 1, nCellsSolve
+         do iCell = 1, nCells
 
             if (bedTopography(iCell) < config_sea_level) then
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -1661,7 +1661,7 @@ module li_calving
                       config_grounded_von_Mises_threshold_stress_source, MPAS_LOG_ERR)
           endif
 
-          if ( minval(groundedVonMisesThresholdStress(:)) <= 0.0_RKIND ) then
+          if ( minval(groundedVonMisesThresholdStress(1:nCells)) <= 0.0_RKIND ) then
                 err = 1
                 call mpas_log_write("groundedVonMisesThresholdStress must be >0.0", MPAS_LOG_ERR)
           endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -107,11 +107,12 @@ module li_core
       logical, pointer :: config_do_restart
       real (kind=RKIND), pointer :: deltat  ! variable in each block
       real (kind=RKIND) :: dtSeconds ! local variable
-      type (MPAS_Pool_type), pointer :: meshPool
+      type (MPAS_Pool_type), pointer :: meshPool, geometryPool, velocityPool
       type (MPAS_TimeInterval_type) :: timeStepInterval
       character (len=StrKIND), pointer :: xtime, simulationStartTime
       real (kind=RKIND), pointer :: daysSinceStart
       integer, dimension(:), pointer :: cellProcID
+      integer, dimension(:), pointer :: cellMask, cellMaskPrevious
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_stream_list_type), pointer :: stream_cursor
       type (MPAS_Alarm_type), pointer :: alarm_cursor
@@ -222,9 +223,12 @@ module li_core
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          ! Assign initial time stamp
          call mpas_pool_get_array(meshPool, 'xtime', xtime)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
          xtime = startTimeStamp
 
          ! Set simulationStartTime on a cold start only - it should have been read from restart otherwise
@@ -251,13 +255,19 @@ module li_core
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          deltat = dtSeconds
 
+         if (config_do_restart) then
+             cellMaskPrevious = cellMask
+             call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+          else
+             call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp, firstCall=.true.)
+          endif
+
          block => block % next
       end do
 
       ! ===
       ! === Initialize modules ===
       ! ===
-
       call li_velocity_init(domain, err_tmp)
       err = ior(err, err_tmp)
 
@@ -783,15 +793,8 @@ module li_core
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
 
-         if (config_do_restart) then
-            cellMaskPrevious = cellMask
-            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         else
-            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp, firstCall=.true.)
-         endif
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -386,6 +386,7 @@ module li_core
       logical :: isRinging
       integer :: restartTimestampUnit
 
+      integer, dimension(:), pointer :: cellMask, cellMaskPrevious
       integer :: err, err_tmp, err_tmp2, globalErr
 
 
@@ -441,6 +442,14 @@ module li_core
          ! === Perform Timestep
          ! ===
          call mpas_timer_start("time integration")
+
+         do while(associated(block))
+            call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+            call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+            call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
+            cellMaskPrevious = cellMask
+            block => block % next
+         end do
 
          call li_timestep(domain, err_tmp)
          err = ior(err,err_tmp)
@@ -725,6 +734,7 @@ module li_core
       character(len=StrKIND) :: timeStamp
       real(kind=RKIND), pointer :: deltat
       real(kind=RKIND) :: deltatTemp
+      integer, dimension(:), pointer :: cellMask, cellMaskPrevious
 
       integer :: err, err_tmp, globalErr
       logical :: solveVelo
@@ -773,8 +783,15 @@ module li_core
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         if (config_do_restart) then
+            cellMaskPrevious = cellMask
+            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         else
+            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp, firstCall=.true.)
+         endif
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -112,7 +112,6 @@ module li_core
       character (len=StrKIND), pointer :: xtime, simulationStartTime
       real (kind=RKIND), pointer :: daysSinceStart
       integer, dimension(:), pointer :: cellProcID
-      integer, dimension(:), pointer :: cellMask, cellMaskPrevious
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_stream_list_type), pointer :: stream_cursor
       type (MPAS_Alarm_type), pointer :: alarm_cursor
@@ -227,8 +226,6 @@ module li_core
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          ! Assign initial time stamp
          call mpas_pool_get_array(meshPool, 'xtime', xtime)
-         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
          xtime = startTimeStamp
 
          ! Set simulationStartTime on a cold start only - it should have been read from restart otherwise
@@ -254,13 +251,6 @@ module li_core
          ! Initialize dt in seconds
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          deltat = dtSeconds
-
-         if (config_do_restart) then
-             cellMaskPrevious = cellMask
-             call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-          else
-             call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp, firstCall=.true.)
-          endif
 
          block => block % next
       end do
@@ -955,6 +945,7 @@ module li_core
       !-----------------------------------------------------------------
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: velocityPool
       integer, dimension(:), pointer :: vertexMask
       real (kind=RKIND), dimension(:), pointer :: thickness, thicknessOld
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness
@@ -970,6 +961,7 @@ module li_core
       ! Get pool stuff
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
       call mpas_pool_get_config(liConfigs, 'config_do_velocity_reconstruction_for_external_dycore', &
          config_do_velocity_reconstruction_for_external_dycore)
@@ -1024,7 +1016,7 @@ module li_core
       endif
 
       ! Mask init identifies initial ice extent
-      call li_calculate_mask_init(geometryPool, err=err_tmp)
+      call li_calculate_mask_init(meshPool, geometryPool, velocityPool, err=err_tmp)
       err = ior(err, err_tmp)
 
       ! Initialize thicknessOld variable used to calculate dHdt

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -246,7 +246,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_mask(meshPool, velocityPool, geometryPool, err)
+   subroutine li_calculate_mask(meshPool, velocityPool, geometryPool, err, firstCall)
 
       !-----------------------------------------------------------------
       !
@@ -259,6 +259,8 @@ contains
 
       type (mpas_pool_type), intent(inout) :: &
          velocityPool          !< Input: velocity information
+
+      logical, intent(in), optional :: firstCall ! If this is the first time called
 
       !-----------------------------------------------------------------
       !
@@ -285,6 +287,7 @@ contains
       integer, pointer :: nVertInterfaces
       real(KIND=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:), pointer :: nEdgesOnCell, cellMask, vertexMask, edgeMask
+      integer, dimension(:), pointer :: cellMaskPrevious
       integer, dimension(:,:), pointer :: cellsOnCell, cellsOnVertex, cellsOnEdge, dirichletVelocityMask
       real (kind=RKIND), pointer :: config_ice_density, config_ocean_density, &
             config_sea_level, config_dynamic_thickness
@@ -306,10 +309,18 @@ contains
       real (kind=RKIND) :: thinnestNeighborHeight
       integer :: iCellNeighbor
       logical :: openOceanNeighbor
+      real (kind=RKIND), parameter :: activeFraction = 0.95_RKIND ! thickness threshold of neighboring cell thickness for a floating cell to be dynamic
+      logical :: firstCall_local
 
       call mpas_timer_start('calculate mask')
 
       err = 0
+
+      if (present(firstCall)) then
+         firstCall_local = firstCall
+      else
+         firstCall_local = .false.
+      endif
 
       ! Assign pointers and variables
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -325,6 +336,7 @@ contains
 
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask, timeLevel=1)
+      call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel=1)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -379,32 +391,81 @@ contains
       enddo
 
       ! Identify cells where the ice is above the ice dynamics thickness limit
-      where ( thickness > config_dynamic_thickness )
-         cellMask = ior(cellMask, li_mask_ValueDynamicIce)
-      end where
-      ! Exclude floating margin cells that are thinner than all their non-margin neighbors
-       do i=1,nCells
-          if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
-              openOceanNeighbor = .false.
-              thinnestNeighborHeight = 1.0e36_RKIND
-              do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
-                 iCellNeighbor = cellsOnCell(j,i)
-                 if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
-                    thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
-                 endif
-                 if ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) then
-                    openOceanNeighbor = .true.
-                 endif
-              enddo
-              if ((openOceanNeighbor) .and. (thickness(i) < 0.95_RKIND * thinnestNeighborHeight)) then
-                 ! Consider this NOT dynamic if the ice shelf margin is not almost as tall as it's inland neighbors.
-                 ! Only do this for a non-dynamic cell adjacent to open ocean.
-                 ! (if the floating cell was marked as a margin because it is adjacent to ice-free land,
-                 !  we want to still consider it as dynamic)
-                 cellMask(i) = iand(cellMask(i), not(li_mask_ValueDynamicIce))  ! (turn off this bit)
-              endif
-          endif
-      enddo
+      if (firstCall_local) then
+         where ( thickness > config_dynamic_thickness )
+            cellMask = ior(cellMask, li_mask_ValueDynamicIce)
+         end where
+         ! Exclude floating margin cells that are thinner than all their non-margin neighbors
+         do i=1,nCells
+            if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
+                openOceanNeighbor = .false.
+                thinnestNeighborHeight = 1.0e36_RKIND
+                do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                   iCellNeighbor = cellsOnCell(j,i)
+                   if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
+                      thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
+                   endif
+                   if ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) then
+                      openOceanNeighbor = .true.
+                   endif
+                enddo
+                if ((openOceanNeighbor) .and. (thickness(i) < activeFraction * thinnestNeighborHeight)) then
+                   ! Consider this NOT dynamic if the ice shelf margin is not almost as tall as it's inland neighbors.
+                   ! Only do this for a non-dynamic cell adjacent to open ocean.
+                   ! (if the floating cell was marked as a margin because it is adjacent to ice-free land,
+                   !  we want to still consider it as dynamic)
+                   cellMask(i) = iand(cellMask(i), not(li_mask_ValueDynamicIce))  ! (turn off this bit)
+                endif
+            endif
+         enddo
+      else ! if not first solve then do this
+         do i=1,nCells
+            if (li_mask_is_grounded_ice(cellMask(i))) then
+               if (thickness(i) > config_dynamic_thickness) then
+                  cellMask(i) = ior(cellMask(i), li_mask_ValueDynamicIce)
+               endif
+            endif
+            if (li_mask_is_floating_ice(cellMask(i))) then
+               ! For floating ice, if it was non-dynamic before, it should remain nondynamic until it meets the thickness thresh
+               ! If it was dynamic before, follow the rules on initialization
+               if (.not. li_mask_is_dynamic_ice(cellMaskPrevious(i))) then
+                  thinnestNeighborHeight = 1.0e36_RKIND
+                  do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                     iCellNeighbor = cellsOnCell(j,i)
+                     if ((li_mask_is_floating_ice(cellMask(iCellNeighbor)) .and.  li_mask_is_dynamic_ice(cellMaskPrevious(iCellNeighbor))) .or. &
+                         (li_mask_is_grounded_ice(cellMask(iCellNeighbor)) .and. thickness(iCellNeighbor) > config_dynamic_thickness)) then
+                        thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
+                     endif
+                  enddo
+                  if (thickness(i) >= activeFraction * thinnestNeighborHeight) then
+                     cellMask(i) = ior(cellMask(i), li_mask_ValueDynamicIce)
+                  endif
+               else ! this was already dynamic before, so follow the standard rules
+                 ! Exclude floating margin cells that are thinner than all their non-margin neighbors
+                    if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
+                       openOceanNeighbor = .false.
+                       thinnestNeighborHeight = 1.0e36_RKIND
+                       do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                          iCellNeighbor = cellsOnCell(j,i)
+                          if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
+                             thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
+                          endif
+                          if ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) then
+                             openOceanNeighbor = .true.
+                          endif
+                       enddo ! neigbors
+                       if ((openOceanNeighbor) .and. (thickness(i) < activeFraction * thinnestNeighborHeight)) then
+                          ! Consider this NOT dynamic if the ice shelf margin is not almost as tall as it's inland neighbors.
+                          ! Only do this for a non-dynamic cell adjacent to open ocean.
+                          ! (if the floating cell was marked as a margin because it is adjacent to ice-free land,
+                          !  we want to still consider it as dynamic)
+                          cellMask(i) = iand(cellMask(i), not(li_mask_ValueDynamicIce))  ! (turn off this bit)
+                       endif
+                    endif ! margin and floating
+              endif ! if already dynamic before
+            endif ! if floating
+         enddo ! loop over cells
+      endif ! if first solve or not
 
       ! Identify cells that Albany would consider as active
       if ( (trim(config_velocity_solver) == 'L1L2') .or. &
@@ -468,6 +529,10 @@ contains
               enddo
           endif
       enddo
+
+      if (firstCall_local) then
+         cellMaskPrevious = cellMask ! need to initialize it
+      endif
 
       !call mpas_timer_stop('calculate mask cell')
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -442,27 +442,28 @@ contains
                      cellMask(i) = ior(cellMask(i), li_mask_ValueDynamicIce)
                   endif
                else ! this was already dynamic before, so follow the standard rules
-                 ! Exclude floating margin cells that are thinner than all their non-margin neighbors
-                    if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
-                       openOceanNeighbor = .false.
-                       thinnestNeighborHeight = 1.0e36_RKIND
-                       do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
-                          iCellNeighbor = cellsOnCell(j,i)
-                          if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
-                             thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
-                          endif
-                          if ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) then
-                             openOceanNeighbor = .true.
-                          endif
-                       enddo ! neigbors
-                       if ((openOceanNeighbor) .and. (thickness(i) < activeFraction * thinnestNeighborHeight)) then
-                          ! Consider this NOT dynamic if the ice shelf margin is not almost as tall as it's inland neighbors.
-                          ! Only do this for a non-dynamic cell adjacent to open ocean.
-                          ! (if the floating cell was marked as a margin because it is adjacent to ice-free land,
-                          !  we want to still consider it as dynamic)
-                          cellMask(i) = iand(cellMask(i), not(li_mask_ValueDynamicIce))  ! (turn off this bit)
-                       endif
-                    endif ! margin and floating
+                  cellMask(i) = ior(cellMask(i), li_mask_ValueDynamicIce)  ! initialize to dynamic, then disable below if appropriate
+                  ! Exclude floating margin cells that are thinner than all their non-margin neighbors
+                  if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
+                     openOceanNeighbor = .false.
+                     thinnestNeighborHeight = 1.0e36_RKIND
+                     do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                        iCellNeighbor = cellsOnCell(j,i)
+                        if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
+                           thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
+                        endif
+                        if ((bedTopography(iCellNeighbor) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCellNeighbor)))) then
+                           openOceanNeighbor = .true.
+                        endif
+                     enddo ! neigbors
+                     if ((openOceanNeighbor) .and. (thickness(i) < activeFraction * thinnestNeighborHeight)) then
+                        ! Consider this NOT dynamic if the ice shelf margin is not almost as tall as it's inland neighbors.
+                        ! Only do this for a non-dynamic cell adjacent to open ocean.
+                        ! (if the floating cell was marked as a margin because it is adjacent to ice-free land,
+                        !  we want to still consider it as dynamic)
+                        cellMask(i) = iand(cellMask(i), not(li_mask_ValueDynamicIce))  ! (turn off this bit)
+                     endif
+                  endif ! margin and floating
               endif ! if already dynamic before
             endif ! if floating
          enddo ! loop over cells

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -392,6 +392,7 @@ contains
 
       ! Identify cells where the ice is above the ice dynamics thickness limit
       if (firstCall_local) then
+         call mpas_log_write("First call to li_calculate_mask:  Initializing floating dynamic mask.")
          where ( thickness > config_dynamic_thickness )
             cellMask = ior(cellMask, li_mask_ValueDynamicIce)
          end where

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -169,13 +169,18 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_mask_init(geometryPool, err)
+   subroutine li_calculate_mask_init(meshPool, geometryPool, velocityPool, err)
 
       !-----------------------------------------------------------------
       !
       ! input variables
       !
       !-----------------------------------------------------------------
+      type (mpas_pool_type), intent(inout) :: &
+         meshPool          !< Input: mesh information
+
+      type (mpas_pool_type), intent(inout) :: &
+         velocityPool          !< Input: velocity information
 
       !-----------------------------------------------------------------
       !
@@ -198,6 +203,7 @@ contains
       !
       !-----------------------------------------------------------------
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: cellMaskPrevious
       real(KIND=RKIND), dimension(:), pointer :: thickness
       logical, pointer :: config_do_restart
       integer, pointer :: config_num_halos, config_number_of_blocks
@@ -208,6 +214,7 @@ contains
 
       ! Assign pointers and variables
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask, timeLevel=1)
+      call mpas_pool_get_array(geometryPool, 'cellMaskPrevious', cellMaskPrevious)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
       call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
@@ -226,6 +233,12 @@ contains
          where (thickness > 0.0_RKIND)
             cellMask = ior(cellMask, li_mask_ValueInitialIceExtent)
          end where
+         ! calculate mask, indicating this is the first call to initialize the floating dynamic mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp, firstCall=.true.)
+      else
+         ! On a restart, set cellMaskPrevious to the cellMask field read from the restart file
+         !cellMaskPrevious = cellMask
+         !call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
       endif
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -401,7 +401,7 @@ contains
             if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
                 openOceanNeighbor = .false.
                 thinnestNeighborHeight = 1.0e36_RKIND
-                do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                do j=1,nEdgesOnCell(i) ! Find height of thinnest neighbor
                    iCellNeighbor = cellsOnCell(j,i)
                    if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
                       thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))
@@ -431,7 +431,7 @@ contains
                ! If it was dynamic before, follow the rules on initialization
                if (.not. li_mask_is_dynamic_ice(cellMaskPrevious(i))) then
                   thinnestNeighborHeight = 1.0e36_RKIND
-                  do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                  do j=1,nEdgesOnCell(i) ! Find height of thinnest neighbor
                      iCellNeighbor = cellsOnCell(j,i)
                      if ((li_mask_is_floating_ice(cellMask(iCellNeighbor)) .and.  li_mask_is_dynamic_ice(cellMaskPrevious(iCellNeighbor))) .or. &
                          (li_mask_is_grounded_ice(cellMask(iCellNeighbor)) .and. thickness(iCellNeighbor) > config_dynamic_thickness)) then
@@ -447,7 +447,7 @@ contains
                   if (li_mask_is_margin(cellMask(i)) .and. li_mask_is_floating_ice(cellMask(i))) then
                      openOceanNeighbor = .false.
                      thinnestNeighborHeight = 1.0e36_RKIND
-                     do j=1,nEdgesOnCell(i) ! Find height of thickest neighbor
+                     do j=1,nEdgesOnCell(i) ! Find height of thinnest neighbor
                         iCellNeighbor = cellsOnCell(j,i)
                         if (thickness(iCellNeighbor) > 0.0_RKIND .and. .not. li_mask_is_margin(cellMask(iCellNeighbor))) then
                            thinnestNeighborHeight = min(thinnestNeighborHeight, thickness(iCellNeighbor))


### PR DESCRIPTION
This PR includes three small bug fixes for evolving calving simulations:
* fixes a check on vM stress values when using a spatial map of values
* fixes a bug in halo values when using restore_calving.  This would lead to garbage temperature values that could keep the solver from the converging.
* changes the definition of floating dynamic ice to avoid edge cases from appearing that lead to large velocity differences for very small thickness changes due to mask changes.  This requires keeping track of the previous dynamic mask, which changes behavior of a cold start vs. a restart.