### PR TITLE
Add new field fluxAcrossGroundingLineOnCells

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1478,6 +1478,9 @@ is the value of that variable from the *previous* time level!
                 <var name="fluxAcrossGroundingLine" type="real" dimensions="nEdges Time" units="m^2 s^{-1}"
                      description="flux across grounding line per unit width.  Positive means flux goes from grounded to floating ice."
                 />
+                <var name="fluxAcrossGroundingLineOnCells" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}"
+                     description="flux across grounding line per unit area normal to a vertical plan aligned with the grounding line.  This variable is calculated on cells and is for the purposes of reporting the ISMIP6 variable ligroundf.  Positive means flux goes from grounded to floating ice."
+                />
 		<var name="vonMisesStress" type="real" dimensions="nCells Time" units="Pa"
 		     description="von Mises stress used for calving law"
 		/>

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -149,7 +149,8 @@ module li_advection
            floatingBasalMassBalApplied,  & ! basal mass balance for floating ice limited by ice thickness
            dynamicThickening,     & ! dynamic thickening rate
            groundedToFloatingThickness, & ! thickness changing from grounded to floating or vice versa
-           fluxAcrossGroundingLine        ! magnitude of flux across GL
+           fluxAcrossGroundingLine, &     ! magnitude of flux across GL
+           fluxAcrossGroundingLineOnCells ! magnitude of flux across GL, calculated on cells
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,           & ! interior ice temperature
@@ -211,7 +212,7 @@ module li_advection
 
       logical :: advectTracers     ! if true, then advect tracers as well as thickness
 
-      integer :: iCell1
+      integer :: iCell1, iCell2, theGroundedCell
 
       real(kind=RKIND) :: GLfluxSign, thicknessFluxEdge
 
@@ -277,6 +278,7 @@ module li_advection
       ! get arrays from the velocity pool
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
+      call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
 
       ! get arrays from the thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -423,7 +425,6 @@ module li_advection
               edgeMask,                &
               layerThickness,          &
               advectedTracers,         &
-              fluxAcrossGroundingLine,       &
               err)
 
          if (config_print_thickness_advection_info) then
@@ -545,19 +546,31 @@ module li_advection
          ! Calculate flux across grounding line
          ! Do this after new thickness & mask have been calculated, including SMB/BMB
          fluxAcrossGroundingLine(:) = 0.0_RKIND
+         fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
          do iEdge = 1, nEdges
             if (li_mask_is_grounding_line(edgeMask(iEdge))) then
                iCell1 = cellsOnEdge(1,iEdge)
-               !iCell2 = cellsOnEdge(2,iEdge)
+               iCell2 = cellsOnEdge(2,iEdge)
                if (li_mask_is_grounded_ice(cellMask(iCell1))) then
                   GLfluxSign = 1.0_RKIND ! edge sign convention is positive from iCell1 to iCell2 on an edge
+                  theGroundedCell = iCell1
                else
                   GLfluxSign = -1.0_RKIND
+                  theGroundedCell = iCell2
                endif
                do k = 1, nVertLevels
                   thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
                   fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
                enddo
+               ! assign to grounded cell in fluxAcrossGroundingLineOnCells
+               if (thickness(theGroundedCell) <= 0.0_RKIND) then
+                  ! This should never be the case, but checking to avoid possible divide by zero
+                  call mpas_log_write("thickness at a grounding line is unexepectedly <=0", MPAS_LOG_ERR)
+                  err = ior(err, 1)
+                  return
+               endif
+               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
+                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
             endif
          enddo ! edges
 
@@ -1318,7 +1331,6 @@ module li_advection
          edgeMask,               &
          layerThicknessNew,      &
          tracersNew,             &
-         fluxAcrossGroundingLine,      &
          err,                    &
          advectTracersIn)
 
@@ -1371,9 +1383,6 @@ module li_advection
 
       real (kind=RKIND), dimension(:,:,:), intent(out) :: &
            tracersNew            !< Output: tracer values
-
-      real (kind=RKIND), dimension(:), intent(out) :: &
-           fluxAcrossGroundingLine     !< Output: ice flux at grounding lines
 
       integer, intent(out) :: &
            err                   !< Output: error flag


### PR DESCRIPTION
This merge adds a new field, fluxAcrossGroundingLineOnCells, which is the GL flux definition required for the ligroundf field required by ISMIP6.  Calculating it within MALI allows us to calculate it fully accurately and eliminates a slow post-processing calculation.