### PR TITLE
Calving mask and restore calving improvements

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -193,7 +193,11 @@
 		            possible_values="Any non-negative real value"
 		/>
 		<nml_option name="config_restore_calving_front" type="logical" default_value=".false." units="unitless"
-                        description="If true, then restore the calving front to its initial position.  If ice grows beyond the initial extent, it is removed.  If ice shrinks to an extent behind the initial extent, those locations are filled with thin ice (defined as 1/10th the value of config_dynamic_thickness).  Note that this violates conservation of mass and energy."
+                        description="If true, then restore the calving front to its initial position.  If ice grows beyond the initial extent, it is removed.  If ice shrinks to an extent behind the initial extent, behavior is determined by config_restore_calving_front_prevent_retreat.  If that option is true, then those locations are filled with thin ice (defined as 1/10th the value of config_dynamic_thickness).  Note that this violates conservation of mass and energy."
+		            possible_values=".true. or .false."
+                />
+		<nml_option name="config_restore_calving_front_prevent_retreat" type="logical" default_value=".true." units="unitless"
+                        description="If true, then the config_restore_calving_front option will fill locations where ice shelves have retreated with a thin layer of ice.  This option should be used in E3SM when the ice shelf extent seen by the E3SM coupler cannot change.  If false, the config_restore_calving_front option will do nothing when ice shelves retreat.  For either value of this option, the config_restore_calving_front option will prevent ice-shelf advance.  True is likely the desired value for standalone runs where no advance is desired.  Default value is true for backwards compatibility."
 		            possible_values=".true. or .false."
                 />
                 <nml_option name="config_remove_icebergs" type="logical" default_value=".false." units="unitless"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -154,7 +154,11 @@
 	<nml_record name="calving" in_defaults="true">
 		<nml_option name="config_calving" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for calving ice (as defined below). 'von_Mises_stress' and 'eigencalving' options can be used in combination with damage threshold calving (see descrption of config_damage_calving_method for details)."
-		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'mask', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving', 'ismip6_retreat'"
+		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving', 'ismip6_retreat'"
+		/>
+                <nml_option name="config_apply_calving_mask" type="logical" default_value=".false." units="unitless"
+			    description="Whether the field 'calvingMask' gets used to force calving.  This is independent of choice of `config_calving'; the application of 'calvingMask' can be applied in conjunction with a physical calving law or with no calving law enabled.  The calving mask gets applied after a physical calving law, if one is selected."
+			    possible_values="'.true.', '.false.'"
 		/>
                 <nml_option name="config_use_Albany_flowA_eqn_for_vM" type="logical" default_value=".false." units="unitless"
 			    description="Not yet supported. Determine whether to use MPAS or Albany calculation for flowParamA used in von Mises stress calving"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -157,12 +157,12 @@
 		            possible_values="'none', 'floating', 'topographic_threshold', 'thickness_threshold', 'eigencalving', 'specified_calving_velocity', 'von_Mises_stress', 'damagecalving', 'ismip6_retreat'"
 		/>
                 <nml_option name="config_apply_calving_mask" type="logical" default_value=".false." units="unitless"
-			    description="Whether the field 'calvingMask' gets used to force calving.  This is independent of choice of `config_calving'; the application of 'calvingMask' can be applied in conjunction with a physical calving law or with no calving law enabled.  The calving mask gets applied after a physical calving law, if one is selected."
-			    possible_values="'.true.', '.false.'"
+			    description="Whether the field 'calvingMask' gets used to force calving.  This is independent of choice of 'config_calving'; the application of 'calvingMask' can be applied in conjunction with a physical calving law or with no calving law enabled.  The calving mask gets applied after a physical calving law, if one is selected."
+			    possible_values=".true. or .false."
 		/>
                 <nml_option name="config_use_Albany_flowA_eqn_for_vM" type="logical" default_value=".false." units="unitless"
 			    description="Not yet supported. Determine whether to use MPAS or Albany calculation for flowParamA used in von Mises stress calving"
-			    possible_values="'.true.', '.false.'"
+			    possible_values=".true. or .false."
 		/>
 		<nml_option name="config_calving_topography" type="real" default_value="-500.0" units="m"
 		            description="Defines the topographic height below which ice calves (for topographic_threshold option)."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1203,6 +1203,9 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                         description="thickness of ice that calves on a given timestep (less than or equal to ice thickness)"
                 />
+                <var name="calvingThicknessFromThreshold" type="real" dimensions="nCells Time" units="m" time_levs="1"
+                        description="thickness of ice that calves on a given timestep for only processes that generate calving based on a threshold.  This includes mask calving, damage calving, iceberg and small island detection, and velocity speed limit."
+                />
                 <var name="calvingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
                         description="approximation of maximum allowable timestep based on calvingVelocity"
                 />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -290,7 +290,6 @@ module li_calving
       ! Consider mask calving as a possible additional step
       ! Mask calving can occur by itself or in conjunction with a physical calving law
       if (config_apply_calving_mask) then
-         call mpas_log_write("Applying calving mask")
          call mask_calving(domain, err_tmp)
          err = ior(err, err_tmp)
       endif
@@ -3701,8 +3700,9 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
       integer, dimension(:), pointer :: calvingMask
       integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nCells
+      integer, pointer :: nCells, nCellsSolve
       integer :: iCell
+      integer :: localMaskCellCount, globalMaskCellCount
       integer :: err_tmp
 
       err = 0
@@ -3718,6 +3718,7 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'calvingMask', calvingMask)
@@ -3728,6 +3729,8 @@ module li_calving
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
+         localMaskCellCount = 0
+
          ! === apply calving ===
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. (calvingMask(iCell) >= 1)) then
@@ -3735,8 +3738,12 @@ module li_calving
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                thickness(iCell) = 0.0_RKIND
+               if (iCell <= nCellsSolve) localMaskCellCount = localMaskCellCount + 1
             endif
          enddo
+
+         call mpas_dmpar_sum_int(domain % dminfo, localMaskCellCount, globalMaskCellCount)
+         call mpas_log_write("Mask calving applied.  Removed $i floating cells with mask.", intArgs=(/globalMaskCellCount/))
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -131,6 +131,9 @@ module li_calving
                                ! typically the entire ice thickness, but will be a fraction of the thickness
                                ! if calving_timescale > dt
 
+      real (kind=RKIND), dimension(:), pointer :: &
+           calvingThicknessFromThreshold   ! thickness of ice that calves from threshold processes (computed in this subroutine)
+
       type (field1dReal), pointer :: originalThicknessField
 
       real (kind=RKIND), dimension(:), pointer :: originalThickness
@@ -160,7 +163,9 @@ module li_calving
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          calvingThickness(:) = 0.0_RKIND
+         calvingThicknessFromThreshold(:) = 0.0_RKIND
          block => block % next
       end do
 
@@ -726,6 +731,9 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: &
            calvingThickness    ! thickness of ice that calves (computed in this subroutine)
 
+      real (kind=RKIND), dimension(:), pointer :: &
+           calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
+
       integer, pointer :: nCells
       integer :: iCell, iCellOnCell, iCellNeighbor
       real (kind=RKIND) :: flotationThickness  ! thickness at which marine-based ice starts to float
@@ -774,6 +782,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
 
          ! get scratch fields for calving
          ! 'true' flag means to allocate the field for a single block
@@ -883,6 +892,7 @@ module li_calving
          where (oceanMask == 1 .and. inactiveMarginMask == 0 .and. thickness > 0.0_RKIND)
             calvingThickness = thickness * calvingFraction
          endwhere
+         calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -934,6 +944,7 @@ module li_calving
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask
 
@@ -947,6 +958,7 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
@@ -956,6 +968,7 @@ module li_calving
          where (li_mask_is_floating_ice(cellMask))
             calvingThickness = thickness * calvingFraction
          endwhere
+         calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -987,6 +1000,7 @@ module li_calving
       logical, pointer :: config_remove_small_islands
       real(kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold    ! thickness of ice that calves (computed in this subroutine)
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: cellMask
@@ -1006,6 +1020,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -1028,6 +1043,7 @@ module li_calving
             if ((nIceNeighbors == 0) .and. (nOpenOceanNeighbors == nEdgesOnCell(iCell))) then
                ! If this is a single cell of ice surrounded by open ocean, kill this location
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                thickness(iCell) = 0.0_RKIND
             elseif (nIceNeighbors == 1) then
                ! check if this neighbor has any additional neighbors with ice
@@ -1046,8 +1062,10 @@ module li_calving
                   ! <- only neighbor with ice must have been iCell
                   ! kill both cells
                   calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+                  calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
                   calvingThickness(neighborWithIce) = calvingThickness(neighborWithIce) + thickness(neighborWithIce)
+                  calvingThicknessFromThreshold(neighborWithIce) = calvingThicknessFromThreshold(neighborWithIce) + thickness(neighborWithIce)
                   thickness(neighborWithIce) = 0.0_RKIND
                endif
 
@@ -1092,6 +1110,7 @@ module li_calving
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool, meshPool
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
       real(kind=RKIND), pointer :: config_calving_topography
       real(kind=RKIND), pointer :: config_sea_level
       logical, pointer :: config_print_calving_info
@@ -1116,6 +1135,7 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -1125,6 +1145,7 @@ module li_calving
          where ( (li_mask_is_floating_ice(cellMask)) .and. (bedTopography < config_calving_topography + config_sea_level) )
             calvingThickness = thickness * calvingFraction
          endwhere
+         calvingThicknessFromThreshold = calvingThickness
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
@@ -3571,6 +3592,7 @@ module li_calving
       type (field1dInteger), pointer :: growMaskField
       integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold !< Output: the applied calving rate as a thickness
       real (kind=RKIND), dimension(:), pointer :: thickness, damage
       real(kind=RKIND), pointer :: config_damage_calving_threshold
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
@@ -3588,6 +3610,7 @@ module li_calving
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -3622,10 +3645,12 @@ module li_calving
                if (li_mask_is_floating_ice(cellMask(jCell)) .and. .not. li_mask_is_dynamic_ice(cellMask(jCell))) then
                   ! this is a thin neighbor - remove the whole cell volume
                   calvingThickness(jCell) = thickness(jCell)
+                  calvingThicknessFromThreshold(jCell) = calvingThicknessFromThreshold(jCell) + thickness(jCell)
                endif
             enddo
 
             calvingThickness(iCell) = thickness(iCell)
+            calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
          endif ! if cell is calving margin
 
       enddo ! cell loop
@@ -3674,8 +3699,11 @@ module li_calving
       type (mpas_pool_type), pointer :: velocityPool
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: calvingThickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
       integer, dimension(:), pointer :: calvingMask
       integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nCells
+      integer :: iCell
       integer :: err_tmp
 
       err = 0
@@ -3690,7 +3718,9 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
 
          ! get fields
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_array(geometryPool, 'calvingMask', calvingMask)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
@@ -3700,10 +3730,14 @@ module li_calving
          err = ior(err, err_tmp)
 
          ! === apply calving ===
-         where (li_mask_is_floating_ice(cellMask) .and. (calvingMask >= 1))
-            calvingThickness = thickness
-            thickness = 0.0_RKIND
-         end where
+         do iCell = 1, nCells
+            if (li_mask_is_floating_ice(cellMask(iCell)) .and. (calvingMask(iCell) >= 1)) then
+               call mpas_log_write("Found masked cell at $i", intArgs=(/iCell/))
+               calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+               calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
+               thickness(iCell) = 0.0_RKIND
+            endif
+         enddo
 
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
@@ -3822,6 +3856,7 @@ module li_calving
       !integer, dimension(:), allocatable :: seedMaskOld !mask of where icebergs are removed, for debugging
 
       real (kind=RKIND), dimension(:), pointer :: calvingThickness    ! thickness of ice that calves (computed in this subroutine)
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold
       real (kind=RKIND), dimension(:), pointer :: thickness
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
@@ -3920,6 +3955,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
          call mpas_pool_get_dimension(geometryPool, 'nCells', nCells)
          call mpas_pool_get_dimension(geometryPool, 'nCellsSolve', nCellsSolve)
          !allocate(seedMaskOld(nCells+1)) ! debug: make this a mask of where icebergs were removed
@@ -3929,6 +3965,7 @@ module li_calving
          do iCell = 1, nCellsSolve
             if (seedMask(iCell) == 0 .and. li_mask_is_floating_ice(cellMask(iCell))) then
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)  ! remove any remaining ice here
+               calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)  ! remove any remaining ice here
                thickness(iCell) = 0.0_RKIND
                localIcebergCellCount = localIcebergCellCount + 1
                !seedMaskOld(iCell) = 1 ! debug: make this a mask of where icebergs were removed
@@ -4001,7 +4038,6 @@ module li_calving
       seedMaskOld(:) = 0
 
       !call mpas_log_write("Flood-fill: allocated.")
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       ! First mark grounded ice to initialize flood fill mask
       block => domain % blocklist

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -387,7 +387,8 @@ module li_calving
       integer, pointer :: nCells, nVertLevels
 
       logical, pointer :: &
-           config_print_calving_info
+           config_print_calving_info, &
+           config_restore_calving_front_prevent_retreat
 
       real (kind=RKIND), pointer ::   &
            config_sea_level,          &
@@ -404,6 +405,7 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: &
            thickness,        & ! ice thickness
            bedTopography,    & ! elevation of the bed
+           calvingVelocity,  &
            calvingThickness, & ! thickness of ice that calves
                                ! > 0 for cells below sea level that were initially ice-free and now have ice
            restoreThickness    ! thickness of ice that is added to restore the calving front to its initial position
@@ -422,6 +424,8 @@ module li_calving
            surfaceAirTemperature, &   ! surface air temperature
            surfaceTemperature,    &   ! surface ice temperature
            basalTemperature           ! basal ice temperature
+
+      real (kind=RKIND), dimension(:), pointer :: surfaceSpeed
 
       integer :: iCell, err_tmp
 
@@ -461,6 +465,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'restoreThickness', restoreThickness)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
 
          ! get required fields from the thermal pool
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -469,10 +474,13 @@ module li_calving
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
 
+         call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
+
          ! get config variables
          call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
          call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
          call mpas_pool_get_config(liConfigs, 'config_dynamic_thickness', config_dynamic_thickness)
+         call mpas_pool_get_config(liConfigs, 'config_restore_calving_front_prevent_retreat', config_restore_calving_front_prevent_retreat)
 
          if (config_print_calving_info) then
             call mpas_log_write('Restore calving front')
@@ -513,41 +521,45 @@ module li_calving
          calvingThickness = 0.0_RKIND
          restoreThickness = 0.0_RKIND
 
-         ! loop over locally owned cells
+         if (config_restore_calving_front_prevent_retreat) then
+            do iCell = 1, nCells
+               if (bedTopography(iCell) < config_sea_level) then
+                  ! The bed is below sea level; test for calving-front advance and retreat.
+                  if (li_mask_is_initial_ice(cellMask(iCell)) .and. thickness(iCell) < restoreThicknessMin) then
+                     ! Ice was present in this cell initially, but now is either very thin or absent;
+                     !  reset the thickness to restoreThicknessMin.
+                     ! Note: Mass is not conserved.
+                     !       Save the difference (restoreThicknessMin - thickness) so as to keep track of energy non-conservation.
+
+                     if (config_print_calving_info) then
+                        call mpas_log_write('Restore ice: indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
+                     endif
+
+                     restoreThickness(iCell) = restoreThicknessMin - thickness(iCell)
+                     thickness(iCell) = restoreThicknessMin
+
+                     ! Initial a linear temperature profile in the column
+                     ! Note: Energy is not conserved.
+
+                     call li_init_linear_temperature_in_column(&
+                          nVertLevels,                   &
+                          layerCenterSigma,              &
+                          thickness(iCell),              &
+                          surfaceAirTemperature(iCell),  &
+                          temperature(:,iCell),          &
+                          waterFrac(:,iCell),            &
+                          surfaceTemperature(iCell),     &
+                          basalTemperature(iCell))
+                  endif ! retreated
+               endif ! bed below sea level
+            enddo ! nCells
+         endif ! if preventing retreat
+
+         ! Now check for marine regions that have advanced
          do iCell = 1, nCells
-
             if (bedTopography(iCell) < config_sea_level) then
-
                ! The bed is below sea level; test for calving-front advance and retreat.
-
-               if (li_mask_is_initial_ice(cellMask(iCell)) .and. thickness(iCell) < restoreThicknessMin) then
-
-                  ! Ice was present in this cell initially, but now is either very thin or absent;
-                  !  reset the thickness to restoreThicknessMin.
-                  ! Note: Mass is not conserved.
-                  !       Save the difference (restoreThicknessMin - thickness) so as to keep track of energy non-conservation.
-
-                  if (config_print_calving_info) then
-                     call mpas_log_write('Restore ice: indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
-                  endif
-
-                  restoreThickness(iCell) = restoreThicknessMin - thickness(iCell)
-                  thickness(iCell) = restoreThicknessMin
-
-                  ! Initial a linear temperature profile in the column
-                  ! Note: Energy is not conserved.
-
-                  call li_init_linear_temperature_in_column(&
-                       nVertLevels,                   &
-                       layerCenterSigma,              &
-                       thickness(iCell),              &
-                       surfaceAirTemperature(iCell),  &
-                       temperature(:,iCell),          &
-                       waterFrac(:,iCell),            &
-                       surfaceTemperature(iCell),     &
-                       basalTemperature(iCell))
-
-               elseif (.not.li_mask_is_initial_ice(cellMask(iCell)) .and. thickness(iCell) > 0.0_RKIND) then
+               if (.not.li_mask_is_initial_ice(cellMask(iCell)) .and. thickness(iCell) > 0.0_RKIND) then
 
                   ! This cell was initially ice-free but now has ice.
                   ! Remove the ice and add it to calvingThickness.
@@ -558,11 +570,10 @@ module li_calving
 
                   calvingThickness(iCell) = thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
-
+                  ! Assign flow speed to calving speed - this allows calculation of licalvf in ISMIP6 postprocessing
+                  calvingVelocity(iCell) = surfaceSpeed(iCell)
                endif   ! li_mask_is_initial_ice
-
             endif    ! bedTopography < config_sea_level
-
          enddo   ! iCell
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -134,6 +134,8 @@ module li_calving
       real (kind=RKIND), dimension(:), pointer :: &
            calvingThicknessFromThreshold   ! thickness of ice that calves from threshold processes (computed in this subroutine)
 
+      real (kind=RKIND), dimension(:), pointer :: calvingVelocity
+
       type (field1dReal), pointer :: originalThicknessField
 
       real (kind=RKIND), dimension(:), pointer :: originalThickness
@@ -164,8 +166,10 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
+         call mpas_pool_get_array(geometryPool, 'calvingVelocity', calvingVelocity)
          calvingThickness(:) = 0.0_RKIND
          calvingThicknessFromThreshold(:) = 0.0_RKIND
+         calvingVelocity(:) = 0.0_RKIND
          block => block % next
       end do
 
@@ -532,7 +536,6 @@ module li_calving
          err = ior(err, err_tmp)
 
          ! initialize
-         calvingThickness = 0.0_RKIND
          restoreThickness = 0.0_RKIND
 
          if (config_restore_calving_front_prevent_retreat) then
@@ -582,7 +585,7 @@ module li_calving
                      call mpas_log_write('Remove ice:  indexToCellID=$i, thickness=$r', intArgs=(/indexToCellID(iCell)/), realArgs=(/thickness(iCell)/))
                   endif
 
-                  calvingThickness(iCell) = thickness(iCell)
+                  calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
                   thickness(iCell) = 0.0_RKIND
                   ! Assign flow speed to calving speed - this allows calculation of licalvf in ISMIP6 postprocessing
                   calvingVelocity(iCell) = surfaceSpeed(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -550,7 +550,7 @@ module li_calving
                      restoreThickness(iCell) = restoreThicknessMin - thickness(iCell)
                      thickness(iCell) = restoreThicknessMin
 
-                     ! Initial a linear temperature profile in the column
+                     ! Initialize a linear temperature profile in the column
                      ! Note: Energy is not conserved.
 
                      call li_init_linear_temperature_in_column(&
@@ -3590,7 +3590,7 @@ module li_calving
       type (field1dInteger), pointer :: growMaskField
       integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
       real (kind=RKIND), dimension(:), pointer :: calvingThickness !< Output: the applied calving rate as a thickness
-      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold !< Output: the applied calving rate as a thickness
+      real (kind=RKIND), dimension(:), pointer :: calvingThicknessFromThreshold !< Output: the applied calving thickness from threshold processes
       real (kind=RKIND), dimension(:), pointer :: thickness, damage
       real(kind=RKIND), pointer :: config_damage_calving_threshold
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
@@ -3734,7 +3734,7 @@ module li_calving
          ! === apply calving ===
          do iCell = 1, nCells
             if (li_mask_is_floating_ice(cellMask(iCell)) .and. (calvingMask(iCell) >= 1)) then
-               call mpas_log_write("Found masked cell at $i", intArgs=(/iCell/))
+               !call mpas_log_write("Found masked cell at $i", intArgs=(/iCell/))
                calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
                calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
                thickness(iCell) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -108,6 +108,7 @@ module li_calving
       character (len=StrKIND), pointer :: config_calving, &
                                           config_front_mass_bal_grounded
       logical, pointer :: config_print_calving_info, config_data_calving
+      logical, pointer :: config_apply_calving_mask
       real(kind=RKIND), pointer :: config_calving_timescale
 
       integer, pointer :: nCells
@@ -142,15 +143,26 @@ module li_calving
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
+      call mpas_pool_get_config(liConfigs, 'config_apply_calving_mask', config_apply_calving_mask)
       call mpas_pool_get_config(liConfigs, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
       call mpas_pool_get_config(liConfigs, 'config_calving_timescale', config_calving_timescale)
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_data_calving', config_data_calving)
       call mpas_pool_get_config(liConfigs, 'config_number_of_blocks', config_number_of_blocks)
 
-      if (trim(config_calving) == 'none') then
-         return ! do nothing
-      endif
+      ! Zero calvingThickness here instead of or in addition to in individual subroutines.
+      ! This is necessary when using damage threshold calving with other calving
+      ! routines. Some individual routines still set calvingThickness to zero, but
+      ! this is redundant. li_apply_front_ablation_velocity will zero
+      ! calvingThickness, so any routines that use that should not be applied
+      ! after other calving routines.
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         calvingThickness(:) = 0.0_RKIND
+         block => block % next
+      end do
 
       ! Get deltat from first block (same on all blocks)
       block => domain % blocklist
@@ -203,22 +215,16 @@ module li_calving
          end do
       endif
       
-      ! Zero calvingThickness here instead of or in addition to in individual subroutines.
-      ! This is necessary when using damage threshold calving with other calving
-      ! routines. Some individual routines still set calvingThickness to zero, but 
-      ! this is redundant. li_apply_front_ablation_velocity will zero 
-      ! calvingThickness, so any routines that use that should not be applied 
-      ! after other calving routines.
-      block => domain % blocklist
-      do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
-         calvingThickness(:) = 0.0_RKIND
-   
-         block => block % next
-      end do
       ! compute calvingThickness based on the calving_config option
-      if (trim(config_calving) == 'thickness_threshold') then
+      if (trim(config_calving) == 'none') then
+
+         ! if mask calving not enabled, do nothing and return.
+         ! if mask calving is enabled do nothing here but continue rest of routine.
+         if (.not. config_apply_calving_mask) then
+            return
+         endif
+
+      elseif (trim(config_calving) == 'thickness_threshold') then
 
          call thickness_calving(domain, calvingFraction, err_tmp)
          err = ior(err, err_tmp)
@@ -248,11 +254,6 @@ module li_calving
          call damage_calving(domain, err_tmp)
          err = ior(err, err_tmp)
 
-      elseif (trim(config_calving) == 'mask') then
-
-         call mask_calving(domain, err_tmp)
-         err = ior(err, err_tmp)
-
       elseif (trim(config_calving) == 'von_Mises_stress') then
 
          call von_Mises_calving(domain, err_tmp)
@@ -279,6 +280,14 @@ module li_calving
          call mpas_log_write("Invalid option for config_calving specified: " // trim(config_calving), MPAS_LOG_ERR)
          err = 1
 
+      endif
+
+      ! Consider mask calving as a possible additional step
+      ! Mask calving can occur by itself or in conjunction with a physical calving law
+      if (config_apply_calving_mask) then
+         call mpas_log_write("Applying calving mask")
+         call mask_calving(domain, err_tmp)
+         err = ior(err, err_tmp)
       endif
 
       ! now also remove any icebergs
@@ -3686,7 +3695,9 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
-         calvingThickness = 0.0_RKIND
+         ! update mask
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
 
          ! === apply calving ===
          where (li_mask_is_floating_ice(cellMask) .and. (calvingMask >= 1))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -227,11 +227,7 @@ module li_calving
       ! compute calvingThickness based on the calving_config option
       if (trim(config_calving) == 'none') then
 
-         ! if mask calving not enabled, do nothing and return.
-         ! if mask calving is enabled do nothing here but continue rest of routine.
-         if (.not. config_apply_calving_mask) then
-            return
-         endif
+         ! Do nothing, but continue through rest of routine
 
       elseif (trim(config_calving) == 'thickness_threshold') then
 
@@ -455,8 +451,8 @@ module li_calving
       integer :: k
 
 
-      ! first remove any icebergs - do it first so restore-calving can put back thin ice in those places
-      call remove_icebergs(domain)
+      ! No longer a need to remove icebergs here, because li_calve_ice is now always called first
+      ! and remove_icebergs is always called from calving routine.
 
       ! block loop
       block => domain % blocklist

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -176,18 +176,14 @@ module li_time_integration_fe
 ! === Calve ice ========================
       call mpas_timer_start("calve_ice")
 
-      if (config_restore_calving_front) then
+      ! ice calving
+      call li_calve_ice(domain, err_tmp)
+      err = ior(err, err_tmp)
 
+      if (config_restore_calving_front) then
          ! restore the calving front to its initial position; calving options are ignored
          call li_restore_calving_front(domain, err_tmp)
          err = ior(err, err_tmp)
-
-      else
-
-         ! ice calving
-         call li_calve_ice(domain, err_tmp)
-         err = ior(err, err_tmp)
-
       endif
 
       call mpas_timer_stop("calve_ice")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -1043,7 +1043,7 @@ contains
       integer, pointer :: nCells
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
-      real(kind=RKIND), dimension(:), pointer :: thickness, calvingThickness
+      real(kind=RKIND), dimension(:), pointer :: thickness, calvingThickness, calvingThicknessFromThreshold
       real(kind=RKIND), dimension(:), pointer :: upperSurface, lowerSurface
       integer, dimension(:), pointer :: cellMask
       integer :: iCell, iEdgeOnCell, iEdge
@@ -1056,6 +1056,7 @@ contains
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+      call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
 
@@ -1066,6 +1067,7 @@ contains
             (sqrt(uReconstructX(1,iCell)**2 + uReconstructY(1,iCell)**2) > config_unrealistic_velocity)) then
          ! "fast" ice that is removed is added to the calving flux
             calvingThickness(iCell) = calvingThickness(iCell) + thickness(iCell)
+            calvingThicknessFromThreshold(iCell) = calvingThicknessFromThreshold(iCell) + thickness(iCell)
             thickness(iCell) = 0.0_RKIND
             uReconstructX(:,iCell) = 0.0_RKIND
             uReconstructY(:,iCell) = 0.0_RKIND


### PR DESCRIPTION
This PR introduces a number of usability changes to the mask-calving and restore_calving_front functionalities.  These changes are necessary to run the ISMIP6 Tier2 experiments that include a mask for where ice should be calved.  The changes are:
* allowing restore_calving_front to be applied after a calving law is applied.  Previously, restore_calving_front and actual calving laws were mutually exclusive.
* creating an option for restore_calving_front to allow retreat.  Previously, restore_calving_front would replace a thin layer of ice out to the original calving front if the calving front retreated for any reason (e.g. melted through).  Preserving the original ice-shelf extent is needed for coupled E3SM runs where the coupler can not yet support a change in ice-shelf extent.  But for standalone runs, we often want to disallow calving front advance but retreat is ok (and preferable to an artificial thin layer of ice).  The default behavior of the new option retains backwards compatible behavior.
* allowing mask calving to be applied in addition to a physically based calving law.  This allows the configuration where we have von Mises (or other) calving law active, but still want to apply the ice-shelf collapse mask from ISMIP6.  
* adding a new field called calvingThicknessFromThreshold that tracks the thickness of ice in each cell removed by any threshold calving process (a subset of what previously has been recorded only in calvingThickness).  This facilitates post-processing of calving flux for ISMIP6 by allowing different calculations for rate-based calving (e.g. von Mises) and threshold-based calving laws.  Implementation of this new field required reorganizing how certain fields are initialized.