### PR TITLE
Zero floatingBasalMassBal in subglacial lakes

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -45,7 +45,7 @@ module li_calving
    !--------------------------------------------------------------------
 
    public :: li_calve_ice, li_restore_calving_front, li_apply_front_ablation_velocity, &
-             li_calculate_damage, li_finalize_damage_after_advection
+             li_calculate_damage, li_finalize_damage_after_advection, li_flood_fill
 
    !--------------------------------------------------------------------
    !
@@ -3632,7 +3632,7 @@ module li_calving
               growMask = 1
       end where
 
-      call flood_fill(seedMask, growMask, domain)
+      call li_flood_fill(seedMask, growMask, domain)
 
       ! Remove ice from flood-filled mask, and any neighboring non-dynamic ice
       do iCell = 1, nCells
@@ -3940,7 +3940,7 @@ module li_calving
       where ( (seedMask == 0) .and. li_mask_is_floating_ice(cellMask(:)) .and. li_mask_is_dynamic_ice(cellMask(:)) )
              growMask = 1
       endwhere
-      call flood_fill(seedMask, growMask, domain)
+      call li_flood_fill(seedMask, growMask, domain)
 
       ! Add floating non-dynamic fringe, but exclude dynamic ice isolated by
       ! non-dynamic ice, which can cause velocity solver to fail to converge.
@@ -3952,7 +3952,7 @@ module li_calving
       elsewhere
              growMask = 0
       endwhere
-      call flood_fill(seedMask, growMask, domain)
+      call li_flood_fill(seedMask, growMask, domain)
       
       ! Now remove any ice that was not flood-filled - these are icebergs
       block => domain % blocklist
@@ -3999,7 +3999,7 @@ module li_calving
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!    routine flood_fill
+!    routine li_flood_fill
 !
 !> \brief  Flood fill routine to differentiate ice sheet from icebergs, critically damaged regions, etc. 
 !> The calling routine defines the seedMask to specify the initial masked region, and the growMask 
@@ -4011,7 +4011,7 @@ module li_calving
 !> \date   March 2021
 !> \details 
 !-----------------------------------------------------------------------
-   subroutine flood_fill(seedMask, growMask, domain)
+   subroutine li_flood_fill(seedMask, growMask, domain)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -4146,7 +4146,7 @@ module li_calving
 
       call mpas_log_write("Flood fill complete.")
 
-   end subroutine flood_fill
+   end subroutine li_flood_fill
 
 end module li_calving
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -78,7 +78,6 @@ module li_iceshelf_melt
 !-----------------------------------------------------------------------
 
    subroutine li_face_melt_grounded_ice(domain, err)
-
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -203,7 +202,7 @@ module li_iceshelf_melt
 !-----------------------------------------------------------------------
 
    subroutine li_basal_melt_floating_ice(domain, err)
-
+      use li_calving, only: li_flood_fill
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -230,8 +229,12 @@ module li_iceshelf_melt
       type (mpas_pool_type), pointer :: velocityPool   ! needed for mask subroutine
       type (mpas_pool_type), pointer :: scratchPool
 
+      type (field1dInteger), pointer :: seedMaskField
+      type (field1dInteger), pointer :: growMaskField
+      integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
+
       integer, pointer :: &
-           nCellsSolve                 ! number of locally owned cells
+           nCellsSolve, nCells             ! number of locally owned cells
 
       logical, pointer :: &
            config_print_thermal_info   ! if true, print debug info
@@ -499,7 +502,43 @@ module li_iceshelf_melt
 
             block => block % next
          enddo   ! associated(block)
+
       endif
+
+      ! Allocate scratch fields for flood-fill
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
+      call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
+      call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
+      seedMask => seedMaskField % array
+      seedMask(:) = 0
+      call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
+      call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
+      growMask => growMaskField % array
+      growMask(:) = 0
+
+      ! Prevent sub-shelf melt in subglacial lakes
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+      do iCell = 1, nCells
+         if ( (.not. li_mask_is_ice(cellMask(iCell))) ) then
+              seedMask(iCell) = 1
+         else if ( li_mask_is_floating_ice(cellMask(iCell)) ) then
+              growMask(iCell) = 1
+         end if
+      end do
+      call li_flood_fill(seedMask, growMask, domain)
+      do iCell = 1, nCells
+         if (seedMask(iCell) == 0) then
+              floatingBasalMassBal(iCell) = 0.0_RKIND
+         end if
+      end do
+
+      ! deallocate scratch fields used for flood fill
+      call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
+      call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
 
       if (trim(config_front_mass_bal_grounded) .ne. 'none') then
          block => domain % blocklist

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -234,7 +234,7 @@ module li_iceshelf_melt
       integer, dimension(:), pointer :: seedMask, growMask !masks to pass to flood-fill routine
 
       integer, pointer :: &
-           nCellsSolve, nCells             ! number of locally owned cells
+           nCellsSolve, nCells         ! number of locally owned cells & total cells on this proc
 
       logical, pointer :: &
            config_print_thermal_info   ! if true, print debug info
@@ -506,6 +506,7 @@ module li_iceshelf_melt
       endif
 
       ! Allocate scratch fields for flood-fill
+      ! Note: This only supports one block per processor
       call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
       call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
       call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
@@ -530,11 +531,8 @@ module li_iceshelf_melt
          end if
       end do
       call li_flood_fill(seedMask, growMask, domain)
-      do iCell = 1, nCells
-         if (seedMask(iCell) == 0) then
-              floatingBasalMassBal(iCell) = 0.0_RKIND
-         end if
-      end do
+
+      floatingBasalMassBal(:) = floatingBasalMassBal(:) * seedMask(:)
 
       ! deallocate scratch fields used for flood fill
       call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)


### PR DESCRIPTION
This merge uses a flood fill starting from ice-free areas and growing into floating ice to mask out sub-shelf melt from subglacial lakes. This also required change the flood_fill subroutine in li_calving to a public subroutine li_flood_fill so it can be called from li_iceshelf_melt.