### PR TITLE
Add ERA5 and firn model updates

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -321,7 +321,7 @@
 
 <compset>
   <alias>BGWCYCL1850</alias>
-  <lname>1850_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_MALI%STATIC_SWAV</lname>
+  <lname>1850_EAM%CMIP6_ELM%SPBC_MPASSI_MPASO_MOSART_MALI%SIA_SWAV</lname>
 </compset>
 
 <!-- OCN + CICE + GLC Only Compsets -->

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -10,12 +10,13 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%ERA5][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
     <desc option="CRUv7"> CLM CRU NCEP v7 data set </desc>
     <desc option="GSWP3v1"> GSWP3v1 data set </desc>
+    <desc option="ERA5"> Fifth generation ECMWF reanalysis </desc>
     <desc option="MOSARTTEST"> MOSART test data set using older NLDAS data </desc>
     <desc option="NLDAS2"> NLDAS2 regional 0.125 degree data set over the U.S. (25-53N, 235-293E). WARNING: Garbage data will be produced for runs extending beyond this regional domain. </desc>
     <desc option="CPLHIST"> Coupler hist data set (in this mode, it is strongly recommended that the model domain and the coupler history forcing are on the same domain)</desc>
@@ -43,13 +44,13 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,IAF_JRA_1p5,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,CFSv2,CFSR</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,ELMERA5,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) are modes used in forcing prognostic ocean/sea-ice components.
-      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMMOSARTTEST, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
+      CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, ELMERA5, CLMMOSARTTEST, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
       WARNING for CLMNLDAS2: This is a regional forcing dataset over the U.S. (25-53N, 235-293E). Garbage data will be produced for runs extending beyond this regional domain. 
       WARNING for CLMGSWP3v1: Humidity is identically zero for last time step in Dec/2013 and all of 2014 so you should NOT use 2014
 data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
@@ -68,6 +69,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%CRU">CLMCRUNCEP</value>
       <value compset="%CRUv7">CLMCRUNCEPv7</value>
       <value compset="%GSWP3v1">CLMGSWP3v1</value>
+      <value compset="%ERA5">ELMERA5</value>
       <value compset="%MOSARTTEST">CLMMOSARTTEST</value>
       <value compset="%NLDAS2">CLMNLDAS2</value>
       <value compset="%1PT">CLM1PT</value>

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%ERA5][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%ERA5][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p5][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304][%CFSv2][%CFSR]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -44,7 +44,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,ELMERA5,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,ELMERA5,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,IAF_JRA_1p5,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA,CFSv2,CFSR</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -2161,7 +2161,8 @@
       valid values:  'copy','spval','nn','nnoni','nnonj'
     </desc>
     <values>
-      <value>nn</value>
+	<value>nn</value>
+        <value stream="ELMERA5">copy</value>
     </values>
   </entry>
 

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -315,7 +315,7 @@
       <value stream="CLMCRUNCEP">domain.lnd.360x720.130305.nc</value>
       <value stream="CLMGSWP3v1">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
       <value stream="CLMGSWP3">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
-      <value stream="ELMERA5">domain.lnd.era5rgr1440x721_oEC60to30v3.220621.nc</value>
+      <value stream="ELMERA5">domain.lnd.era5_721x1440_rdrlat_EC30to60E2r2.221115.nc</value>
       <value stream="CLMMOSARTTEST">domain.lnd.nldas2_0224x0464_c110415.nc</value>
       <value stream="CLMNLDAS2">domain.lnd.0.125nldas2_0.125nldas2.190410.nc</value>
       <value stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
@@ -2050,8 +2050,8 @@
       <value stream="CPLHISTForcing.State1hr">900</value>
       <value stream="presaero.cplhist">0</value>
       <value stream="topo.cplhist">0</value>
-      <value stream="ELMERA5.msdrswrf">-1800</value>
-      <value stream="ELMERA5.msdfswrf">-1800</value>
+      <value stream="ELMERA5.msdrswrf">-3600</value>
+      <value stream="ELMERA5.msdfswrf">-3600</value>
       <value stream="ELMERA5.mcpr">-60</value>
       <value stream="ELMERA5.mlspr">-60</value>
       <value stream="ELMERA5.msdwlwrf">-60</value>

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -36,6 +36,7 @@
     CLMCRUNCEP		= Run with the CLM CRU NCEP V4 ( default ) forcing valid from 1900 to 2010 (force CLM)
     CLMCRUNCEPv7 	= Run with the CLM CRU NCEP V7 forcing valid from 1900 to 2010 (force CLM)
     CLMGSWP3v1		= Run with the CLM GSWP3 V1 forcing (force CLM)
+    ELMERA5         = Run with the ELM fifth generation ECMWF reanalysis from 1979 to present
     CLMMOSARTTEST   	= Run with the CLM NLDAS data (force CLM) for testing MOSART
     CLMNLDAS2		= Run with the CLM NLDAS2 regional forcing valid from 1980 to 2018 (force CLM)
     CLM1PT		= Run with supplied single point data (force CLM)
@@ -103,6 +104,16 @@
     CLMGSWP3v1.Solar
     CLMGSWP3v1.Precip
     CLMGSWP3v1.TPQW
+    
+    ELMERA5.msdrswrf # mean surface direct shortwave radiation flux
+    ELMERA5.msdfswrf # mean surface diffuse shortwave radiation flux
+    ELMERA5.mcpr # mean convective precipitation rate
+    ELMERA5.mlspr # mean large-scale precipitation rate
+    ELMERA5.t2m # temperature at 2 m
+    ELMERA5.sp # surface pressure
+    ELMERA5.d2m # dew point temperature at 2 m
+    ELMERA5.w10 # wind speed at 10 m
+    ELMERA5.msdwlwrf # mean surface downward longwave radiation flux
 
     CLMMOSARTTEST
 
@@ -202,6 +213,7 @@
       <value datm_mode="CLMCRUNCEP$">CLMCRUNCEP.Solar,CLMCRUNCEP.Precip,CLMCRUNCEP.TPQW</value>
       <value datm_mode="CLMCRUNCEPv7">CLMCRUNCEPv7.Solar,CLMCRUNCEPv7.Precip,CLMCRUNCEPv7.TPQW</value>
       <value datm_mode="CLMGSWP3v1">CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW</value>
+      <value datm_mode="ELMERA5">ELMERA5.msdrswrf,ELMERA5.msdfswrf,ELMERA5.mcpr,ELMERA5.mlspr,ELMERA5.t2m,ELMERA5.sp,ELMERA5.d2m,ELMERA5.w10,ELMERA5.msdwlwrf</value>
       <value datm_mode="CLMMOSARTTEST">CLMMOSARTTEST</value>
       <value datm_mode="CLMNLDAS2">CLMNLDAS2.Solar,CLMNLDAS2.Precip,CLMNLDAS2.TPQW</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
@@ -234,6 +246,7 @@
       <value stream="CLMCRUNCEPv7">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715</value>
       <value stream="CLMCRUNCEP">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMGSWP3v1">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516</value>
+      <value stream="ELMERA5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614</value>
       <value stream="CLMCRUNCEP\.">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMCRUNCEP_V5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.V5.c140715</value>
       <value stream="CLMGSWP3">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516</value>
@@ -302,6 +315,7 @@
       <value stream="CLMCRUNCEP">domain.lnd.360x720.130305.nc</value>
       <value stream="CLMGSWP3v1">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
       <value stream="CLMGSWP3">domain.lnd.360x720_gswp3.0v1.c170606.nc</value>
+      <value stream="ELMERA5">domain.lnd.era5rgr1440x721_oEC60to30v3.220621.nc</value>
       <value stream="CLMMOSARTTEST">domain.lnd.nldas2_0224x0464_c110415.nc</value>
       <value stream="CLMNLDAS2">domain.lnd.0.125nldas2_0.125nldas2.190410.nc</value>
       <value stream="CORE2_NYF.GISS">nyf.giss.T62.051007.nc</value>
@@ -478,6 +492,15 @@
       <value stream="CLMGSWP3.Solar">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Solar3Hrly</value>
       <value stream="CLMGSWP3.Precip">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/Precip3Hrly</value>
       <value stream="CLMGSWP3.TPQW">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.GSWP3.0.5d.v1.c170516/TPHWL3Hrly</value>
+      <value stream="ELMERA5.msdfswrf">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/swdn</value>
+      <value stream="ELMERA5.msdrswrf">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/swdn</value>
+      <value stream="ELMERA5.mcpr">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/prec</value>
+      <value stream="ELMERA5.mlspr">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/prec</value>
+      <value stream="ELMERA5.t2m">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/tbot</value>
+      <value stream="ELMERA5.sp">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/pbot</value>
+      <value stream="ELMERA5.d2m">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/tdew</value>
+      <value stream="ELMERA5.w10">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/wind</value>
+      <value stream="ELMERA5.msdwlwrf">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.ERA.0.25d.v5.c180614/lwdn</value>
       <value stream="CLMMOSARTTEST">$DIN_LOC_ROOT/atm/datm7/NLDAS</value>
       <value stream="CLMNLDAS2.Solar">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Solar</value>
       <value stream="CLMNLDAS2.Precip">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.NLDAS2.0.125d.v1/Precip</value>
@@ -553,6 +576,15 @@
       <value  stream="CLMGSWP3v1.Solar">clmforc.GSWP3.c2011.0.5x0.5.Solr.%ym.nc</value>
       <value  stream="CLMGSWP3v1.Precip">clmforc.GSWP3.c2011.0.5x0.5.Prec.%ym.nc</value>
       <value  stream="CLMGSWP3v1.TPQW">clmforc.GSWP3.c2011.0.5x0.5.TPQWL.%ym.nc</value>
+      <value  stream="ELMERA5.msdrswrf">elmforc.ERA5.c2018.0.25d.msdrswrf.%ym.nc</value>
+      <value  stream="ELMERA5.msdfswrf">elmforc.ERA5.c2018.0.25d.msdfswrf.%ym.nc</value>
+      <value  stream="ELMERA5.mcpr">elmforc.ERA5.c2018.0.25d.mcpr.%ym.nc</value>
+      <value  stream="ELMERA5.mlspr">elmforc.ERA5.c2018.0.25d.mlspr.%ym.nc</value>
+      <value  stream="ELMERA5.t2m">elmforc.ERA5.c2018.0.25d.t2m.%ym.nc</value>
+      <value  stream="ELMERA5.sp">elmforc.ERA5.c2018.0.25d.sp.%ym.nc</value>
+      <value  stream="ELMERA5.d2m">elmforc.ERA5.c2018.0.25d.d2m.%ym.nc</value>
+      <value  stream="ELMERA5.w10">elmforc.ERA5.c2018.0.25d.w10.%ym.nc</value>
+      <value  stream="ELMERA5.msdwlwrf">elmforc.ERA5.c2018.0.25d.msdwlwrf.%ym.nc</value>
       <value  stream="CLMMOSARTTEST">clmforc.nldas.%ym.nc</value>
       <value  stream="CLMNLDAS2.Solar">ctsmforc.NLDAS2.0.125d.v1.Solr.%ym.nc</value>
       <value  stream="CLMNLDAS2.Precip">ctsmforc.NLDAS2.0.125d.v1.Prec.%ym.nc</value>
@@ -1523,6 +1555,33 @@
         PSRF     pbot
         FLDS     lwdn
       </value>
+      <value  stream="ELMERA5.msdrswrf">
+        msdrswrf    swdndr
+      </value>
+      <value  stream="ELMERA5.msdfswrf">
+        msdfswrf    swdndf
+      </value>
+      <value  stream="ELMERA5.mcpr">
+        mcpr    precc
+      </value>
+      <value  stream="ELMERA5.mlspr">
+        mlspr    precl
+      </value>
+      <value  stream="ELMERA5.t2m">
+        t2m    tbot
+      </value>
+      <value  stream="ELMERA5.sp">
+        sp    pbot
+      </value>
+      <value  stream="ELMERA5.d2m">
+        d2m    tdew
+      </value>
+      <value  stream="ELMERA5.w10">
+        w10    wind
+      </value>
+      <value  stream="ELMERA5.msdwlwrf">
+        msdwlwrf    lwdn
+      </value>
       <value  stream="CLMMOSARTTEST">
         TBOT     tbot
         WIND     wind
@@ -1793,6 +1852,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_ALIGN</value>
+      <value stream="ELMERA5">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMMOSARTTEST">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_ALIGN</value>
       <value stream="CORE2_NYF">1</value>
@@ -1843,6 +1903,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_START</value>
+      <value stream="ELMERA5">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMMOSARTTEST">$DATM_CLMNCEP_YR_START</value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_START</value>
       <value stream="CORE2_NYF">1</value>
@@ -1914,6 +1975,7 @@
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMCRUNCEP">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMGSWP3">$DATM_CLMNCEP_YR_END  </value>
+      <value stream="ELMERA5">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMMOSARTTEST">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CLMNLDAS2">$DATM_CLMNCEP_YR_END  </value>
       <value stream="CORE2_NYF">1</value>
@@ -1988,6 +2050,11 @@
       <value stream="CPLHISTForcing.State1hr">900</value>
       <value stream="presaero.cplhist">0</value>
       <value stream="topo.cplhist">0</value>
+      <value stream="ELMERA5.msdrswrf">-1800</value>
+      <value stream="ELMERA5.msdfswrf">-1800</value>
+      <value stream="ELMERA5.mcpr">-60</value>
+      <value stream="ELMERA5.mlspr">-60</value>
+      <value stream="ELMERA5.msdwlwrf">-60</value>
     </values>
   </entry>
 
@@ -2054,6 +2121,7 @@
     <values>
       <value>NULL</value>
       <value datm_mode="CLM">CLMNCEP</value>
+      <value datm_mode="ELMERA5">CLMNCEP</value>
       <value datm_mode="CORE2_NYF">CORE2_NYF</value>
       <value datm_mode="CORE2_IAF">CORE2_IAF</value>
       <value datm_mode="CORE_IAF_JRA.*">CORE_IAF_JRA</value>
@@ -2248,6 +2316,11 @@
       <value stream="CLMCRUNCEPv7.Precip">nearest</value>
       <value stream="CLMGSWP3v1.Solar">coszen</value>
       <value stream="CLMGSWP3v1.Precip">nearest</value>
+      <value stream="ELMERA5.msdrswrf">coszen</value>
+      <value stream="ELMERA5.msdfswrf">coszen</value>
+      <value stream="ELMERA5.mcpr">upper</value>
+      <value stream="ELMERA5.mlspr">upper</value>
+      <value stream="ELMERA5.msdwlwrf">upper</value>
       <value stream="CLMNLDAS2.Solar">coszen</value>
       <value stream="CLMNLDAS2.Precip">nearest</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">nearest</value>

--- a/components/elm/src/biogeophys/SnowHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SnowHydrologyMod.F90
@@ -702,7 +702,7 @@ contains
                          ddz2 = (-k_creep_firn * (max(denice / bi, 1._r8) - 1._r8) * &
                                  exp(-60.e6_r8 / (rgas * t_soisno(c,j))) * p_gls) / &
                                  (snw_rds(c,j) * 1.e-6_r8 * snw_rds(c,j) * 1.e-6_r8) - &
-                                 1.0e-11_r8 ! smaller additional constant
+                                 1.0e-10_r8 ! small additional constant
                       endif
                    endif
 

--- a/components/elm/src/biogeophys/SnowSnicarMod.F90
+++ b/components/elm/src/biogeophys/SnowSnicarMod.F90
@@ -80,7 +80,7 @@ module SnowSnicarMod
   integer,  parameter :: snw_rds_max_tbl = 1500          ! maximum effective radius defined in Mie lookup table [microns]
   integer,  parameter :: snw_rds_min_tbl = 30            ! minimium effective radius defined in Mie lookup table [microns]
   real(r8), parameter :: snw_rds_max     = 1500._r8      ! maximum allowed snow effective radius [microns]
-  real(r8), parameter :: snw_rds_refrz   = 1000._r8      ! effective radius of re-frozen snow [microns]
+  real(r8), parameter :: snw_rds_refrz   = 1500._r8      ! effective radius of re-frozen snow [microns]
   !$acc declare copyin(snw_rds_max_tbl)
   !$acc declare copyin(snw_rds_min_tbl)
   !$acc declare copyin(snw_rds_max    )

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -18,7 +18,7 @@ module ColumnDataType
   use elm_varpar      , only : nlevdecomp_full, crop_prog, nlevdecomp
   use elm_varpar      , only : i_met_lit, i_cel_lit, i_lig_lit, i_cwd
   use elm_varcon      , only : spval, ispval, zlnd, snw_rds_min, denice, denh2o, tfrz, pondmx
-  use elm_varcon      , only : watmin, bdsno, zsoi, zisoi, dzsoi_decomp
+  use elm_varcon      , only : watmin, bdsno, bdfirn, zsoi, zisoi, dzsoi_decomp
   use elm_varcon      , only : c13ratio, c14ratio, secspday
   use elm_varctl      , only : use_fates, use_fates_planthydro, create_glacier_mec_landunit
   use elm_varctl      , only : use_hydrstress
@@ -28,6 +28,7 @@ module ColumnDataType
   use elm_varctl      , only : hist_wrtch4diag, use_century_decomp
   use elm_varctl      , only : get_carbontag, override_bgc_restart_mismatch_dump
   use elm_varctl      , only : pf_hmode, nu_com
+  use elm_varctl      , only : use_extrasnowlayers
   use ch4varcon       , only : allowlakeprod
   use pftvarcon       , only : VMAX_MINSURF_P_vr, KM_MINSURF_P_vr, pinit_beta1, pinit_beta2
   use soilorder_varcon, only : smax, ks_sorption
@@ -1672,8 +1673,20 @@ contains
           end do
           do j = -nlevsno+1, 0
              if (j > col_pp%snl(c)) then
-                this%h2osoi_ice(c,j) = col_pp%dz(c,j)*250._r8
-                this%h2osoi_liq(c,j) = 0._r8
+                 if (use_extrasnowlayers) then 
+                   ! amschnei@uci.edu: Initialize "deep firn" on glacier columns
+                   if (lun_pp%itype(l) == istice .or. lun_pp%itype(l) == istice_mec) then
+                     this%h2osoi_ice(c,j) = col_pp%dz(c,j)*bdfirn
+                     this%h2osoi_liq(c,j) = 0._r8
+                   else
+                     this%h2osoi_ice(c,j) = col_pp%dz(c,j)*bdsno
+                     this%h2osoi_liq(c,j) = 0._r8
+                   end if
+                 else ! no firn model (default in v2)
+                      ! Below, "250._r8" should instead be "bdsno", which is 250 kg m^3 by default
+                   this%h2osoi_ice(c,j) = col_pp%dz(c,j)*250._r8
+                   this%h2osoi_liq(c,j) = 0._r8
+                 end if
              end if
           end do
        end if

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -5456,26 +5456,27 @@ contains
           avgflag='A', long_name='column-integrated snow freezing rate', &
            ptr_col=this%qflx_snofrz, set_lake=spval, c2l_scale_type='urbanf', default='inactive')
 
-    if (create_glacier_mec_landunit) then
-       this%qflx_glcice(begc:endc) = spval
-        call hist_addfld1d (fname='QICE',  units='mm/s',  &
-             avgflag='A', long_name='ice growth/melt', &
-              ptr_col=this%qflx_glcice, l2g_scale_type='ice')
-    end if
+    !if (create_glacier_mec_landunit) then
+    ! amschnei@uci.edu: Turn on QICE for stand-alone ELM runs
+    this%qflx_glcice(begc:endc) = spval
+    call hist_addfld1d (fname='QICE',  units='mm/s',  &
+                        avgflag='A', long_name='ice growth/melt', &
+                        ptr_col=this%qflx_glcice, l2g_scale_type='ice')
+    !end if
 
-    if (create_glacier_mec_landunit) then
-       this%qflx_glcice_frz(begc:endc) = spval
-        call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
+    !if (create_glacier_mec_landunit) then
+    this%qflx_glcice_frz(begc:endc) = spval
+    call hist_addfld1d (fname='QICE_FRZ',  units='mm/s',  &
              avgflag='A', long_name='ice growth', &
               ptr_col=this%qflx_glcice_frz, l2g_scale_type='ice')
-    end if
+    !end if
 
-    if (create_glacier_mec_landunit) then
-       this%qflx_glcice_melt(begc:endc) = spval
+    !if (create_glacier_mec_landunit) then
+    this%qflx_glcice_melt(begc:endc) = spval
         call hist_addfld1d (fname='QICE_MELT',  units='mm/s',  &
              avgflag='A', long_name='ice melt', &
               ptr_col=this%qflx_glcice_melt, l2g_scale_type='ice')
-    end if
+    !end if
 
     ! As defined here, snow_sources - snow_sinks will equal the change in h2osno at any
     ! given time step but only if there is at least one snow layer (for all landunits

--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -262,7 +262,7 @@ contains
     !
     use shr_scam_mod                      , only : shr_scam_getCloseLatLon
     use landunit_varcon                   , only : istice, istice_mec, istsoil
-    use elm_varcon                        , only : h2osno_max, bdsno
+    use elm_varcon                        , only : h2osno_max, bdsno, bdfirn
     use domainMod                         , only : ldomain
     use elm_varpar                        , only : nlevsno, numpft
     use elm_varctl                        , only : single_column, fsurdat, scmlat, scmlon, use_extrasnowlayers
@@ -318,8 +318,19 @@ contains
            else
               h2osno_col(c) = 0._r8
            endif
+         snow_depth_col(c)  = h2osno_col(c) / bdsno
        else ! With a deeper firn model, we can no longer depend on "h2osno_max," because this will
            !  potentially be large, resulting in a lot of artificial firn at initialization.
+           ! 
+           ! amschnei@uci.edu: UPDATE - By including a new parameter, bdfirn, we can
+           !   initialize a dense (e.g, 730 kd m^-3) "deep firn" layer for glacier
+           !   land units. This deep firn layer can be set to half of the total
+           !   maximum allotted snowpack mass (i.e., "h2osno_max"), which effectively
+           !   sets the Greenland and Antarctic ice sheets' (and mountain glaciers')
+           !   climatic (aka surface) mass balance (SMB) initial condition to 0. With this
+           !   cold start condition, a multi-decadal (100 to 300 years or more)
+           !   spin up is first required to prognose nonzero SMB.
+           ! 
            ! However... (below docstring from CLMv5)
            ! In areas that should be snow-covered, it can be problematic to start with 0 snow
            ! cover, because this can affect the long-term state through soil heating, albedo
@@ -328,17 +339,21 @@ contains
            ! feedback may not activate on time (or at all). So, as a compromise, we start with
            ! a small amount of snow in places that are likely to be snow-covered for much or
            ! all of the year.
+
+           ! amschnei@uci.edu: Initializing "deep firn" for glacier columns
            if (lun_pp%itype(l)==istice .or. lun_pp%itype(l)==istice_mec) then
               ! land ice (including multiple elevation classes, i.e. glacier_mec)
-              h2osno_col(c) = 50._r8
+              h2osno_col(c) = 0.5_r8 * h2osno_max   ! start with half full snow column, representing deep firn
+              snow_depth_col(c)  = h2osno_col(c) / bdfirn
            else if (lun_pp%itype(l)==istsoil .and. grc_pp%latdeg(g) >= 44._r8) then
               ! Northern hemisphere seasonal snow
               h2osno_col(c) = 50._r8
+              snow_depth_col(c)  = h2osno_col(c) / bdsno
            else
               h2osno_col(c) = 0._r8
+              snow_depth_col(c)  = h2osno_col(c) / bdsno
            endif
        endif
-       snow_depth_col(c)  = h2osno_col(c) / bdsno
     end do
 
    ! Initialize urban constants

--- a/components/elm/src/main/elm_varcon.F90
+++ b/components/elm/src/main/elm_varcon.F90
@@ -250,7 +250,7 @@ contains
     allocate( dzsoifl(1:nlevsoifl            ))
 
     if (use_extrasnowlayers) then
-       h2osno_max = 20000._r8
+       h2osno_max = 30000._r8
     end if
 
   end subroutine elm_varcon_init

--- a/components/elm/src/main/elm_varcon.F90
+++ b/components/elm/src/main/elm_varcon.F90
@@ -68,6 +68,7 @@ module elm_varcon
   real(r8) :: oneatm = 1.01325e5_r8                         ! one standard atmospheric pressure [Pa]
 
   real(r8) :: bdsno = 250._r8                               ! bulk density snow (kg/m**3)
+  real(r8) :: bdfirn = 730._r8                              ! bulk density of deep firn (kg/m**3)
   real(r8) :: alpha_aero = 1.0_r8                           ! constant for aerodynamic parameter weighting
   real(r8) :: tlsai_crit = 2.0_r8                           ! critical value of elai+esai for which aerodynamic parameters are maximum
   real(r8) :: watmin = 0.01_r8                              ! minimum soil moisture (mm)
@@ -249,7 +250,7 @@ contains
     allocate( dzsoifl(1:nlevsoifl            ))
 
     if (use_extrasnowlayers) then
-       h2osno_max = 10000._r8
+       h2osno_max = 20000._r8
     end if
 
   end subroutine elm_varcon_init


### PR DESCRIPTION
This PR brings in an option to force the land model with ERA5 surface variables. ERA5 is configured with additions to datm.

This PR also includes tweaks to the firn density parameterization and a new cold start condition. The new cold start (initial) condition sets the mass of snow on glaciers and ice sheets to one half of the maximum allotted SWE. The maximum allotted mass of snow in a column is determined by the constant "h2osno_max," which is set to 1 m by default. With "use_extrasnowlayers" active (firn model on), this PR sets h2osno_max to 30 m (SWE).

In this PR, the initial condition for a cold start with use_extrasnowlayers is therefore 15 m SWE, which represents a "deep firn" layer with a density of (~)730 kg / m^3. From this initial condition, a spin up period of at least 300 years is recommended before initializing simulations of nonzero ice sheet SMB.