### PR TITLE
Use 3D thermal forcing to calculate grounded face-melting

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -752,9 +752,9 @@
                         <!-- these variables just for ISMIP6 ice shelf forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
                         <var name="ismip6shelfMelt_offset" packages="ismip6ShelfMelt"/>
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1328,7 +1328,7 @@ is the value of that variable from the *previous* time level!
                      description="thermal forcing at ice shelf draft used for ISMIP6 ice-shelf melting method, calculated by param."
                 />
                 <var name="ismip6shelfMelt_3dThermalForcing" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C" 
-                     default_value="2.0" packages="ismip6ShelfMelt"
+                     default_value="0.0" packages="ismip6ShelfMelt"
                      description="thermal forcing for ISMIP6 ice-shelf melting method, input to model"
                 />
                 <var name="ismip6shelfMelt_zOcean" type="real" dimensions="nISMIP6OceanLayers" units="m" packages="ismip6ShelfMelt"
@@ -1347,7 +1347,7 @@ is the value of that variable from the *previous* time level!
                 <var name="ismip6Runoff" type="real" dimensions="nCells Time" units="kg m^{-2} s^{-1}" packages="ismip6GroundedFaceMelt" default_value="0.0"
                      description="Runoff forcing for ISMIP6 grounded ice melting method, input to model" 
                 />
-		<var name="ismip6_2dThermalForcing" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="2.0"
+		<var name="ismip6_2dThermalForcing" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6GroundedFaceMelt" default_value="0.0"
 	 	     description="thermal forcing for ISMIP6 grounded marine melt method, input to model"
 		/>
 		<var name="faceMeltingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -413,6 +413,10 @@
                             description="Selection of the method for computing the frontal mass balance of submarine grounded ice.  'none' sets the front mass balance field to 0 everywhere. 'uniform' sets faceMeltSpeed to the value given by config_uniform_face_melt_rate. 'ismip6' uses the parameterization provided by ISMIP6 and requires an ocean thermal forcing field and subglacial hydrology."
                             possible_values="'none', 'uniform', 'ismip6'"
                 />
+                <nml_option name="config_use_3d_thermal_forcing_for_face_melt" type="logical" default_value=".false." units="unitless"
+                            description="If true, use ismip6shelfMelt_3dThermalForcing and associated variables to calculate a depth-averaged thermal forcing for use with the config_front_mass_bal_grounded = 'ismip6' melt paramterization."
+                            possible_values=".true. or .false."
+                />
                 <nml_option name="config_beta_ocean_thermal_forcing" type="real" default_value="1.18" units="unitless"
 			    description="Exponent of the ocean thermal forcing in ISMIP6 grounded ice front melting parameterization"
                             possible_values="any real value"
@@ -843,9 +847,9 @@
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
                         <var name="ismip6shelfMelt_offset" packages="ismip6ShelfMelt"/>
                         <!-- these variables just for ISMIP6 grounded glacier forcing -->
                         <var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
@@ -1321,17 +1325,17 @@ is the value of that variable from the *previous* time level!
                      description="gamma0 value prescribed for ISMIP6 ice-shelf melting method, input to model.  Defaults to 0 so that missing input value will zero melt field."
                 />
                 <var name="ismip6shelfMelt_deltaT" type="real" dimensions="nCells" units="K" default_value="0.0"
-                     packages="ismip6ShelfMelt"
+                     packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
                      description="basin-by-basin temperature bias correction for ISMIP6 ice-shelf melting method, input to model"
                 />
                 <var name="ismip6shelfMelt_TFdraft" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6ShelfMelt"
                      description="thermal forcing at ice shelf draft used for ISMIP6 ice-shelf melting method, calculated by param."
                 />
                 <var name="ismip6shelfMelt_3dThermalForcing" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C" 
-                     default_value="0.0" packages="ismip6ShelfMelt"
+                     default_value="0.0" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
                      description="thermal forcing for ISMIP6 ice-shelf melting method, input to model"
                 />
-                <var name="ismip6shelfMelt_zOcean" type="real" dimensions="nISMIP6OceanLayers" units="m" packages="ismip6ShelfMelt"
+                <var name="ismip6shelfMelt_zOcean" type="real" dimensions="nISMIP6OceanLayers" units="m" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
                      description="depth coordinate associated with ismip6shelfMelt_3dThermalForcing field, input to model"
                 />
                 <var name="ismip6shelfMelt_offset" type="real" dimensions="nCells" units="kg m^{-2} s^{-1}" packages="ismip6ShelfMelt" default_value="0.0"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -500,6 +500,11 @@
 			description="A multiplier on the minimum allowable time step calculated from the calving CFL condition. This should be conservative given the calving CFL calculation is lagged"
 			possible_values="Any positive real value.  Note that values greater than 1.0 are allowed and may be desired.  This is because the calving CFL is an approximate calculation.  A value between 0.75 and 1.0, possibly as large as 1.25, was found to maintain converged accuracy for many configurations explored, so it is recommended to use values in this range.  However, much larger values (up to 2 or 3) provide acceptable accuracy for some configurations (but it is not clear what conditions allow it).  If values much greater than 1.0 are used, it is recommended to set config_distribute_unablatedVolumeDynCell to true."
 		/>
+                <nml_option name="config_adaptive_timestep_faceMeltingCFL_fraction" type="real" default_value="1.0" units="none"
+                        description="A multiplier on the minimum allowable time step calculated from the face-melting CFL condition. This should be conservative given the calving CFL calculation is lagged"
+                        possible_values="Any positive real value.  Note that values greater than 1.0 are allowed and may be desired.  This is because the face-melting CFL is an approximate calculation.  A value between 0.75 and 1.0, possibly as large as 1.25, was found to maintain converged accuracy for the analogous calving CFL fraction, so it is recommended to use values in this range. If values much greater than 1.0 are used, it is recommended to set config_distribute_unablatedVolumeDynCell to true."
+                />
+
 		<nml_option name="config_adaptive_timestep_include_DCFL" type="logical" default_value=".false." units="none"
 			description="Option of whether to include the diffusive CFL condition in the determination of the maximum allowable timestep. The diffusive CFL condition at any location is estimated based on the local ice flux and surface slope."
 			possible_values=".true. or .false."
@@ -508,6 +513,10 @@
 			description="Option of whether to include the calving CFL condition in the determination of the maximum allowable timestep. This only is applied if config_calving is set to a method that uses a calvingVelocity.  Note that this is an approximate CFL condition and is lagged a timestep."
 			possible_values=".true. or .false."
 		/>
+                <nml_option name="config_adaptive_timestep_include_face_melting" type="logical" default_value=".true." units="none"
+                        description="Option of whether to include the face-melting CFL condition in the determination of the maximum allowable timestep. This only is applied if config_front_mass_bal_grounded is not set to 'none'.  Note that this is an approximate CFL condition and is lagged a timestep."
+                        possible_values=".true. or .false."
+                />
 		<nml_option name="config_adaptive_timestep_force_interval" type="character" default_value="1000-00-00_00:00:00" units="unitless"
 		            description="If adaptive timestep is enabled, the model will ensure a timestep ends at multiples of this interval.  This is useful for ensuring that model output is written at a specific desired interval (rather than the closest time after) or when running coupled to an earth system model that expects a certain interval."
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'. (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
@@ -1357,6 +1366,12 @@ is the value of that variable from the *previous* time level!
 		<var name="faceMeltingThickness" type="real" dimensions="nCells Time" units="m" time_levs="1"
                      description="Equivalent plan-view averaged thickness of ice that melts on a given timestep from front ablation (less than or equal to ice thickness)"
 		/>
+                <var name="faceMeltingCFLdt" type="real" dimensions="Time" units="s" time_levs="1" default_value="1.0e16"
+                        description="approximation of maximum allowable timestep based on faceMeltSpeed"
+                />
+                <var name="dtFaceMeltingCFLratio" type="real" dimensions="Time" units="none" time_levs="1" default_value="0.0"
+                        description="ratio of timestep being used to the maximum timestep calculated for the face-melting CFL condition.  This metric can be used to assess the accuracy of the face-melting CFL calculation being lagged by a timestep."
+                />
                <var name="unmeltedVolume" type="real" dimensions="nCells Time" units="m^3" time_levs="1"
                      description="volume of ice that was left unmelted from required facemelt flux due to only applying flux over immediate neighbors (diagnostic field to assess if this limitation is a problem)"
 	        />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -414,7 +414,7 @@
                             possible_values="'none', 'uniform', 'ismip6'"
                 />
                 <nml_option name="config_use_3d_thermal_forcing_for_face_melt" type="logical" default_value=".false." units="unitless"
-                            description="If true, use ismip6shelfMelt_3dThermalForcing and associated variables to calculate a depth-averaged thermal forcing for use with the config_front_mass_bal_grounded = 'ismip6' melt paramterization."
+                            description="If true, use ismip6shelfMelt_3dThermalForcing and associated variables to calculate ocean-bottom thermal forcing for use with the config_front_mass_bal_grounded = 'ismip6' melt paramterization."
                             possible_values=".true. or .false."
                 />
                 <nml_option name="config_beta_ocean_thermal_forcing" type="real" default_value="1.18" units="unitless"
@@ -761,9 +761,9 @@
                         <!-- these variables just for ISMIP6 ice shelf forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
-                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
-                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_offset" packages="ismip6ShelfMelt"/>
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
@@ -856,9 +856,9 @@
                         <!-- these variables just for ISMIP6 forcing -->
                         <var name="ismip6shelfMelt_basin" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_gamma0" packages="ismip6ShelfMelt"/>
-                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
-                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
-                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"/>
+                        <var name="ismip6shelfMelt_3dThermalForcing" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_deltaT" packages="ismip6ShelfMelt"/>
+                        <var name="ismip6shelfMelt_zOcean" packages="ismip6ShelfMelt"/>
                         <var name="ismip6shelfMelt_offset" packages="ismip6ShelfMelt"/>
                         <!-- these variables just for ISMIP6 grounded glacier forcing -->
                         <var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
@@ -1122,7 +1122,7 @@ is the value of that variable from the *previous* time level!
 		     description="The maximum allowable time step based on the diffusive CFL condition.  Value on a given time is the value appropriate for  between the previous time level and the current time level."
                 />
 		<var name="processLimitingTimestep" type="integer" time_levs="1" dimensions="Time" units="none" default_value="0"
-		     description="A code for which process limits the timestep length through the CFL condition. 1=advective CFL, 2=diffusive CFL, 3=calving CFL.  Value of 0 indicates adaptive timestepper not used."
+		     description="A code for which process limits the timestep length through the CFL condition. 1=advective CFL, 2=diffusive CFL, 3=calving CFL, 4=face-melting.  Value of 0 indicates adaptive timestepper not used."
                 />
                 <var name="simulationStartTime" type="text" dimensions="" units="unitless" default_value="'no_date_available'"
                      description="start time of first simulation, with format 'YYYY-MM-DD_HH:MM:SS'"
@@ -1334,17 +1334,17 @@ is the value of that variable from the *previous* time level!
                      description="gamma0 value prescribed for ISMIP6 ice-shelf melting method, input to model.  Defaults to 0 so that missing input value will zero melt field."
                 />
                 <var name="ismip6shelfMelt_deltaT" type="real" dimensions="nCells" units="K" default_value="0.0"
-                     packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
+                     packages="ismip6ShelfMelt"
                      description="basin-by-basin temperature bias correction for ISMIP6 ice-shelf melting method, input to model"
                 />
                 <var name="ismip6shelfMelt_TFdraft" type="real" dimensions="nCells Time" units="deg. C" packages="ismip6ShelfMelt"
                      description="thermal forcing at ice shelf draft used for ISMIP6 ice-shelf melting method, calculated by param."
                 />
                 <var name="ismip6shelfMelt_3dThermalForcing" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C" 
-                     default_value="0.0" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
+                     default_value="0.0" packages="ismip6ShelfMelt"
                      description="thermal forcing for ISMIP6 ice-shelf melting method, input to model"
                 />
-                <var name="ismip6shelfMelt_zOcean" type="real" dimensions="nISMIP6OceanLayers" units="m" packages="ismip6ShelfMelt;ismip6GroundedFaceMelt"
+                <var name="ismip6shelfMelt_zOcean" type="real" dimensions="nISMIP6OceanLayers" units="m" packages="ismip6ShelfMelt"
                      description="depth coordinate associated with ismip6shelfMelt_3dThermalForcing field, input to model"
                 />
                 <var name="ismip6shelfMelt_offset" type="real" dimensions="nCells" units="kg m^{-2} s^{-1}" packages="ismip6ShelfMelt" default_value="0.0"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
@@ -104,6 +104,7 @@ module li_core_interface
       character (len=StrKIND), pointer :: config_basal_mass_bal_float
       character (len=StrKIND), pointer :: config_front_mass_bal_grounded
       character (len=StrKIND), pointer :: config_thermal_solver
+      logical, pointer :: config_use_3d_thermal_forcing_for_face_melt
       logical, pointer :: config_SGH
       logical, pointer :: config_adaptive_timestep_include_DCFL
       logical, pointer :: config_write_albany_ascii_mesh
@@ -124,6 +125,7 @@ module li_core_interface
       call mpas_pool_get_config(configPool, 'config_write_albany_ascii_mesh', config_write_albany_ascii_mesh)
       call mpas_pool_get_config(configPool, 'config_basal_mass_bal_float', config_basal_mass_bal_float)
       call mpas_pool_get_config(configPool, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
+      call mpas_pool_get_config(configPool, 'config_use_3d_thermal_forcing_for_face_melt', config_use_3d_thermal_forcing_for_face_melt)
       call mpas_pool_get_config(configPool, 'config_thermal_solver', config_thermal_solver)
 
       call mpas_pool_get_package(packagePool, 'SIAvelocityActive', SIAvelocityActive)
@@ -155,10 +157,13 @@ module li_core_interface
               "'config_write_albany_ascii_mesh' is set to .true.")
       endif
 
-      if (trim(config_basal_mass_bal_float) == 'ismip6') then
+      if ( (trim(config_basal_mass_bal_float) == 'ismip6') .or. &
+           ((trim(config_front_mass_bal_grounded) == 'ismip6') .and. &
+            (config_use_3d_thermal_forcing_for_face_melt)) ) then
          ismip6ShelfMeltActive = .true.
          call mpas_log_write("The 'ismip6Melt' package and assocated variables have been enabled because " // &
-              "'config_basal_mass_bal_float' is set to 'ismip6'")
+              "'config_basal_mass_bal_float' is set to 'ismip6' or 'config_front_mass_bal_grounded' is set to 'ismip6' // &
+              and 'config_use_3d_thermal_forcing_for_face_melt' is set to .true.")
       endif
 
       if ((trim(config_front_mass_bal_grounded) == 'ismip6') .or. (trim(config_calving) == 'ismip6_retreat')) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1379,6 +1379,8 @@ module li_iceshelf_melt
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool, meshPool, velocityPool
       real (kind=RKIND), pointer :: seaLevel
+      real (kind=RKIND), pointer :: faceMeltingCFLdt
+      real (kind=RKIND), pointer :: dtFaceMeltingCFLratio
       real (kind=RKIND), dimension(:), pointer :: thickness, faceMeltingThickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
@@ -1443,6 +1445,8 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
+         call mpas_pool_get_array(geometryPool, 'faceMeltingCFLdt', faceMeltingCFLdt)
+         call mpas_pool_get_array(geometryPool, 'dtFaceMeltingCFLratio', dtFaceMeltingCFLratio)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
             call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
@@ -1505,7 +1509,8 @@ module li_iceshelf_melt
          ! Distribute melt among neighbors
          call li_apply_front_ablation_velocity(meshPool, geometryPool, velocityPool, &
                                             faceMeltingThickness, faceMeltSpeedVertAvg, applyToGrounded, &
-                                            applyToFloating, applyToGroundingLine, domain, err=err_tmp)
+                                            applyToFloating, applyToGroundingLine, domain, & 
+                                            maxDt=faceMeltingCFLdt, CFLratio=dtFaceMeltingCFLratio, err=err_tmp)
          err = ior(err, err_tmp)
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1373,7 +1373,7 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
-      integer, pointer :: nCells, nCellsSolve
+      integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers
       integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
       real (kind=RKIND) :: waterDepth
       type (block_type), pointer :: block
@@ -1445,24 +1445,30 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
+            call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
-            call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_zOcean", zOcean)
-            call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_deltaT", ismip6shelfMelt_deltaT)
+            call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
+            call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_deltaT', ismip6shelfMelt_deltaT)
 
             ! Calculate thermal forcing based on bedTopography
             TFocean(:) = 0.0_RKIND
             do iCell = 1, nCellsSolve
                if (bedTopography(iCell) < 0.0_RKIND) then
                   kk = 1
-                  ! Calculate TF at ocean floor, assuming slope from layers above
-                  do while ( zOcean(kk) >= bedTopography(iCell) )
+                  ! Find deepest zOcean above ocean floor
+                  do while ( (zOcean(kk) >= bedTopography(iCell)) .and. (kk < nISMIP6OceanLayers) )
                      kk = kk + 1
                   enddo
-                  TFocean(iCell) = (ismip6shelfMelt_3dThermalForcing(kk-1, iCell) - &
+                  ! Calculate thermal forcing at ocean floor. If possible, extrapolate slope from layers above.
+                  ! If too shallow (k<=2), just use TF at closest layer. This can probably be improved.
+                  if (kk <= 2 ) then
+                     TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                  else
+                     TFocean(iCell) = (ismip6shelfMelt_3dThermalForcing(kk-1, iCell) - &
                                    ismip6shelfMelt_3dThermalForcing(kk-2, iCell)) / (zOcean(kk-1) - &
                                    zOcean(kk-2)) * (bedTopography(iCell) - zOcean(kk-1)) + &
                                    ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
-                           
+                  endif 
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1458,21 +1458,18 @@ module li_iceshelf_melt
             TFocean(:) = 0.0_RKIND
             do iCell = 1, nCellsSolve
                if (bedTopography(iCell) < 0.0_RKIND) then
-                  kk = 1
-                  ! Find deepest zOcean above ocean floor
-                  do while ( (zOcean(kk) >= bedTopography(iCell)) .and. (kk < nISMIP6OceanLayers) )
-                     kk = kk + 1
-                  enddo
-                  ! Calculate thermal forcing at ocean floor. If possible, extrapolate slope from layers above.
-                  ! If too shallow (k<=2), just use TF at closest layer. This can probably be improved.
-                  if (kk <= 2 ) then
-                     TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
-                  else
-                     TFocean(iCell) = (ismip6shelfMelt_3dThermalForcing(kk-1, iCell) - &
-                                   ismip6shelfMelt_3dThermalForcing(kk-2, iCell)) / (zOcean(kk-1) - &
-                                   zOcean(kk-2)) * (bedTopography(iCell) - zOcean(kk-1)) + &
-                                   ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
-                  endif 
+                     kk = 1
+                     ! Find deepest zOcean above ocean floor
+                     do while ( (zOcean(kk) >= bedTopography(iCell)) .and. (kk < nISMIP6OceanLayers) )
+                        kk = kk + 1
+                     enddo
+                     ! Calculate thermal forcing at ocean floor, using deepest ocean layer above seafloor.
+                     ! If bed is shallower than first layer, use TF from the first layer.
+                     if ( (kk == 1) .or. (kk == nISMIP6OceanLayers) ) then
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     else
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     endif
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1463,12 +1463,15 @@ module li_iceshelf_melt
                      do while ( (zOcean(kk) >= bedTopography(iCell)) .and. (kk < nISMIP6OceanLayers) )
                         kk = kk + 1
                      enddo
-                     ! Calculate thermal forcing at ocean floor, using deepest ocean layer above seafloor.
                      ! If bed is shallower than first layer, use TF from the first layer.
+                     ! If bed is deeper than the bottomg ocean layer, use TF from the bottom layer.
                      if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
                         TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     ! For all other bed depths, interpolate linearly between layers above and below bed depth.
                      else
-                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
+                        TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
+                                           (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
+                                           (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
                      endif
                endif
             end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1429,14 +1429,27 @@ module li_iceshelf_melt
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
+         call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
 
-         ! Get ISMIP6 forcing fields
+         ! Get mesh and geometry arrays
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
+         call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
+
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
             call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_zOcean", zOcean)
             call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_deltaT", ismip6shelfMelt_deltaT)
 
-            ! Vertically average thermal forcing based on bedTopography
+            ! Calculate thermal forcing based on bedTopography
             TFocean(:) = 0.0_RKIND
             do iCell = 1, nCellsSolve
                if (bedTopography(iCell) < 0.0_RKIND) then
@@ -1453,21 +1466,6 @@ module li_iceshelf_melt
                endif
             end do
          endif
-
-         call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
-
-         ! Get mesh and geometry arrays
-         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-         call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-         call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-         call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
-         call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
-         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
 
          faceMeltSpeed(:) = 0.0_RKIND
          allocate(faceMeltSpeedVertAvg(nCells+1))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1465,7 +1465,7 @@ module li_iceshelf_melt
                      enddo
                      ! Calculate thermal forcing at ocean floor, using deepest ocean layer above seafloor.
                      ! If bed is shallower than first layer, use TF from the first layer.
-                     if ( (kk == 1) .or. (kk == nISMIP6OceanLayers) ) then
+                     if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
                         TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
                      else
                         TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1383,6 +1383,9 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: lowerSurface
       real (kind=RKIND), dimension(:), pointer :: TFocean, ismip6Runoff
+      real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing
+      real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_deltaT
+      real (kind=RKIND), dimension(:), pointer :: zOcean
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
       real (kind=RKIND), pointer :: aSubglacial ! param A
@@ -1392,13 +1395,14 @@ module li_iceshelf_melt
       real (kind=RKIND), pointer :: addTFocean ! adjust ocean thermal forcing
       real (kind=RKIND), pointer :: config_uniform_face_melt_rate
       character(len=StrKIND), pointer :: config_front_mass_bal_grounded
+      logical, pointer :: config_use_3d_thermal_forcing_for_face_melt
       real (kind=RKIND), parameter :: secPerDay = 86400.0_RKIND
       real (kind=RKIND), parameter :: rhow = 1000.0_RKIND ! subglacial runoff density
       real (kind=RKIND), dimension(:), pointer :: faceMeltSpeed
       real (kind=RKIND), dimension(:), allocatable :: faceMeltSpeedVertAvg !vertically averaged faceMeltSpeed
                                                                 !to pass to  li_apply_front_ablation_velocity,
                                                                 !because faceMeltSpeed is only below water-line
-      integer :: err_tmp
+      integer :: err_tmp, kk
 
       err = 0
       call mpas_log_write('Starting face melt routine')
@@ -1415,6 +1419,7 @@ module li_iceshelf_melt
       call mpas_pool_get_config(liConfigs, 'config_add_ocean_thermal_forcing', addTFocean)
       call mpas_pool_get_config(liConfigs, 'config_uniform_face_melt_rate', config_uniform_face_melt_rate)
       call mpas_pool_get_config(liConfigs, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
+      call mpas_pool_get_config(liConfigs, 'config_use_3d_thermal_forcing_for_face_melt', config_use_3d_thermal_forcing_for_face_melt)
 
       block => domain % blocklist
       do while (associated(block))
@@ -1423,9 +1428,32 @@ module li_iceshelf_melt
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
 
          ! Get ISMIP6 forcing fields
-         call mpas_pool_get_array(geometryPool, 'ismip6_2dThermalForcing', TFocean)
+         if ( config_use_3d_thermal_forcing_for_face_melt ) then
+            call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
+            call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_zOcean", zOcean)
+            call mpas_pool_get_array(geometryPool, "ismip6shelfMelt_deltaT", ismip6shelfMelt_deltaT)
+
+            ! Vertically average thermal forcing based on bedTopography
+            TFocean(:) = 0.0_RKIND
+            do iCell = 1, nCellsSolve
+               if (bedTopography(iCell) < 0.0_RKIND) then
+                  kk = 1
+                  ! Calculate TF at ocean floor, assuming slope from layers above
+                  do while ( zOcean(kk) >= bedTopography(iCell) )
+                     kk = kk + 1
+                  enddo
+                  TFocean(iCell) = (ismip6shelfMelt_3dThermalForcing(kk-1, iCell) - &
+                                   ismip6shelfMelt_3dThermalForcing(kk-2, iCell)) / (zOcean(kk-1) - &
+                                   zOcean(kk-2)) * (bedTopography(iCell) - zOcean(kk-1)) + &
+                                   ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
+                           
+               endif
+            end do
+         endif
+
          call mpas_pool_get_array(geometryPool, 'ismip6Runoff', ismip6Runoff)
 
          ! Get mesh and geometry arrays

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -279,7 +279,7 @@ module li_time_integration_fe
 
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
-      real (kind=RKIND), pointer :: calvingCFLdt
+      real (kind=RKIND), pointer :: calvingCFLdt, faceMeltingCFLdt
       integer, pointer :: processLimitingTimestep
       integer, dimension(:), pointer :: edgeMask
 
@@ -502,8 +502,9 @@ module li_time_integration_fe
       ! Set adaptive timestep if needed
       if (config_adaptive_timestep) then
          call mpas_pool_get_array(geometryPool, 'calvingCFLdt', calvingCFLdt)
+         call mpas_pool_get_array(geometryPool, 'faceMeltingCFLdt', faceMeltingCFLdt)
          call mpas_pool_get_array(meshPool, 'processLimitingTimestep', processLimitingTimestep)
-         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, calvingCFLdt, domain % clock, dtSeconds, processLimitingTimestep, err_tmp)
+         call set_timestep(allowableAdvecDtAllProcs, allowableDiffDtAllProcs, calvingCFLdt, faceMeltingCFLdt, domain % clock, dtSeconds, processLimitingTimestep, err_tmp)
          err = ior(err,err_tmp)
          ! Set new value on all blocks
          block => domain % blocklist
@@ -831,7 +832,7 @@ module li_time_integration_fe
 !>  This routine sdjusts the time step based on the CFL condition.
 !
 !-----------------------------------------------------------------------
-   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, calvingCFLdt, clock, dtSeconds, CFLprocess, err)
+   subroutine set_timestep(allowableAdvecDt, allowableDiffDt, calvingCFLdt, faceMeltingCFLdt, clock, dtSeconds, CFLprocess, err)
       use mpas_timekeeping
 
       !-----------------------------------------------------------------
@@ -839,7 +840,7 @@ module li_time_integration_fe
       !-----------------------------------------------------------------
       real (kind=RKIND), intent(in) :: allowableAdvecDt
       real (kind=RKIND), intent(in) :: allowableDiffDt
-      real (kind=RKIND), intent(in) :: calvingCFLdt
+      real (kind=RKIND), intent(in) :: calvingCFLdt, faceMeltingCFLdt
       type (MPAS_Clock_type), intent(in) :: clock
 
       !-----------------------------------------------------------------
@@ -853,12 +854,14 @@ module li_time_integration_fe
       ! local variables
       !-----------------------------------------------------------------
       logical, pointer :: config_adaptive_timestep_include_DCFL
-      logical, pointer :: config_adaptive_timestep_include_calving
+      logical, pointer :: config_adaptive_timestep_include_calving, &
+                          config_adaptive_timestep_include_face_melting
       real (kind=RKIND), pointer :: config_adaptive_timestep_CFL_fraction
-      real (kind=RKIND), pointer :: config_adaptive_timestep_calvingCFL_fraction
+      real (kind=RKIND), pointer :: config_adaptive_timestep_calvingCFL_fraction, &
+                                    config_adaptive_timestep_faceMeltingCFL_fraction
       real (kind=RKIND), pointer :: config_max_adaptive_timestep
       real (kind=RKIND), pointer :: config_min_adaptive_timestep
-      character (len=StrKIND), pointer :: config_calving
+      character (len=StrKIND), pointer :: config_calving, config_front_mass_bal_grounded
       character (len=StrKIND), pointer :: config_damage_calving_method
       type (MPAS_Time_type) :: nextForceTime, currTime
       type (MPAS_TimeInterval_type) :: intervalToNextForceTime
@@ -876,8 +879,11 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_min_adaptive_timestep', config_min_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_calving', config_adaptive_timestep_include_calving)
+      call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_face_melting', config_adaptive_timestep_include_face_melting)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_calvingCFL_fraction', config_adaptive_timestep_calvingCFL_fraction)
+      call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_faceMeltingCFL_fraction', config_adaptive_timestep_faceMeltingCFL_fraction)
       call mpas_pool_get_config(liConfigs, 'config_calving', config_calving)
+      call mpas_pool_get_config(liConfigs, 'config_front_mass_bal_grounded', config_front_mass_bal_grounded)
       call mpas_pool_get_config(liConfigs, 'config_damage_calving_method', config_damage_calving_method)
 
 
@@ -906,16 +912,28 @@ module li_time_integration_fe
          endif
       endif
 
-      call mpas_log_write("CFL dt adjusted for fractions (days): advective=$r, diffusive=$r, calving=$r", &
+      ! Only include face-melting CFL if requested and we are using a calving option that calculates it.
+      if (config_adaptive_timestep_include_face_melting .and. ( &
+             trim(config_front_mass_bal_grounded) .ne. 'none' ) ) then
+         if (config_adaptive_timestep_faceMeltingCFL_fraction * faceMeltingCFLdt < allowableDt) then
+            allowableDt = config_adaptive_timestep_faceMeltingCFL_fraction * faceMeltingCFLdt
+            CFLprocess = 4
+         endif
+      endif
+
+      call mpas_log_write("CFL dt adjusted for fractions (days): advective=$r, diffusive=$r, calving=$r, face-melting=$r", &
          realArgs=(/allowableAdvecDt*config_adaptive_timestep_CFL_fraction/86400.0_RKIND, &
                     allowableDiffDt/86400.0_RKIND, &
-                    calvingCFLdt*config_adaptive_timestep_calvingCFL_fraction/86400.0_RKIND/))
+                    calvingCFLdt*config_adaptive_timestep_calvingCFL_fraction/86400.0_RKIND, &
+                    faceMeltingCFLdt*config_adaptive_timestep_faceMeltingCFL_fraction/86400.0_RKIND/) )
       if (CFLprocess == 1) then
          call mpas_log_write("Timestep limited by advective CFL condition.")
       elseif (CFLprocess == 2) then
          call mpas_log_write("Timestep limited by diffusive CFL condition.")
       elseif (CFLprocess == 3) then
          call mpas_log_write("Timestep limited by calving CFL condition.")
+      elseif (CFLprocess == 4) then
+         call mpas_log_write("Timestep limited by face-melting CFL condition.")
       endif
 
       ! Take minimum of the max adaptive timestep setting and the allowable dt from the CFL condition

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -847,7 +847,7 @@ module li_time_integration_fe
       ! output variables
       !-----------------------------------------------------------------
       real (kind=RKIND), intent(out) :: dtSeconds  !< Output: time step in seconds determined by this routine
-      integer, intent(out) :: CFLprocess !< Output: flag for which process limits the CFL: 1=advective, 2=diffusive, 3=calving
+      integer, intent(out) :: CFLprocess !< Output: flag for which process limits the CFL: 1=advective, 2=diffusive, 3=calving, 4=face-melting
       integer, intent(out) :: err !< Output: error flag
 
       !-----------------------------------------------------------------


### PR DESCRIPTION
This merge adds to ability to use a 3D ocean thermal forcing field in the ISMIP6/Rignot (2016) face-melting parameterization for grounded marine margins. If the new namelist option `config_use_3d_thermal_forcing_for_face_melt`, the relevant 2D thermal forcing is calculated from `ismip6shelfMelt_3dThermalForcing`, `ismip6shelfMelt_deltaT`, and `bedTopography`. As in Slater et al. (2020), it uses the thermal forcing at the ocean floor. Another approach would be to use a depth-averaged thermal forcing, but the treatment used here is consistent with ISMIP6.
This also sets default values for `ismip6shelfMelt_3dThermalForcing` and `ismip6_2dThermalForcing` to 0.0 instead of 2.0. The previous implementation was dangerous because it could create a reasonable melt field even if the input streams were incorrect and thermal forcing data was not being read.