### PR TITLE
Add totalFaceMeltingFlux to global and regional stats output

### DIFF
--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -85,6 +85,9 @@
                 <var name="totalCalvingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
                         description="total, area integrated mass loss due to calving. Positive values represent ice loss."
                 />
+                <var name="totalFaceMeltingFlux" type="real" dimensions="Time" units="kg yr^{-1}"
+                        description="total, area integrated mass loss due to face melting. Positive values represent ice loss."
+                />
                 <var name="groundingLineFlux" type="real" dimensions="Time" units="kg yr^{-1}"
                         description="total mass flux across all grounding lines.  Note that flux from floating to grounded ice makes a negative contribution to this metric."
                 />

--- a/components/mpas-albany-landice/src/analysis_members/Registry_regional_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_regional_stats.xml
@@ -87,6 +87,9 @@
                 <var name="regionalSumCalvingFlux" type="real" dimensions="nRegions Time" units="kg yr^{-1}"
                         description="area-integrated calving flux within region"
                 />
+                <var name="regionalSumFaceMeltingFlux" type="real" dimensions="nRegions Time" units="kg yr^{-1}"
+                        description="area-integrated face-melting flux within region"
+                />
                 <var name="regionalSumGroundingLineFlux" type="real" dimensions="nRegions Time" units="kg yr^{-1}"
                         description="total mass flux across all grounding lines (note that flux from floating to grounded ice makes a negative contribution to this metric)"
                 />

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -176,6 +176,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness
+      real (kind=RKIND), dimension(:), pointer ::  faceMeltingThickness
       real (kind=RKIND), dimension(:), pointer ::  surfaceSpeed
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
@@ -200,6 +201,7 @@ contains
       real (kind=RKIND), pointer ::  iceThicknessMax, iceThicknessMin, iceThicknessMean
       real (kind=RKIND), pointer ::  totalSfcMassBal, totalBasalMassBal
       real (kind=RKIND), pointer ::  totalGroundedSfcMassBal, totalFloatingSfcMassBal
+      real (kind=RKIND), pointer ::  totalFaceMeltingFlux
       real (kind=RKIND), pointer ::  totalGroundedBasalMassBal, totalFloatingBasalMassBal
       real (kind=RKIND), pointer ::  avgNetAccumulation
       real (kind=RKIND), pointer ::  avgGroundedBasalMelt
@@ -220,6 +222,7 @@ contains
       real (kind=RKIND) ::  blockSumGroundedSfcMassBal, blockSumFloatingSfcMassBal
       real (kind=RKIND) ::  blockSumGroundedBasalMassBal, blockSumFloatingBasalMassBal
       real (kind=RKIND) ::  blockSumCalvingFlux
+      real (kind=RKIND) ::  blockSumFaceMeltingFlux
       real (kind=RKIND) ::  blockMaxSurfaceSpeed
       real (kind=RKIND) ::  blockMaxBasalSpeed
       real (kind=RKIND) ::  blockGLflux
@@ -251,6 +254,7 @@ contains
       blockSumGroundedBasalMassBal = 0.0_RKIND
       blockSumFloatingBasalMassBal = 0.0_RKIND
       blockSumCalvingFlux = 0.0_RKIND
+      blockSumFaceMeltingFlux = 0.0_RKIND
       blockGLflux = 0.0_RKIND
       blockGLMigrationFlux = 0.0_RKIND
 
@@ -290,6 +294,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
          call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
@@ -335,8 +340,12 @@ contains
             blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr
             blockSumFloatingBasalMassBal = blockSumFloatingBasalMassBal + areaCell(iCell) * floatingBasalMassBalApplied(iCell) * scyr
 
-            ! mass lass due do calving (kg yr^{-1})
+            ! mass loss due do calving (kg yr^{-1})
             blockSumCalvingFlux = blockSumCalvingFlux + calvingThickness(iCell) * &
+               areaCell(iCell) * rhoi / ( deltat / scyr )
+
+            ! mass loss due to face-melting (kg yr^{-1})
+            blockSumFaceMeltingFlux = blockSumFaceMeltingFlux + faceMeltingThickness(iCell) * &
                areaCell(iCell) * rhoi / ( deltat / scyr )
 
             ! max surface speed
@@ -405,10 +414,11 @@ contains
       sums(11) = blockSumGroundedBasalMassBal
       sums(12) = blockSumFloatingBasalMassBal
       sums(13) = blockSumCalvingFlux
-      sums(14) = blockSumVAF
-      sums(15) = blockGLflux
-      sums(16) = blockGLMigrationflux
-      nVars = 16
+      sums(14) = blockSumFaceMeltingFlux
+      sums(15) = blockSumVAF
+      sums(16) = blockGLflux
+      sums(17) = blockGLMigrationflux
+      nVars = 17
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -434,6 +444,7 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'totalFloatingBasalMassBal', totalFloatingBasalMassBal)
          call mpas_pool_get_array(globalStatsAMPool, 'avgSubshelfMelt', avgSubshelfMelt)
          call mpas_pool_get_array(globalStatsAMPool, 'totalCalvingFlux', totalCalvingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
 
@@ -450,9 +461,10 @@ contains
          totalGroundedBasalMassBal = reductions(11)
          totalFloatingBasalMassBal = reductions(12)
          totalCalvingFlux = reductions(13)
-         volumeAboveFloatation = reductions(14)
-         groundingLineFlux = reductions(15)
-         groundingLineMigrationFlux = reductions(16)
+         totalFaceMeltingFlux = reductions(14)
+         volumeAboveFloatation = reductions(15)
+         groundingLineFlux = reductions(16)
+         groundingLineMigrationFlux = reductions(17)
 
          if (totalIceArea > 0.0_RKIND) then
             iceThicknessMean = totalIceVolume / totalIceArea

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -178,6 +178,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  groundedBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  floatingBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer ::  calvingThickness
+      real (kind=RKIND), dimension(:), pointer ::  faceMeltingThickness
       real (kind=RKIND), dimension(:), pointer ::  surfaceSpeed
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
@@ -209,6 +210,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  regionalSumGroundedSfcMassBal, regionalSumFloatingSfcMassBal
       real (kind=RKIND), dimension(:), pointer ::  regionalSumGroundedBasalMassBal, regionalSumFloatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer ::  regionalSumCalvingFlux
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumFaceMeltingFlux
       real (kind=RKIND), dimension(:), pointer ::  regionalSumGroundingLineFlux
       real (kind=RKIND), dimension(:), pointer ::  regionalSumGroundingLineMigrationFlux
       real (kind=RKIND), dimension(:), pointer ::  regionalAvgNetAccumulation
@@ -227,6 +229,7 @@ contains
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionGroundedSfcMassBal, blockSumRegionFloatingSfcMassBal
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionGroundedBasalMassBal, blockSumRegionFloatingBasalMassBal
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionCalvingFlux
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionFaceMeltingFlux
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionGLflux
       real (kind=RKIND), dimension(:), allocatable ::  blockRegionGLMigrationFlux
       real (kind=RKIND), dimension(:), allocatable ::  blockRegionMaxSurfaceSpeed
@@ -283,6 +286,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
          call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
@@ -303,6 +307,7 @@ contains
          allocate(blockSumRegionGroundedBasalMassBal(nRegions)); allocate(blockSumRegionFloatingBasalMassBal(nRegions))
          allocate(blockSumRegionGroundedSfcMassBal(nRegions)); allocate(blockSumRegionFloatingSfcMassBal(nRegions))
          allocate(blockSumRegionCalvingFlux(nRegions))
+         allocate(blockSumRegionFaceMeltingFlux(nRegions))
          allocate(blockSumRegionGLflux(nRegions))
          allocate(blockRegionGLMigrationFlux(nRegions))
 
@@ -316,6 +321,7 @@ contains
          blockSumRegionGroundedSfcMassBal = 0.0_RKIND; blockSumRegionFloatingSfcMassBal = 0.0_RKIND
          blockSumRegionGroundedBasalMassBal = 0.0_RKIND; blockSumRegionFloatingBasalMassBal = 0.0_RKIND
          blockSumRegionCalvingFlux = 0.0_RKIND
+         blockSumRegionFaceMeltingFlux = 0.0_RKIND
          blockSumRegionGLflux = 0.0_RKIND
          blockRegionGLMigrationFlux = 0.0_RKIND
 
@@ -386,6 +392,11 @@ contains
             blockSumRegionCalvingFlux(iRegion) = blockSumRegionCalvingFlux(iRegion) + &
             ( real(regionCellMasks(iRegion,iCell),RKIND) &
               * calvingThickness(iCell) * areaCell(iCell) * config_ice_density / ( deltat / scyr ) )
+
+            ! regional sum of mass lass due do face-melting (kg yr^{-1})
+            blockSumRegionFaceMeltingFlux(iRegion) = blockSumRegionFaceMeltingFlux(iRegion) + &
+            ( real(regionCellMasks(iRegion,iCell),RKIND) &
+              * faceMeltingThickness(iCell) * areaCell(iCell) * config_ice_density / ( deltat / scyr ) )
 
             ! max, min thickness values (m)
             if( ( thickness(iCell) * real(regionCellMasks(iRegion,iCell),RKIND) * &
@@ -479,10 +490,11 @@ contains
         sums(11) = blockSumRegionGroundedBasalMassBal(iRegion)
         sums(12) = blockSumRegionFloatingBasalMassBal(iRegion)
         sums(13) = blockSumRegionCalvingFlux(iRegion)
-        sums(14) = blockSumRegionVAF(iRegion)
-        sums(15) = blockSumRegionGLflux(iRegion)
-        sums(16) = blockRegionGLMigrationFlux(iRegion)
-        nVars = 16
+        sums(14) = blockSumRegionFaceMeltingFlux(iRegion)
+        sums(15) = blockSumRegionVAF(iRegion)
+        sums(16) = blockSumRegionGLflux(iRegion)
+        sums(17) = blockRegionGLMigrationFlux(iRegion)
+        nVars = 17
 
         call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -510,6 +522,7 @@ contains
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumFloatingBasalMassBal', regionalSumFloatingBasalMassBal)
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalAvgSubshelfMelt', regionalAvgSubshelfMelt)
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumCalvingFlux', regionalSumCalvingFlux)
+           call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumFaceMeltingFlux', regionalSumFaceMeltingFlux)
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumGroundingLineFlux', regionalSumGroundingLineFlux)
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumGroundingLineMigrationFlux', &
                    regionalSumGroundingLineMigrationFlux)
@@ -527,9 +540,10 @@ contains
            regionalSumGroundedBasalMassBal(iRegion) = reductions(11)
            regionalSumFloatingBasalMassBal(iRegion) = reductions(12)
            regionalSumCalvingFlux(iRegion) = reductions(13)
-           regionalVolumeAboveFloatation(iRegion) = reductions(14)
-           regionalSumGroundingLineFlux(iRegion) = reductions(15)
-           regionalSumGroundingLineMigrationFlux(iRegion) = reductions(16)
+           regionalSumFaceMeltingFlux(iRegion) = reductions(14)
+           regionalVolumeAboveFloatation(iRegion) = reductions(15)
+           regionalSumGroundingLineFlux(iRegion) = reductions(16)
+           regionalSumGroundingLineMigrationFlux(iRegion) = reductions(17)
 
            if (regionalIceArea(iRegion) > 0.0_RKIND) then
               regionalIceThicknessMean(iRegion) = regionalIceVolume(iRegion) / regionalIceArea(iRegion)
@@ -607,6 +621,7 @@ contains
       deallocate(blockSumRegionGroundedSfcMassBal); deallocate(blockSumRegionFloatingSfcMassBal)
       deallocate(blockSumRegionGroundedBasalMassBal); deallocate(blockSumRegionFloatingBasalMassBal)
       deallocate(blockSumRegionCalvingFlux)
+      deallocate(blockSumRegionFaceMeltingFlux)
       deallocate(blockSumRegionGLflux)
       deallocate(blockRegionGLMigrationflux)
 


### PR DESCRIPTION
Add a new metric called `totalFaceMeltingFlux` to global stats output and `regionalSumFaceMeltingFlux` to regional stats output to keep track of mass loss due to ocean melting of grounded termini.