### PR TITLE
Add flux-corrected transport scheme to MALI

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -121,7 +121,7 @@
 			    possible_values="2, 3 and 4"
 		/>
 		<nml_option name="config_advection_coef_3rd_order" type="real" default_value="0.25" units="unitless"
-					description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction"
+					description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction. Equivalent to beta in Skamarock and Gassmann (2011) eq. 7. 0 is fully 4th order, 1 is fully 3rd order."
 					possible_values="any real between 0 and 1"
 		/>
 		<nml_option name="config_restore_thickness_after_advection" type="logical" default_value=".false." units="unitless"
@@ -647,7 +647,7 @@
 		            possible_values=".true. or .false."
 		/>
 		<nml_option name="config_check_tracer_monotonicity" type="logical" default_value=".false."
-                            description="Enables a change on tracer monotonicity at the end of the monotonic advection routine. Only used if config_flux_limiter is set to monotonic"
+                            description="Check tracer monotonicity at the end of the monotonic advection routine and write warnings to log file if not monotonic."
                             possible_values=".true. or .false."
 		/>
 	</nml_record>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -753,7 +753,7 @@
                         <var name="uReconstructX" packages="higherOrderVelocity"/>
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
                         <var name="basalFrictionFlux"/>
-                        <var name="passiveTracer"/>
+                        <var name="passiveTracer2d"/>
 			<var name="damage"/>
 			<var name="calvingVelocityData"/>
 			<var name="basalMeltInput" packages="hydro"/>
@@ -863,7 +863,7 @@
 			<var name="waterPressure" packages="hydro"/>
                         <var name="channelArea" packages="hydro"/>  <!-- this is only needed if running with channels - could be package-controlled -->
 			<var name="waterFluxMask" packages="hydro"/>
-                        <var name="passiveTracer"/>
+                        <var name="passiveTracer2d"/>
 			<var name="damage"/>
 			<var name="calvingVelocityData"/>
 			<var name="damageMax"/>
@@ -1284,7 +1284,7 @@ is the value of that variable from the *previous* time level!
                 <var name="calvingVelocityData" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane), given by the input netCDF file."
                 />
-                <var name="passiveTracer" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                <var name="passiveTracer2d" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="passive tracer used to verify advection routines"
                 />
                 <var name="damage" type="real" dimensions="nCells Time" units="none" time_levs="1"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -116,9 +116,9 @@
 		            description="Selection of the method for advecting tracers."
 		            possible_values="'fo', 'fct', 'none'"
 		/>
-		<nml_option name="config_horiz_tracer_adv_order" type="integer" default_value="3"
-					description="Order of polynomial used for tracer reconstruction at cell edges"
-					possible_values="2, 3 and 4"
+		<nml_option name="config_horiz_tracer_adv_order" type="integer" default_value="3" units="unitless"
+			    description="Order of polynomial used for tracer reconstruction at cell edges"
+			    possible_values="2, 3 and 4"
 		/>
 		<nml_option name="config_advection_coef_3rd_order" type="real" default_value="0.25" units="unitless"
 					description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -42,7 +42,7 @@
 		<dim name="nISMIP6OceanLayers" units="unitless"
 		     description="The number of layers in the ISMIP6 ocean temperature dataset."
 		/>
-		<dim name="maxTracersAdvect" definition="3" units="unitless"
+		<dim name="maxTracersAdvect" definition="4" units="unitless"
 		     description="The maximum number of tracers to be advected."
 		/>
 		<dim name="nRegions" definition="1" units="unitless"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -42,7 +42,7 @@
 		<dim name="nISMIP6OceanLayers" units="unitless"
 		     description="The number of layers in the ISMIP6 ocean temperature dataset."
 		/>
-		<dim name="maxTracersAdvect" definition="2" units="unitless"
+		<dim name="maxTracersAdvect" definition="3" units="unitless"
 		     description="The maximum number of tracers to be advected."
 		/>
 		<dim name="nRegions" definition="1" units="unitless"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -116,6 +116,10 @@
 		            description="Selection of the method for advecting tracers."
 		            possible_values="'fo', 'fct', 'none'"
 		/>
+		<nml_option name="config_horiz_tracer_adv_order" type="integer" default_value="3"
+					description="Order of polynomial used for tracer reconstruction at cell edges"
+					possible_values="2, 3 and 4"
+		/>
 		<nml_option name="config_advection_coef_3rd_order" type="real" default_value="0.25" units="unitless"
 					description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction"
 					possible_values="any real between 0 and 1"
@@ -641,6 +645,10 @@
 		<nml_option name="config_print_velocity_cleanup_details" type="logical" default_value=".false." units="unitless"
 		            description="After velocity is calculated there are a few checks for appropriate values in certain geometric configurations.  Setting this option to .true. will cause detailed information about those adjustments to be printed."
 		            possible_values=".true. or .false."
+		/>
+		<nml_option name="config_check_tracer_monotonicity" type="logical" default_value=".false."
+                            description="Enables a change on tracer monotonicity at the end of the monotonic advection routine. Only used if config_flux_limiter is set to monotonic"
+                            possible_values=".true. or .false."
 		/>
 	</nml_record>
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -753,6 +753,7 @@
                         <var name="uReconstructX" packages="higherOrderVelocity"/>
 			<var name="uReconstructY" packages="higherOrderVelocity"/>
                         <var name="basalFrictionFlux"/>
+                        <var name="passiveTracer"/>
 			<var name="damage"/>
 			<var name="calvingVelocityData"/>
 			<var name="basalMeltInput" packages="hydro"/>
@@ -862,6 +863,7 @@
 			<var name="waterPressure" packages="hydro"/>
                         <var name="channelArea" packages="hydro"/>  <!-- this is only needed if running with channels - could be package-controlled -->
 			<var name="waterFluxMask" packages="hydro"/>
+                        <var name="passiveTracer"/>
 			<var name="damage"/>
 			<var name="calvingVelocityData"/>
 			<var name="damageMax"/>
@@ -1281,6 +1283,9 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="calvingVelocityData" type="real" dimensions="nCells Time" units="m s^{-1}" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane), given by the input netCDF file."
+                />
+                <var name="passiveTracer" type="real" dimensions="nCells Time" units="none" time_levs="1"
+                     description="passive tracer used to verify advection routines"
                 />
                 <var name="damage" type="real" dimensions="nCells Time" units="none" time_levs="1"
                      description="Damage is parameterized as the local ice thickness divided by the fracture depth, such that unfractured ice has damage=0 and ice fractured through its full thickness has damage=1"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -110,12 +110,16 @@
 	<nml_record name="advection" in_defaults="true">
 		<nml_option name="config_thickness_advection" type="character" default_value="fo" units="unitless"
 		            description="Selection of the method for advecting thickness ('fo' = first-order upwinding)."
-		            possible_values="'fo', 'none'"
+		            possible_values="'fo', 'fct', 'none'"
 		/>
 		<nml_option name="config_tracer_advection" type="character" default_value="none" units="unitless"
 		            description="Selection of the method for advecting tracers."
-		            possible_values="'fo', 'none'"
-                />
+		            possible_values="'fo', 'fct', 'none'"
+		/>
+		<nml_option name="config_advection_coef_3rd_order" type="real" default_value="0.25" units="unitless"
+					description="Reconstruction of 3rd-order reconstruction to blend with 4th-order reconstuction"
+					possible_values="any real between 0 and 1"
+		/>
 		<nml_option name="config_restore_thickness_after_advection" type="logical" default_value=".false." units="unitless"
 			    description="If true, reset thickness to values at previous timestep after advection occurs. This is used for spinning up tracer fields such as damage.  When this is true, geometry changes from surface and basal mass balance (grounded or floating) and facemelting are not retained, but changes from calving are."
 			    possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/mode_forward/Makefile
+++ b/components/mpas-albany-landice/src/mode_forward/Makefile
@@ -7,6 +7,8 @@ OBJS =  mpas_li_core.o \
     mpas_li_time_integration_fe.o \
     mpas_li_diagnostic_vars.o \
     mpas_li_advection.o \
+    mpas_li_advection_fct_shared.o \
+    mpas_li_advection_fct.o \
     mpas_li_calving.o \
     mpas_li_statistics.o \
     mpas_li_velocity.o \
@@ -45,7 +47,11 @@ mpas_li_time_integration_fe.o: mpas_li_advection.o \
 			       mpas_li_bedtopo.o
 
 mpas_li_advection.o: mpas_li_thermal.o \
+                     mpas_li_advection_fct.o \
+                     mpas_li_advection_fct_shared.o \
 	             mpas_li_diagnostic_vars.o
+
+mpas_li_advection_fct.o:  mpas_li_advection_fct_shared.o
 
 mpas_li_calving.o: mpas_li_thermal.o \
 		   mpas_li_advection.o

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -489,18 +489,14 @@ module li_advection
              ! Call fct routine for thickness first, and use activeTracerHorizontalAdvectionEdgeFlux
              ! returned by that call as normalThicknessFlux for call to tracer fct
              call li_tracer_advection_fct_tend(&
-                  tend, advectedTracers, layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
+                  tend(nTracers:,:,:), advectedTracers(nTracers:,:,:), layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
                   layerNormalVelocity, 0.0_RKIND * normalVelocity, dt,    &
-                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
+                  1, activeTracerHorizontalAdvectionEdgeFlux(nTracers:,:,:), computeBudgets=.false.)
              ! layerThickness is last tracer. However, for some reason
              ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
              ! This does conserve mass:
              layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
-             ! Reset tracers after thickness advection for tracer advection
-             ! TODO: determine whether we need to treat other tracer tendencies
-             ! the same as layerThickness for conservation.
-             advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
-             tend(:,:,:) = 0.0_RKIND
+
              ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
              ! from fct thickness advection as normalThicknessFlux
              call li_tracer_advection_fct_tend(&

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -184,8 +184,8 @@ module li_advection
            thermalCellMaskField
 
       ! Allocatable arrays need for flux-corrected transport advection
-      real (kind=RKIND), dimension(:,:), allocatable :: tendLayerThickness
       real (kind=RKIND), dimension(:,:,:), allocatable :: tend
+      real (kind=RKIND), dimension(:,:,:), allocatable :: activeTracerHorizontalAdvectionEdgeFlux
 
       integer, dimension(:), pointer :: &
            cellMask,              & ! integer bitmask for cells
@@ -403,10 +403,10 @@ module li_advection
 
          if ((trim(config_thickness_advection) .eq. 'fct') .or. &
              (trim(config_tracer_advection) .eq. 'fct' ) ) then
-            allocate(tendLayerThickness(nVertLevels,nCells+1))
-            tendLayerThickness(:,:) = 0.0_RKIND
             allocate(tend(nTracers,nVertLevels,nCells+1))
             tend(:,:,:) = 0.0_RKIND
+            allocate(activeTracerHorizontalAdvectionEdgeFlux(nTracers,nVertLevels+1,nEdges+1))
+            activeTracerHorizontalAdvectionEdgeFlux(:,:,:) = 0.0_RKIND
          endif
 
          ! Transport thickness and tracers using a first-order upwind scheme
@@ -469,16 +469,20 @@ module li_advection
              ! Reset tracers after fo advection for fct advection
              advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
 
+             ! Pass FO upwind normalThicknessFlux (layerThicknessEdge * layerNormalVelocity)
+             ! to fct tracer routine
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  nTracers, computeBudgets=.false.)!{{{
+                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)!{{{
          elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
                   trim(config_tracer_advection) .eq. 'fct') then
+             ! Call fct routine for thickness first, and use activeTracerHorizontalAdvectionEdgeFlux
+             ! returned by that call as normalThicknessFlux for call to tracer fct
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
                   layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  nTracers, computeBudgets=.false.)
+                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
              ! layerThickness is last tracer. However, for some reason
              ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
              ! This does conserve mass:
@@ -487,10 +491,13 @@ module li_advection
              ! TODO: determine whether we need to treat other tracer tendencies
              ! the same as layerThickness for conservation.
              advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
+             tend(:,:,:) = 0.0_RKIND
+             ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
+             ! from fct thickness advection as normalThicknessFlux
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
-                  layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  nTracers, computeBudgets=.false.)
+                  activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0 * normalVelocity, dt,    &
+                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
          endif
 
          if (config_print_thickness_advection_info) then
@@ -690,7 +697,9 @@ module li_advection
                      advCoefs, &
                      advCoefs3rd, &
                      advMaskHighOrder, &
-                     advMask2ndOrder)
+                     advMask2ndOrder, &
+                     tend, &
+                     activeTracerHorizontalAdvectionEdgeFlux)
       endif
 
       ! clean up

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1,3 +1,11 @@
+! Copyright (c) 2013-2018,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  li_advection
@@ -481,7 +489,7 @@ module li_advection
              ! returned by that call as normalThicknessFlux for call to tracer fct
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
-                  layerNormalVelocity, 0 * normalVelocity, dt,    &
+                  layerNormalVelocity, 0.0_RKIND * normalVelocity, dt,    &
                   nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
              ! layerThickness is last tracer. However, for some reason
              ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
@@ -496,7 +504,7 @@ module li_advection
              ! from fct thickness advection as normalThicknessFlux
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
-                  activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0 * normalVelocity, dt,    &
+                  activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
                   nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
          endif
 
@@ -1069,8 +1077,8 @@ module li_advection
          nTracers)
 
       use li_thermal, only: li_temperature_to_enthalpy_kelvin
-      use li_tracer_advection_fct_shared!, only: li_tracer_advection_fct_shared_init
-      use li_tracer_advection_fct!, only: li_tracer_advection_fct_init
+      use li_tracer_advection_fct_shared
+      use li_tracer_advection_fct
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -1266,7 +1274,7 @@ module li_advection
          iTracer = iTracer + 1
 
          ! copy 2d thickness to all vertical levels in the tracer array
-         advectedTracers(iTracer,:,:) = layerThickness(:,:) !1.0_RKIND
+         advectedTracers(iTracer,:,:) = layerThickness(:,:)
          surfaceTracers(iTracer,:) = 0.0_RKIND
          basalTracers(iTracer,:) = 0.0_RKIND
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -506,6 +506,11 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld, &
                   activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
                   nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
+         elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
+                  trim(config_tracer_advection) .eq. 'fo') then
+            err_tmp = 1
+            call mpas_log_write("config_tracer_advection = fo is not currently supposed &
+                                 with config_thickness_advection = fct", MPAS_LOG_ERR)
          endif
 
          if (config_print_thickness_advection_info) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -386,7 +386,7 @@ module li_advection
          endif
 
 
-         if (advectTracers) then
+         if ( (advectTracers) .or. (trim(config_thickness_advection) .eq. 'fct') ) then
 
             ! Copy the old tracer values into the advectedTracers array.
             ! This requires setting a tracer pointer to either temperature or enthalpy,
@@ -484,8 +484,7 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)!{{{
-         elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
-                  trim(config_tracer_advection) .eq. 'fct') then
+         elseif (trim(config_thickness_advection) .eq. 'fct') then
              ! Call fct routine for thickness first, and use activeTracerHorizontalAdvectionEdgeFlux
              ! returned by that call as normalThicknessFlux for call to tracer fct
              call li_tracer_advection_fct_tend(&
@@ -497,17 +496,25 @@ module li_advection
              ! This does conserve mass:
              layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
 
-             ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
-             ! from fct thickness advection as normalThicknessFlux
-             call li_tracer_advection_fct_tend(&
-                  tend(1:nTracers-1,:,:), advectedTracers(1:nTracers-1,:,:), layerThicknessOld, &
-                  activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
-                  nTracers-1, computeBudgets=.false.)
-         elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
-                  trim(config_tracer_advection) .eq. 'fo') then
+             if (trim(config_tracer_advection) .eq. 'fct') then
+                ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
+                ! from fct thickness advection as normalThicknessFlux
+                call li_tracer_advection_fct_tend(&
+                     tend(1:nTracers-1,:,:), advectedTracers(1:nTracers-1,:,:), layerThicknessOld, &
+                     activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
+                     nTracers-1, computeBudgets=.false.)
+             elseif (trim(config_tracer_advection) .eq. 'none') then
+                ! do nothing
+             else
+                err_tmp = 1
+                call mpas_log_write(trim(config_tracer_advection) // &
+                                    ' tracer advection is not currently supported with fct thickness advection.', MPAS_LOG_ERR)
+             endif
+         else
             err_tmp = 1
-            call mpas_log_write("config_tracer_advection = fo is not currently supposed &
-                                 with config_thickness_advection = fct", MPAS_LOG_ERR)
+            call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &
+                                ", config_tracer_advection = " // trim(config_tracer_advection) // &
+                                " is not a supported combination.", MPAS_LOG_ERR)
          endif
 
          if (config_print_thickness_advection_info) then
@@ -701,7 +708,8 @@ module li_advection
       err = ior(err,err_tmp)
 
       ! Deallocate arrays for fct
-      if (trim(config_tracer_advection) .eq. 'fct') then
+      if ( (trim(config_thickness_advection) .eq. 'fct') .or. &
+           (trim(config_tracer_advection) .eq. 'fct') ) then
          deallocate( nAdvCellsForEdge, &
                      advCellsForEdge, &
                      advCoefs, &
@@ -1285,7 +1293,8 @@ module li_advection
       nTracers = iTracer
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
-      if (trim(config_tracer_advection) == 'fct') then
+      if ( (trim(config_tracer_advection) == 'fct') .or. &
+           (trim(config_thickness_advection) == 'fct') ) then
          call li_tracer_advection_fct_shared_init(geometryPool, err1)
          call li_tracer_advection_fct_init(err2)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1149,7 +1149,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:), pointer :: &
            damage, & ! damage
-           passiveTracer
+           passiveTracer2d
 
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
@@ -1171,7 +1171,7 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
-      call mpas_pool_get_array(geometryPool, 'passiveTracer', passiveTracer)
+      call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -1262,11 +1262,11 @@ module li_advection
 
       endif
 
-      ! always advect passiveTracer
+      ! always advect passiveTracer2d
       iTracer = iTracer + 1
-      ! copy 2d passiveTracer to all vertical levels in the tracer array
+      ! copy 2d passiveTracer2d to all vertical levels in the tracer array
       do k = 1, nVertLevels
-         advectedTracers(iTracer,k,:) = passiveTracer(:)
+         advectedTracers(iTracer,k,:) = passiveTracer2d(:)
       enddo
       surfaceTracers(iTracer,:) = 0.0_RKIND
       basalTracers(iTracer,:) = 0.0_RKIND
@@ -1368,7 +1368,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:), pointer :: &
            damage, & ! damage
-           passiveTracer
+           passiveTracer2d
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
@@ -1389,7 +1389,7 @@ module li_advection
       ! get arrays from geometry pool
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
-      call mpas_pool_get_array(geometryPool, 'passiveTracer', passiveTracer)
+      call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -1440,10 +1440,10 @@ module li_advection
          enddo
       endif
 
-      ! Always advect passiveTracer
+      ! Always advect passiveTracer2d
       iTracer = iTracer + 1
       do iCell = 1, nCellsSolve
-         passiveTracer(iCell) = sum(advectedTracers(iTracer,:,iCell) * layerThicknessFractions)  ! thickness-weighted average
+         passiveTracer2d(iCell) = sum(advectedTracers(iTracer,:,iCell) * layerThicknessFractions)  ! thickness-weighted average
       enddo
 
       ! Note: Other tracers (e.g., ice age) can be added here as needed.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -445,7 +445,8 @@ module li_advection
 
          ! compute new values of layer thickness and tracers
          if ((trim(config_thickness_advection) .eq. 'fo') .and. &
-             (trim(config_tracer_advection) .eq. 'fo'))then
+             ( (trim(config_tracer_advection) .eq. 'fo') .or. &
+               (trim(config_tracer_advection) .eq. 'none') ) ) then
              call advect_thickness_tracers_upwind(&
                   dt,                      &
                   meshPool,                &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -503,9 +503,9 @@ module li_advection
              ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
              ! from fct thickness advection as normalThicknessFlux
              call li_tracer_advection_fct_tend(&
-                  tend, advectedTracers, layerThicknessOld, &
+                  tend(1:nTracers-1,:,:), advectedTracers(1:nTracers-1,:,:), layerThicknessOld, &
                   activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
-                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)
+                  nTracers-1, computeBudgets=.false.)
          elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
                   trim(config_tracer_advection) .eq. 'fo') then
             err_tmp = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -479,10 +479,13 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
                   layerNormalVelocity, 0 * normalVelocity, dt,    &
                   nTracers, computeBudgets=.false.)
-             !layerThickness is last tracer.
-             layerThickness(:,:) = advectedTracers(nTracers,:,:)
-             !layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
+             ! layerThickness is last tracer. However, for some reason
+             ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
+             ! This does conserve mass:
+             layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
              ! Reset tracers after thickness advection for tracer advection
+             ! TODO: determine whether we need to treat other tracer tendencies
+             ! the same as layerThickness for conservation.
              advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -482,6 +482,12 @@ module li_advection
              !layerThickness is last tracer.
              layerThickness(:,:) = advectedTracers(nTracers,:,:)
              !layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
+             ! Reset tracers after thickness advection for tracer advection
+             advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
+             call li_tracer_advection_fct_tend(&
+                  tend, advectedTracers, layerThicknessOld, &
+                  layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
+                  nTracers, computeBudgets=.false.)
          endif
 
          if (config_print_thickness_advection_info) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -680,7 +680,8 @@ module li_advection
                      advCellsForEdge, &
                      advCoefs, &
                      advCoefs3rd, &
-                     advMaskHighOrder)
+                     advMaskHighOrder, &
+                     advMask2ndOrder)
       endif
 
       ! clean up

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -352,7 +352,8 @@ module li_advection
       ! define max number of advection cells as max number of edges*2
       nAdvCellsMax = maxEdges2
 
-      if (trim(config_thickness_advection) .eq. 'fct') then
+      if ((trim(config_thickness_advection) .eq. 'fct') .or. &
+          (trim(config_tracer_advection) .eq. 'fct' ) ) then
          allocate(tendLayerThickness(nVertLevels,nEdges))
          tendLayerThickness(:,:) = 0.0_RKIND
          allocate(tend(nTracers,nVertLevels,nEdges))
@@ -435,7 +436,8 @@ module li_advection
          advectedTracersOld(:,:,:) = advectedTracers(:,:,:)
 
          ! compute new values of layer thickness and tracers
-         if (trim(config_thickness_advection) .eq. 'fo') then
+         if ((trim(config_thickness_advection) .eq. 'fo') .and. &
+             (trim(config_tracer_advection) .eq. 'fo'))then
              call advect_thickness_tracers_upwind(&
                   dt,                      &
                   meshPool,                &
@@ -448,9 +450,24 @@ module li_advection
                   layerThickness,          &
                   advectedTracers,         &
                   err)
-         elseif (trim(config_thickness_advection) .eq. 'fct') then
+         elseif ((trim(config_thickness_advection) .eq. 'fo') .and. &
+                  trim(config_tracer_advection) .eq. 'fct') then
              ! TODO: Decide what to do about w (vertical vel).
              ! For now, just setting it to 0 to try to get this to compile.
+             call advect_thickness_tracers_upwind(&
+                  dt,                      &
+                  meshPool,                &
+                  layerNormalVelocity,     &
+                  layerThicknessEdge,      &
+                  layerThicknessOld,       &
+                  advectedTracersOld,      &
+                  cellMask,                &
+                  edgeMask,                &
+                  layerThickness,          &
+                  advectedTracers,         &
+                  err)
+             ! Reset tracers after fo advection for fct advection
+             advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
 
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThickness, &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -476,8 +476,8 @@ module li_advection
          elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
                   trim(config_tracer_advection) .eq. 'fct') then
              call li_tracer_advection_fct_tend(&
-                  tend, advectedTracers, layerThicknessOld, &
-                  layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
+                  tend, advectedTracers, layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
+                  layerNormalVelocity, 0 * normalVelocity, dt,    &
                   nTracers, computeBudgets=.false.)
              !layerThickness is last tracer.
              layerThickness(:,:) = advectedTracers(nTracers,:,:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1234,13 +1234,7 @@ module li_advection
          iTracer = iTracer + 1
 
          ! copy 2d thickness to all vertical levels in the tracer array
-         !where (layerThickness(:,:) > 1.0e-10_RKIND)
-         !   advectedTracers(iTracer,:,:) = 1.0_RKIND
-         !elsewhere
-         !   advectedTracers(iTracer,:,:) = 0.0_RKIND
-         !endwhere
          advectedTracers(iTracer,:,:)  = layerThickness(:,:)
-         ! Is this right?
          surfaceTracers(iTracer,:) = 0.0_RKIND
          basalTracers(iTracer,:) = 0.0_RKIND
 
@@ -1249,7 +1243,7 @@ module li_advection
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
       if (trim(config_tracer_advection) == 'fct') then
-         call li_tracer_advection_fct_shared_init(err1)
+         call li_tracer_advection_fct_shared_init(geometryPool, err1)
          call li_tracer_advection_fct_init(err2)
 
          if (err1 /= 0 .or. err2 /= 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -470,7 +470,7 @@ module li_advection
              advectedTracers(:,:,:) = advectedTracersOld(:,:,:)
 
              call li_tracer_advection_fct_tend(&
-                  tend, advectedTracers, layerThickness, &
+                  tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   computeBudgets=.false.)!{{{
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -479,8 +479,9 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   nTracers, computeBudgets=.false.)
-             ! layerThickness is last tracer.
-             layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
+             !layerThickness is last tracer.
+             layerThickness(:,:) = advectedTracers(nTracers,:,:)
+             !layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
          endif
 
          if (config_print_thickness_advection_info) then
@@ -1246,7 +1247,7 @@ module li_advection
          iTracer = iTracer + 1
 
          ! copy 2d thickness to all vertical levels in the tracer array
-         advectedTracers(iTracer,:,:) = 1.0_RKIND
+         advectedTracers(iTracer,:,:) = layerThickness(:,:) !1.0_RKIND
          surfaceTracers(iTracer,:) = 0.0_RKIND
          basalTracers(iTracer,:) = 0.0_RKIND
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -657,7 +657,6 @@ module li_advection
                  geometryPool,          &
                  thermalPool,           &
                  advectedTracers)
-
          endif
 
       elseif (trim(config_thickness_advection) .eq. 'none') then
@@ -1119,7 +1118,8 @@ module li_advection
            thickness                  ! ice thickness
 
       real (kind=RKIND), dimension(:), pointer :: &
-           damage ! damage
+           damage, & ! damage
+           passiveTracer
 
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
@@ -1141,6 +1141,7 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
+      call mpas_pool_get_array(geometryPool, 'passiveTracer', passiveTracer)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -1231,6 +1232,15 @@ module li_advection
 
       endif
 
+      ! always advect passiveTracer
+      iTracer = iTracer + 1
+      ! copy 2d passiveTracer to all vertical levels in the tracer array
+      do k = 1, nVertLevels
+         advectedTracers(iTracer,k,:) = passiveTracer(:)
+      enddo
+      surfaceTracers(iTracer,:) = 0.0_RKIND
+      basalTracers(iTracer,:) = 0.0_RKIND
+ 
       if (trim(config_thickness_advection) == 'fct') then
          ! increment the tracer index
          iTracer = iTracer + 1
@@ -1327,7 +1337,8 @@ module li_advection
            thickness                  ! ice thickness
 
       real (kind=RKIND), dimension(:), pointer :: &
-           damage ! damage
+           damage, & ! damage
+           passiveTracer
 
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
@@ -1348,6 +1359,7 @@ module li_advection
       ! get arrays from geometry pool
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
+      call mpas_pool_get_array(geometryPool, 'passiveTracer', passiveTracer)
 
       ! get arrays from thermal pool
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
@@ -1397,6 +1409,12 @@ module li_advection
             damage(iCell) = sum(advectedTracers(iTracer,:,iCell) * layerThicknessFractions)  ! thickness-weighted average
          enddo
       endif
+
+      ! Always advect passiveTracer
+      iTracer = iTracer + 1
+      do iCell = 1, nCellsSolve
+         passiveTracer(iCell) = sum(advectedTracers(iTracer,:,iCell) * layerThicknessFractions)  ! thickness-weighted average
+      enddo
 
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -82,7 +82,8 @@ module li_advection
         advectTracersIn)
 
      use li_setup, only: li_calculate_layerThickness
-
+     use mpas_tracer_advection_helpers
+     use mpas_tracer_advection_mono
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -187,6 +188,16 @@ module li_advection
            cellMaskTemporaryField, & ! scratch field containing old values of cellMask
            thermalCellMaskField
 
+      ! Allocatable arrays need for flux-corrected transport advection
+      real(kind=RKIND), dimension(:,:,:), allocatable :: derivTwo
+      real (kind=RKIND), dimension(:,:), allocatable :: advCoefs
+      real (kind=RKIND), dimension(:,:), allocatable :: advCoefs3rd
+      integer, dimension(:), allocatable :: nAdvCellsForEdge
+      integer, dimension(:,:), allocatable :: advCellsForEdge
+      real (kind=RKIND), dimension(:,:), allocatable :: advMaskHighOrder
+      real (kind=RKIND), dimension(:,:), allocatable :: tendLayerThickness
+      real (kind=RKIND), dimension(:,:,:), allocatable :: tend
+
       integer, dimension(:), pointer :: &
            cellMask,              & ! integer bitmask for cells
            edgeMask,              & ! integer bitmask for edges
@@ -208,15 +219,23 @@ module li_advection
            config_ice_density,    & ! rhoi
            config_ocean_density,  & ! rhoo
            config_sea_level,      & ! sea level relative to z = 0
-           config_thermal_thickness
+           config_thermal_thickness, &
+           config_advection_coef_3rd_order
+
+      integer, pointer :: config_num_halos
 
       logical :: advectTracers     ! if true, then advect tracers as well as thickness
 
       integer :: iCell1, iCell2, theGroundedCell
+      integer, parameter :: horizAdvOrder = 4
+      integer, parameter :: vertAdvOrder = 1
 
       real(kind=RKIND) :: GLfluxSign, thicknessFluxEdge
 
       integer :: err_tmp
+      integer :: nTracers
+      integer, pointer :: maxEdges2
+      integer :: nAdvCellsMax
 
       !WHL - debug
       integer, dimension(:), pointer :: indexToCellID, indexToEdgeID
@@ -295,11 +314,12 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+      call mpas_pool_get_config(liConfigs, 'config_num_halos', config_num_halos)
 
-      !WHL - debug
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'maxEdges2', maxEdges2)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
@@ -315,6 +335,7 @@ module li_advection
       call mpas_pool_get_field(scratchPool, 'workTracerLevelCell', advectedTracersField)
       call mpas_allocate_scratch_field(advectedTracersField, .true.)
       advectedTracers => advectedTracersField % array
+      nTracers = size(advectedTracers,1)
 
       call mpas_pool_get_field(scratchPool, 'workLevelCell', layerThicknessOldField)
       call mpas_allocate_scratch_field(layerThicknessOldField, .true.)
@@ -339,6 +360,28 @@ module li_advection
       call mpas_allocate_scratch_field(thermalCellMaskField, .true.)
       thermalCellMask => thermalCellMaskField % array
 
+      ! define max number of advection cells as max number of edges*2
+      nAdvCellsMax = maxEdges2
+
+      if (trim(config_thickness_advection) .eq. 'fct') then
+         allocate(nAdvCellsForEdge(nEdges))
+         nAdvCellsForEdge(:) = 0
+         allocate(advCellsForEdge (nAdvCellsMax,nEdges))
+         advCellsForEdge(:,:) = 0
+         allocate(advCoefs(nAdvCellsMax,nEdges))
+         advCoefs(:,:) = 0.0_RKIND
+         allocate(advCoefs3rd(nAdvCellsMax,nEdges))
+         advCoefs3rd(:,:) = 0.0_RKIND
+         allocate(advMaskHighOrder(nVertLevels,nEdges))
+         advMaskHighOrder(:,:) = 0.0_RKIND
+         allocate(tendLayerThickness(nVertLevels,nEdges))
+         tendLayerThickness(:,:) = 0.0_RKIND
+         allocate(tend(nAdvCellsMax,2,nEdges))
+         tend(:,:,:) = 0.0_RKIND
+         allocate(derivTwo(nAdvCellsMax,2,nEdges))
+         derivTwo(:,:,:) = 0.0_RKIND
+      endif
+
       ! given the old thickness, compute the thickness in each layer
       call li_calculate_layerThickness(meshPool, thickness, layerThickness)
 
@@ -353,9 +396,8 @@ module li_advection
       ! Horizontal transport of thickness and tracers
       !-----------------------------------------------------------------
 
-      select case (trim(config_thickness_advection))
-
-      case ('fo')
+      if ( (trim(config_thickness_advection) .eq. 'fo') .or. &
+          (trim(config_thickness_advection) .eq. 'fct') ) then
 
          if (config_print_thickness_advection_info) then
             call mpas_log_write('Using first-order upwind for thickness advection')
@@ -402,8 +444,10 @@ module li_advection
                        intArgs=(/iCell, indexToCellID(iCell)/), realArgs=(/thickness(iCell), advectedTracers(1,1,iCell)/))
                   do iEdgeOnCell = 1, nEdgesOnCell(iCell)
                      iEdge = edgesOnCell(iEdgeOnCell,iCell)
-                     call mpas_log_write('iEdge (local=$i, global=$i), layerNormalVelocity=$r:', &
-                        intArgs=(/iEdge, indexToEdgeID(iEdge)/), realArgs=(/layerNormalVelocity(1,iEdge)/))
+                     call mpas_log_write('iEdge (local=$i, global=$i), &
+                             layerNormalVelocity=$r:', &
+                             intArgs=(/iEdge, indexToEdgeID(iEdge)/), &
+                             realArgs=(/layerNormalVelocity(1,iEdge)/))
                   enddo
                endif
             enddo
@@ -414,18 +458,61 @@ module li_advection
          advectedTracersOld(:,:,:) = advectedTracers(:,:,:)
 
          ! compute new values of layer thickness and tracers
-         call advect_thickness_tracers_upwind(&
-              dt,                      &
-              meshPool,                &
-              layerNormalVelocity,     &
-              layerThicknessEdge,      &
-              layerThicknessOld,       &
-              advectedTracersOld,      &
-              cellMask,                &
-              edgeMask,                &
-              layerThickness,          &
-              advectedTracers,         &
-              err)
+         if (trim(config_thickness_advection) .eq. 'fo') then
+             call advect_thickness_tracers_upwind(&
+                  dt,                      &
+                  meshPool,                &
+                  layerNormalVelocity,     &
+                  layerThicknessEdge,      &
+                  layerThicknessOld,       &
+                  advectedTracersOld,      &
+                  cellMask,                &
+                  edgeMask,                &
+                  layerThickness,          &
+                  advectedTracers,         &
+                  err)
+         elseif (trim(config_thickness_advection) .eq. 'fct') then
+             call mpas_initialize_deriv_two(meshPool, derivTwo, err)
+             call mpas_tracer_advection_coefficients(&
+                       meshPool,         &
+                       horizAdvOrder,    &
+                       derivTwo,         &
+                       advCoefs,         &
+                       advCoefs3rd,      &
+                       nAdvCellsForEdge, &
+                       advCellsForEdge,  &
+                       err)
+             call mpas_tracer_advection_mono_init(&
+                       config_num_halos,            &
+                       horizAdvOrder,               &
+                       vertAdvOrder,                &
+                       config_advection_coef_3rd_order, &
+                       dzdk_positive = .false.,     &
+                       check_monotonicity = .true., &
+                       err = err)
+             call mpas_tracer_advection_mono_tend(&
+                       advectedTracers,             &
+                       advcoefs,           &
+                       advCoefs3rd,       &
+                       nAdvCellsForEdge,    &
+                       advCellsForEdge,     &
+                       layerNormalVelocity * layerThicknessEdge, &
+                       layerNormalVelocity * 0.0_RKIND,          &
+                       layerThickness,      &
+                       layerThickness,    & ! TODO: decipher difference
+                                            ! between verticalCellSize 
+                                            ! and layerThickness
+                       dt,                  &
+                       meshPool,            &
+                       tendLayerThickness, &
+                       tend)
+                       ! optional: maxLevelCell_in, axLevelEdgeTop_in,
+                       !           highOrderAdvectionMask_in,
+                       !           verticalDivergenceFactor_in,
+                       !           edgeSignOnCell_in
+              ! Then apply tend and tend_layerThickness to tracer
+              ! fields?
+         endif
 
          if (config_print_thickness_advection_info) then
             do iCell = 1, nCells
@@ -604,17 +691,17 @@ module li_advection
 
          endif
 
-      case ('none')
+      elseif (trim(config_thickness_advection) .eq. 'none') then
 
          ! Do nothing
 
-      case default
+      else
 
          call mpas_log_write(trim(config_thickness_advection) // ' is not a valid option for thickness/tracer advection.', &
                  MPAS_LOG_ERR)
          err_tmp = 1
 
-      end select
+      end if ! config_thickness_advection
 
       err = ior(err,err_tmp)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -324,7 +324,6 @@ module li_advection
       call mpas_pool_get_field(scratchPool, 'workTracerLevelCell', advectedTracersField)
       call mpas_allocate_scratch_field(advectedTracersField, .true.)
       advectedTracers => advectedTracersField % array
-      nTracers = size(advectedTracers,1)
 
       call mpas_pool_get_field(scratchPool, 'workLevelCell', layerThicknessOldField)
       call mpas_allocate_scratch_field(layerThicknessOldField, .true.)
@@ -401,7 +400,8 @@ module li_advection
                  thermalPool,       &
                  advectedTracers,   &
                  surfaceTracers,    &
-                 basalTracers)
+                 basalTracers,      &
+                 nTracers)
 
          else   ! no tracer advection; pass a tracer array full of zeroes
 
@@ -479,8 +479,10 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   computeBudgets=.false.)
-             ! layerThickness is last tracer
-             layerThickness(:,:) = advectedTracers(nTracers,:,:) !layerThickness(:,:) + tend(nTracers,:,:) * dt
+             ! layerThickness is last tracer. Use this if passing layerThickness as tracer
+             layerThickness(:,:) = advectedTracers(nTracers,:,:)
+             ! Use this if passing array of ones as tracer
+             !layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
          endif
 
          if (config_print_thickness_advection_info) then
@@ -1046,7 +1048,8 @@ module li_advection
          thermalPool,      &
          advectedTracers,  &
          surfaceTracers,   &
-         basalTracers)
+         basalTracers,     &
+         nTracers)
 
       use li_thermal, only: li_temperature_to_enthalpy_kelvin
       use li_tracer_advection_fct_shared!, only: li_tracer_advection_fct_shared_init
@@ -1081,6 +1084,7 @@ module li_advection
            basalTracers      ! tracer values for new ice at lower surface
                              ! dimension 1 = maxTracers, 2 = nCells
 
+      integer, intent(out)  :: nTracers
       !-----------------------------------------------------------------
       !
       ! local variables
@@ -1240,6 +1244,7 @@ module li_advection
 
       endif
 
+      nTracers = iTracer
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
       if (trim(config_tracer_advection) == 'fct') then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -157,7 +157,8 @@ module li_advection
            layerNormalVelocity,   & ! normal component of velocity on cell edges at layer midpoints
            layerThickness,        & ! thickness of each layer
            layerThicknessOld,     & ! old layer thickness
-           layerThicknessEdge       ! layer thickness on upstream edge of cell
+           layerThicknessEdge,    & ! layer thickness on upstream edge of cell
+           normalVelocity           ! horizontal velocity on interfaces
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
            advectedTracers,       & ! values of advected tracers
@@ -283,6 +284,7 @@ module li_advection
 
       ! get arrays from the velocity pool
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
+      call mpas_pool_get_array(velocityPool, 'normalVelocity', normalVelocity)
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
 
@@ -353,7 +355,7 @@ module li_advection
       if (trim(config_thickness_advection) .eq. 'fct') then
          allocate(tendLayerThickness(nVertLevels,nEdges))
          tendLayerThickness(:,:) = 0.0_RKIND
-         allocate(tend(nAdvCellsMax,2,nEdges))
+         allocate(tend(nTracers,nVertLevels,nEdges))
          tend(:,:,:) = 0.0_RKIND
       endif
 
@@ -448,11 +450,11 @@ module li_advection
                   err)
          elseif (trim(config_thickness_advection) .eq. 'fct') then
              ! TODO: Decide what to do about w (vertical vel).
-             ! For now, just setting it to 0 to try to get this to compile
+             ! For now, just setting it to 0 to try to get this to compile.
 
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThickness, &
-                  layerThicknessEdge * layerNormalVelocity, 0 * layerThickness, dt,    &
+                  layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   computeBudgets=.false.)!{{{
          endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -354,9 +354,9 @@ module li_advection
 
       if ((trim(config_thickness_advection) .eq. 'fct') .or. &
           (trim(config_tracer_advection) .eq. 'fct' ) ) then
-         allocate(tendLayerThickness(nVertLevels,nEdges))
+         allocate(tendLayerThickness(nVertLevels,nCells+1))
          tendLayerThickness(:,:) = 0.0_RKIND
-         allocate(tend(nTracers,nVertLevels,nEdges))
+         allocate(tend(nTracers,nVertLevels,nCells+1))
          tend(:,:,:) = 0.0_RKIND
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -473,6 +473,14 @@ module li_advection
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
                   computeBudgets=.false.)!{{{
+         elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
+                  trim(config_tracer_advection) .eq. 'fct') then
+             call li_tracer_advection_fct_tend(&
+                  tend, advectedTracers, layerThicknessOld, &
+                  layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
+                  computeBudgets=.false.)
+             ! layerThickness is last tracer
+             layerThickness(:,:) = advectedTracers(nTracers,:,:) !layerThickness(:,:) + tend(nTracers,:,:) * dt
          endif
 
          if (config_print_thickness_advection_info) then
@@ -1080,7 +1088,8 @@ module li_advection
       !-----------------------------------------------------------------
 
       character (len=StrKIND), pointer :: &
-           config_thermal_solver
+           config_thermal_solver, &
+           config_thickness_advection
 
       logical, pointer :: &
            config_calculate_damage
@@ -1094,7 +1103,8 @@ module li_advection
       real (kind=RKIND), dimension(:,:), pointer :: &
            temperature,             & ! interior ice temperature
            waterFrac,               & ! interior water fraction
-           enthalpy                   ! interior ice enthalpy
+           enthalpy,                & ! interior ice enthalpy
+           layerThickness
 
       real (kind=RKIND), dimension(:), pointer :: &
            surfaceAirTemperature,   & ! surface air temperature
@@ -1127,6 +1137,7 @@ module li_advection
 
       ! get arrays from geometry pool
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
 
       ! get arrays from thermal pool
@@ -1140,6 +1151,7 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage', config_calculate_damage)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
+      call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
 
       ! initialize
       advectedTracers(:,:,:) = 0.0_RKIND
@@ -1212,6 +1224,23 @@ module li_advection
          ! TODO: Assess if this is the most appropriate option.  Other options would be setting damage equal to the existing value
          ! or the Nye zero stress value.  BISICLES implementation of the Bassis & Ma damage model sets damage associated with
          ! surface and basal accumulation as we are doing now.
+         surfaceTracers(iTracer,:) = 0.0_RKIND
+         basalTracers(iTracer,:) = 0.0_RKIND
+
+      endif
+
+      if (trim(config_thickness_advection) == 'fct') then
+         ! increment the tracer index
+         iTracer = iTracer + 1
+
+         ! copy 2d thickness to all vertical levels in the tracer array
+         !where (layerThickness(:,:) > 1.0e-10_RKIND)
+         !   advectedTracers(iTracer,:,:) = 1.0_RKIND
+         !elsewhere
+         !   advectedTracers(iTracer,:,:) = 0.0_RKIND
+         !endwhere
+         advectedTracers(iTracer,:,:)  = layerThickness(:,:)
+         ! Is this right?
          surfaceTracers(iTracer,:) = 0.0_RKIND
          basalTracers(iTracer,:) = 0.0_RKIND
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -351,14 +351,6 @@ module li_advection
       ! define max number of advection cells as max number of edges*2
       nAdvCellsMax = maxEdges2
 
-      if ((trim(config_thickness_advection) .eq. 'fct') .or. &
-          (trim(config_tracer_advection) .eq. 'fct' ) ) then
-         allocate(tendLayerThickness(nVertLevels,nCells+1))
-         tendLayerThickness(:,:) = 0.0_RKIND
-         allocate(tend(nTracers,nVertLevels,nCells+1))
-         tend(:,:,:) = 0.0_RKIND
-      endif
-
       ! given the old thickness, compute the thickness in each layer
       call li_calculate_layerThickness(meshPool, thickness, layerThickness)
 
@@ -407,6 +399,14 @@ module li_advection
 
             advectedTracers(:,:,:) = 0.0_RKIND
 
+         endif
+
+         if ((trim(config_thickness_advection) .eq. 'fct') .or. &
+             (trim(config_tracer_advection) .eq. 'fct' ) ) then
+            allocate(tendLayerThickness(nVertLevels,nCells+1))
+            tendLayerThickness(:,:) = 0.0_RKIND
+            allocate(tend(nTracers,nVertLevels,nCells+1))
+            tend(:,:,:) = 0.0_RKIND
          endif
 
          ! Transport thickness and tracers using a first-order upwind scheme

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -472,17 +472,15 @@ module li_advection
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  computeBudgets=.false.)!{{{
+                  nTracers, computeBudgets=.false.)!{{{
          elseif ((trim(config_thickness_advection) .eq. 'fct') .and. &
                   trim(config_tracer_advection) .eq. 'fct') then
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  computeBudgets=.false.)
-             ! layerThickness is last tracer. Use this if passing layerThickness as tracer
-             layerThickness(:,:) = advectedTracers(nTracers,:,:)
-             ! Use this if passing array of ones as tracer
-             !layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
+                  nTracers, computeBudgets=.false.)
+             ! layerThickness is last tracer.
+             layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
          endif
 
          if (config_print_thickness_advection_info) then
@@ -1238,7 +1236,7 @@ module li_advection
          iTracer = iTracer + 1
 
          ! copy 2d thickness to all vertical levels in the tracer array
-         advectedTracers(iTracer,:,:)  = layerThickness(:,:)
+         advectedTracers(iTracer,:,:) = 1.0_RKIND
          surfaceTracers(iTracer,:) = 0.0_RKIND
          basalTracers(iTracer,:) = 0.0_RKIND
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1,11 +1,3 @@
-! Copyright (c) 2013-2018,  Los Alamos National Security, LLC (LANS)
-! and the University Corporation for Atmospheric Research (UCAR).
-!
-! Unless noted otherwise source code is licensed under the BSD license.
-! Additional copyright and license information can be found in the LICENSE file
-! distributed with this code, or at http://mpas-dev.github.io/license.html
-!
-
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
 !  li_advection
@@ -82,8 +74,7 @@ module li_advection
         advectTracersIn)
 
      use li_setup, only: li_calculate_layerThickness
-     use mpas_tracer_advection_helpers
-     use mpas_tracer_advection_mono
+     use li_tracer_advection_fct, only: li_tracer_advection_ftc_tend
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -472,25 +463,7 @@ module li_advection
                   advectedTracers,         &
                   err)
          elseif (trim(config_thickness_advection) .eq. 'fct') then
-             call mpas_initialize_deriv_two(meshPool, derivTwo, err)
-             call mpas_tracer_advection_coefficients(&
-                       meshPool,         &
-                       horizAdvOrder,    &
-                       derivTwo,         &
-                       advCoefs,         &
-                       advCoefs3rd,      &
-                       nAdvCellsForEdge, &
-                       advCellsForEdge,  &
-                       err)
-             call mpas_tracer_advection_mono_init(&
-                       config_num_halos,            &
-                       horizAdvOrder,               &
-                       vertAdvOrder,                &
-                       config_advection_coef_3rd_order, &
-                       dzdk_positive = .false.,     &
-                       check_monotonicity = .true., &
-                       err = err)
-             call mpas_tracer_advection_mono_tend(&
+             call li_tracer_advection_fct_tend(&
                        advectedTracers,             &
                        advcoefs,           &
                        advCoefs3rd,       &
@@ -1071,7 +1044,8 @@ module li_advection
          basalTracers)
 
       use li_thermal, only: li_temperature_to_enthalpy_kelvin
-
+      use li_tracer_advection_fct_shared, only: li_tracer_advection_fct_shared_init
+      use li_tracer_advection_fct, only: li_tracer_advection_fct_init
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -1141,7 +1115,10 @@ module li_advection
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
 
-      integer :: iCell, iTracer, k
+      integer :: iCell, iTracer, k, err1, err2
+
+      err1 = 0
+      err2 = 0
 
       ! get dimensions
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -1244,6 +1221,17 @@ module li_advection
 
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
+      if (trim(config_config_tracer_advection) == 'fct') then
+         call li_tracer_advection_fct_shared_init(err1)
+         call li_tracer_advection_fct_init(err2)
+
+         if (err1 /= 0 .or. err2 /= 0 .or. err3 /=0 .or. err4 /= 0) then
+            err = 1
+            call mpas_log_write(                                 &
+               'Error encountered during fct tracer advection init', &
+               MPAS_LOG_ERR, masterOnly=.true.)
+         endif
+      endif
 
     end subroutine tracer_setup
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -19,6 +19,7 @@ module li_advection
    use li_setup
    use li_mask
    use li_constants
+   use li_config
 
    implicit none
    private
@@ -74,7 +75,7 @@ module li_advection
         advectTracersIn)
 
      use li_setup, only: li_calculate_layerThickness
-     use li_tracer_advection_fct, only: li_tracer_advection_ftc_tend
+     use li_tracer_advection_fct, only: li_tracer_advection_fct_tend
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -463,28 +464,12 @@ module li_advection
                   advectedTracers,         &
                   err)
          elseif (trim(config_thickness_advection) .eq. 'fct') then
+             ! TODO: Decide what to do about w (vertical vel).
+             ! For now, just setting it to 0 to try to get this to compile
              call li_tracer_advection_fct_tend(&
-                       advectedTracers,             &
-                       advcoefs,           &
-                       advCoefs3rd,       &
-                       nAdvCellsForEdge,    &
-                       advCellsForEdge,     &
-                       layerNormalVelocity * layerThicknessEdge, &
-                       layerNormalVelocity * 0.0_RKIND,          &
-                       layerThickness,      &
-                       layerThickness,    & ! TODO: decipher difference
-                                            ! between verticalCellSize 
-                                            ! and layerThickness
-                       dt,                  &
-                       meshPool,            &
-                       tendLayerThickness, &
-                       tend)
-                       ! optional: maxLevelCell_in, axLevelEdgeTop_in,
-                       !           highOrderAdvectionMask_in,
-                       !           verticalDivergenceFactor_in,
-                       !           edgeSignOnCell_in
-              ! Then apply tend and tend_layerThickness to tracer
-              ! fields?
+                  tend, advectedTracers, layerThickness, &
+                  layerThicknessEdge * layerNormalVelocity, 0 * layerThickness, dt,    &
+                  computeBudgets=.false.)!{{{
          endif
 
          if (config_print_thickness_advection_info) then
@@ -1115,8 +1100,9 @@ module li_advection
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
 
-      integer :: iCell, iTracer, k, err1, err2
+      integer :: iCell, iTracer, k, err, err1, err2
 
+      err  = 0
       err1 = 0
       err2 = 0
 
@@ -1221,11 +1207,11 @@ module li_advection
 
       ! Note: Other tracers (e.g., ice age) can be added here as needed.
       !       May need to increase maxTracers in the Registry.
-      if (trim(config_config_tracer_advection) == 'fct') then
+      if (trim(config_tracer_advection) == 'fct') then
          call li_tracer_advection_fct_shared_init(err1)
          call li_tracer_advection_fct_init(err2)
 
-         if (err1 /= 0 .or. err2 /= 0 .or. err3 /=0 .or. err4 /= 0) then
+         if (err1 /= 0 .or. err2 /= 0) then
             err = 1
             call mpas_log_write(                                 &
                'Error encountered during fct tracer advection init', &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -20,6 +20,7 @@ module li_advection
    use li_mask
    use li_constants
    use li_config
+   use li_mesh
 
    implicit none
    private
@@ -76,6 +77,7 @@ module li_advection
 
      use li_setup, only: li_calculate_layerThickness
      use li_tracer_advection_fct, only: li_tracer_advection_fct_tend
+     use li_tracer_advection_fct_shared
       !-----------------------------------------------------------------
       !
       ! input variables
@@ -181,12 +183,6 @@ module li_advection
            thermalCellMaskField
 
       ! Allocatable arrays need for flux-corrected transport advection
-      real(kind=RKIND), dimension(:,:,:), allocatable :: derivTwo
-      real (kind=RKIND), dimension(:,:), allocatable :: advCoefs
-      real (kind=RKIND), dimension(:,:), allocatable :: advCoefs3rd
-      integer, dimension(:), allocatable :: nAdvCellsForEdge
-      integer, dimension(:,:), allocatable :: advCellsForEdge
-      real (kind=RKIND), dimension(:,:), allocatable :: advMaskHighOrder
       real (kind=RKIND), dimension(:,:), allocatable :: tendLayerThickness
       real (kind=RKIND), dimension(:,:,:), allocatable :: tend
 
@@ -227,7 +223,6 @@ module li_advection
       integer :: err_tmp
       integer :: nTracers
       integer, pointer :: maxEdges2
-      integer :: nAdvCellsMax
 
       !WHL - debug
       integer, dimension(:), pointer :: indexToCellID, indexToEdgeID
@@ -356,22 +351,10 @@ module li_advection
       nAdvCellsMax = maxEdges2
 
       if (trim(config_thickness_advection) .eq. 'fct') then
-         allocate(nAdvCellsForEdge(nEdges))
-         nAdvCellsForEdge(:) = 0
-         allocate(advCellsForEdge (nAdvCellsMax,nEdges))
-         advCellsForEdge(:,:) = 0
-         allocate(advCoefs(nAdvCellsMax,nEdges))
-         advCoefs(:,:) = 0.0_RKIND
-         allocate(advCoefs3rd(nAdvCellsMax,nEdges))
-         advCoefs3rd(:,:) = 0.0_RKIND
-         allocate(advMaskHighOrder(nVertLevels,nEdges))
-         advMaskHighOrder(:,:) = 0.0_RKIND
          allocate(tendLayerThickness(nVertLevels,nEdges))
          tendLayerThickness(:,:) = 0.0_RKIND
          allocate(tend(nAdvCellsMax,2,nEdges))
          tend(:,:,:) = 0.0_RKIND
-         allocate(derivTwo(nAdvCellsMax,2,nEdges))
-         derivTwo(:,:,:) = 0.0_RKIND
       endif
 
       ! given the old thickness, compute the thickness in each layer
@@ -466,6 +449,7 @@ module li_advection
          elseif (trim(config_thickness_advection) .eq. 'fct') then
              ! TODO: Decide what to do about w (vertical vel).
              ! For now, just setting it to 0 to try to get this to compile
+
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThickness, &
                   layerThicknessEdge * layerNormalVelocity, 0 * layerThickness, dt,    &
@@ -662,6 +646,15 @@ module li_advection
       end if ! config_thickness_advection
 
       err = ior(err,err_tmp)
+
+      ! Deallocate arrays for fct
+      if (trim(config_tracer_advection) .eq. 'fct') then
+         deallocate( nAdvCellsForEdge, &
+                     advCellsForEdge, &
+                     advCoefs, &
+                     advCoefs3rd, &
+                     advMaskHighOrder)
+      endif
 
       ! clean up
       call mpas_deallocate_scratch_field(advectedTracersField, .true.)
@@ -1029,8 +1022,8 @@ module li_advection
          basalTracers)
 
       use li_thermal, only: li_temperature_to_enthalpy_kelvin
-      use li_tracer_advection_fct_shared, only: li_tracer_advection_fct_shared_init
-      use li_tracer_advection_fct, only: li_tracer_advection_fct_init
+      use li_tracer_advection_fct_shared!, only: li_tracer_advection_fct_shared_init
+      use li_tracer_advection_fct!, only: li_tracer_advection_fct_init
       !-----------------------------------------------------------------
       !
       ! input variables

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -388,6 +388,8 @@ module li_tracer_advection_fct
                                     + tracerWeight*(tracerCur(k,cell1) &
                                                   + tracerCur(k,cell2))
 
+              ! only remove low order flux where high order flux is valid to
+              ! avoid introducing nonzero values to highOrderFlx where it is invalid
               highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
                                     -  lowOrderFlx(k,iEdge) * &
                                     (advMaskHighOrder(k,iEdge) + advMask2ndOrder(k,iEdge) &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -66,15 +66,17 @@ module li_tracer_advection_fct
    subroutine li_tracer_advection_fct_tend( &
                                         tend, tracers, layerThickness, &
                                         normalThicknessFlux, w, dt,    &
-                                        nTracers, computeBudgets)!{{{
+                                        nTracers, &
+                                        activeTracerHorizontalAdvectionEdgeFlux, &
+                                        computeBudgets)!{{{
       use li_mesh
       !-----------------------------------------------------------------
       ! Input/Output parameters
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-         tend    !< [inout] Tracer tendency to which advection added
-
+         tend, &    !< [inout] Tracer tendency to which advection added
+         activeTracerHorizontalAdvectionEdgeFlux  !< [inout] used to compute higher order normalThicknessFlux
       !-----------------------------------------------------------------
       ! Input parameters
       !-----------------------------------------------------------------
@@ -160,6 +162,21 @@ module li_tracer_advection_fct
                lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
                highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
 
+      ! Initialize variables so you don't get floating point exceptions
+      wgtTmp(:) = 0.0_RKIND
+      flxTmp(:) = 0.0_RKIND
+      sgnTmp(:) = 0.0_RKIND
+      tracerCur(:,:) = 0.0_RKIND
+      tracerMin(:,:) = 0.0_RKIND
+      tracerMax(:,:) = 0.0_RKIND
+      hNewInv(:,:) = 0.0_RKIND
+      hProv(:,:) = 0.0_RKIND
+      hProvInv(:,:) = 0.0_RKIND
+      flxIn(:,:) = 0.0_RKIND
+      flxOut(:,:) = 0.0_RKIND
+      workTend(:,:) = 0.0_RKIND
+      lowOrderFlx(:,:) = 0.0_RKIND
+      highOrderFlx(:,:) = 0.0_RKIND
       !$acc enter data create(wgtTmp, flxTmp, sgnTmp, &
       !$acc                   tracerCur, tracerMin, tracerMax, &
       !$acc                   hNewInv, hProv, hProvInv, flxIn, flxOut, &
@@ -588,17 +605,22 @@ module li_tracer_advection_fct
 !           !$omp parallel
 !           !$omp do schedule(runtime) private(k)
 !#endif
-!
-!           ! TODO: Determine if it is necessary to define activeTracerHorizontalAdvectionEdgeFlux
-!           !do iEdge = 1,nEdges
-!           !do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-!           !   ! Save u*h*T flux on edge for analysis. This variable will be
-!           !   ! divided by h at the end of the time step.
-!           !   activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
-!           !      (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
-!           !enddo
-!           !enddo
-!
+
+           ! Use activeTracerHorizontalAdvectionEdgeFlux from the call to fct for thickness
+           ! advection as the higher-order normalThicknessFlux for fct tracer advection.
+           do iEdge = 1,nEdges
+           do k = 1, nVertLevels
+              ! Save u*h*T flux on edge for analysis. This variable will be
+              ! divided by h at the end of the time step.
+              if (dvEdge(iEdge) > 0.0_RKIND) then
+                 activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                     (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+              else
+                 activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = 0.0_RKIND
+              endif
+           enddo
+           enddo
+
 !#ifndef MPAS_OPENACC
 !          !$omp end do
 !#endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -75,7 +75,8 @@ module li_tracer_advection_fct
       !-----------------------------------------------------------------
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-         tend, &    !< [inout] Tracer tendency to which advection added
+         tend    !< [inout] Tracer tendency to which advection added
+      real (kind=RKIND), dimension(:,:,:), intent(inout), optional :: &
          activeTracerHorizontalAdvectionEdgeFlux  !< [inout] used to compute higher order normalThicknessFlux
       !-----------------------------------------------------------------
       ! Input parameters
@@ -610,19 +611,20 @@ module li_tracer_advection_fct
 
            ! Use activeTracerHorizontalAdvectionEdgeFlux from the call to fct for thickness
            ! advection as the higher-order normalThicknessFlux for fct tracer advection.
-           do iEdge = 1,nEdges
-           do k = 1, nVertLevels
-              ! Save u*h*T flux on edge for analysis. This variable will be
-              ! divided by h at the end of the time step.
-              if (dvEdge(iEdge) > 0.0_RKIND) then
-                 activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
-                     (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
-              else
-                 activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = 0.0_RKIND
-              endif
-           enddo
-           enddo
-
+           if (present(activeTracerHorizontalAdvectionEdgeFlux)) then
+               do iEdge = 1,nEdges
+               do k = 1, nVertLevels
+                  ! Save u*h*T flux on edge for analysis. This variable will be
+                  ! divided by h at the end of the time step.
+                  if (dvEdge(iEdge) > 0.0_RKIND) then
+                     activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                         (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+                  else
+                     activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = 0.0_RKIND
+                  endif
+               enddo
+               enddo
+           endif
 !#ifndef MPAS_OPENACC
 !          !$omp end do
 !#endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -358,7 +358,7 @@ module li_tracer_advection_fct
            ! Remove low order flux from the high order flux
            ! Store left over high order flux in highOrderFlx array
            do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
-              tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
+              tracerWeight = advMask2ndOrder(k,iEdge) &
                            * (dvEdge(iEdge) * 0.5_RKIND)             &
                            * normalThicknessFlux(k, iEdge)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -372,7 +372,9 @@ module li_tracer_advection_fct
                                                   + tracerCur(k,cell2))
 
               highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
-                                    -  lowOrderFlx(k,iEdge)
+                                    -  lowOrderFlx(k,iEdge) * &
+                                    (advMaskHighOrder(k,iEdge) + advMask2ndOrder(k,iEdge) &
+                                     * (1.0_RKIND - advMaskHighOrder(k, iEdge)) )
            end do ! k loop
         end do ! iEdge loop
 #ifndef MPAS_OPENACC

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -359,6 +359,7 @@ module li_tracer_advection_fct
            ! Store left over high order flux in highOrderFlx array
            do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               tracerWeight = advMask2ndOrder(k,iEdge) &
+                           * (1.0_RKIND - advMaskHighOrder(k, iEdge)) &
                            * (dvEdge(iEdge) * 0.5_RKIND)             &
                            * normalThicknessFlux(k, iEdge)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -66,7 +66,7 @@ module li_tracer_advection_fct
    subroutine li_tracer_advection_fct_tend( &
                                         tend, tracers, layerThickness, &
                                         normalThicknessFlux, w, dt,    &
-                                        computeBudgets)!{{{
+                                        nTracers, computeBudgets)!{{{
       use li_mesh
       !-----------------------------------------------------------------
       ! Input/Output parameters
@@ -91,8 +91,7 @@ module li_tracer_advection_fct
          dt                    !< [in] Timestep
 
       logical, intent(in) :: &
-         computeBudgets        !< [in] Flag to compute active tracer budgets
-
+         computeBudgets    !< [in] Flag to compute active tracer budgets
       !-----------------------------------------------------------------
       ! Local variables
       !-----------------------------------------------------------------
@@ -103,7 +102,7 @@ module li_tracer_advection_fct
          k,kmin, kmax, &! vert index variants
          kmin1, kmax1,    &! vert index variants
          iTracer,         &! tracer index
-         numTracers        ! total number of tracers
+         nTracers        ! total number of tracers
 
       real (kind=RKIND) ::  &
          signedFactor,      &! temp factor including flux sign
@@ -143,8 +142,6 @@ module li_tracer_advection_fct
 #ifdef _ADV_TIMERS
       call mpas_timer_start('allocates')
 #endif
-      ! Get dimensions
-      numTracers  = size(tracers,dim=1)
 
       ! allocate temporary arrays
       allocate(wgtTmp      (nVertLevels), &
@@ -231,7 +228,7 @@ module li_tracer_advection_fct
 #endif
 
       ! Loop over tracers. One tracer is advected at a time.
-      do iTracer = 1, numTracers
+      do iTracer = 1, nTracers
 
 #ifdef _ADV_TIMERS
         call mpas_timer_start('cell init')

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -7,7 +7,7 @@
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  ocn_tracer_advection_mono
+!  tracer_advection_mono
 !
 !> \brief MPAS monotonic tracer advection with FCT
 !> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
@@ -18,7 +18,7 @@
 !
 !-----------------------------------------------------------------------
 
-module ocn_tracer_advection_mono
+module li_tracer_advection_fct
 
    ! module includes
 #ifdef _ADV_TIMERS
@@ -26,11 +26,11 @@ module ocn_tracer_advection_mono
 #endif
    use mpas_kind_types
 
-   use ocn_config
-   use ocn_mesh
-   use ocn_diagnostics_variables
-   use ocn_tracer_advection_shared
-   use ocn_tracer_advection_vert
+!   use ocn_config
+!   use ocn_mesh
+!   use ocn_diagnostics_variables
+   use li_tracer_advection_fct_shared
+!   use tracer_advection_vert
 
    implicit none
    private
@@ -43,8 +43,8 @@ module ocn_tracer_advection_mono
       monotonicityCheck   !< flag to check monotonicity
 
    ! public method interfaces
-   public :: ocn_tracer_advection_mono_tend, &
-             ocn_tracer_advection_mono_init
+   public :: li_tracer_advection_fct_tend, &
+             li_tracer_advection_fct_init
 
 !**********************************************************************
 
@@ -52,7 +52,7 @@ module ocn_tracer_advection_mono
 
 !**********************************************************************
 !
-!  routine ocn_tracer_advection_mono_tend
+!  routine li_tracer_advection_fct_tend
 !
 !> \brief MPAS monotonic tracer horizontal advection tendency with FCT
 !> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
@@ -63,7 +63,7 @@ module ocn_tracer_advection_mono
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_mono_tend( &
+   subroutine li_tracer_advection_fct_tend( &
                                         tend, tracers, layerThickness, &
                                         normalThicknessFlux, w, dt,    &
                                         computeBudgets)!{{{
@@ -726,7 +726,7 @@ module ocn_tracer_advection_mono
 
         ! Compute the high order vertical fluxes based on order selected.
 
-        call ocn_tracer_advection_vert_flx(tracerCur, w, hProv, &
+        call tracer_advection_vert_flx(tracerCur, w, hProv, &
                                            highOrderFlx)
 
 #ifdef _ADV_TIMERS
@@ -999,11 +999,11 @@ module ocn_tracer_advection_mono
       call mpas_timer_stop('deallocates')
 #endif
 
-   end subroutine ocn_tracer_advection_mono_tend!}}}
+   end subroutine li_tracer_advection_fct_tend!}}}
 
 !**********************************************************************
 !
-!  routine ocn_tracer_advection_mono_init
+!  routine li_tracer_advection_fct_init
 !
 !> \brief MPAS initialize monotonic tracer advection tendency with FCT
 !> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
@@ -1014,7 +1014,7 @@ module ocn_tracer_advection_mono
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_mono_init(err)!{{{
+   subroutine li_tracer_advection_fct_init(err)!{{{
 
       !*** output parameters
 
@@ -1053,10 +1053,10 @@ module ocn_tracer_advection_mono
       ! Set flag for checking monotonicity
       monotonicityCheck = config_check_tracer_monotonicity
 
-   end subroutine ocn_tracer_advection_mono_init!}}}
+   end subroutine li_tracer_advection_fct_init!}}}
 
 !***********************************************************************
 
-end module ocn_tracer_advection_mono
+end module li_tracer_advection_fct
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -730,20 +730,20 @@ module li_tracer_advection_fct
         !$omp end parallel
 #endif
 
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('vertical bounds')
-        call mpas_timer_start('vertical flux high')
-#endif
-
-        ! Compute the high order vertical fluxes based on order selected.
-
-        call tracer_advection_vert_flx(tracerCur, w, hProv, &
-                                           highOrderFlx)
-
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('vertical flux high')
-        call mpas_timer_start('vertical flux')
-#endif
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('vertical bounds')
+!        call mpas_timer_start('vertical flux high')
+!#endif
+!
+!        ! Compute the high order vertical fluxes based on order selected.
+!
+!        call tracer_advection_vert_flx(tracerCur, w, hProv, &
+!                                           highOrderFlx)
+!
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('vertical flux high')
+!        call mpas_timer_start('vertical flux')
+!#endif
 
         ! Compute low order upwind vertical flux (monotonic)
         ! Remove low order flux from the high order flux.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -26,8 +26,8 @@ module li_tracer_advection_fct
 #endif
    use mpas_kind_types
 
-!   use ocn_config
-!   use ocn_mesh
+   use li_config
+   use li_mesh
 !   use ocn_diagnostics_variables
    use li_tracer_advection_fct_shared
 !   use tracer_advection_vert
@@ -151,17 +151,17 @@ module li_tracer_advection_fct
       allocate(wgtTmp      (nVertLevels), &
                flxTmp      (nVertLevels), &
                sgnTmp      (nVertLevels), &
-               tracerCur   (nVertLevels  ,nCellsAll+1), &
-               tracerMin   (nVertLevels  ,nCellsAll), &
-               tracerMax   (nVertLevels  ,nCellsAll), &
-               hNewInv     (nVertLevels  ,nCellsAll), &
-               hProv       (nVertLevels  ,nCellsAll), &
-               hProvInv    (nVertLevels  ,nCellsAll), &
-               flxIn       (nVertLevels  ,nCellsAll+1), &
-               flxOut      (nVertLevels  ,nCellsAll+1), &
-               workTend    (nVertLevels  ,nCellsAll+1), &
-               lowOrderFlx (nVertLevels+1,max(nCellsAll,nEdgesAll)+1), &
-               highOrderFlx(nVertLevels+1,max(nCellsAll,nEdgesAll)+1))
+               tracerCur   (nVertLevels  ,nCells+1), &
+               tracerMin   (nVertLevels  ,nCells), &
+               tracerMax   (nVertLevels  ,nCells), &
+               hNewInv     (nVertLevels  ,nCells), &
+               hProv       (nVertLevels  ,nCells), &
+               hProvInv    (nVertLevels  ,nCells), &
+               flxIn       (nVertLevels  ,nCells+1), &
+               flxOut      (nVertLevels  ,nCells+1), &
+               workTend    (nVertLevels  ,nCells+1), &
+               lowOrderFlx (nVertLevels+1,max(nCells,nEdges)+1), &
+               highOrderFlx(nVertLevels+1,max(nCells,nEdges)+1))
 
       !$acc enter data create(wgtTmp, flxTmp, sgnTmp, &
       !$acc                   tracerCur, tracerMin, tracerMax, &
@@ -191,10 +191,10 @@ module li_tracer_advection_fct
       !$omp do schedule(runtime) &
       !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
 #endif
-      do iCell = 1, nCellsAll
+      do iCell = 1, nCells
          invAreaCell1 = dt/areaCell(iCell)
-         kmin = minLevelCell(iCell)
-         kmax = maxLevelCell(iCell)
+         kmin = 1 !minLevelCell(iCell)
+         kmax = nVertLevels !maxLevelCell(iCell)
          do k = kmin, kmax
             hProv(k, iCell) = layerThickness(k, iCell)
          end do
@@ -241,7 +241,7 @@ module li_tracer_advection_fct
         !$omp parallel
         !$omp do schedule(runtime) private(k)
 #endif
-        do iCell = 1, nCellsAll+1
+        do iCell = 1, nCells+1
         do k=1, nVertLevels
            tracerCur(k,iCell) = tracers(iTracer,k,iCell)
         end do ! k loop
@@ -274,23 +274,24 @@ module li_tracer_advection_fct
         !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
 #endif
         do iCell = 1, nCells
-           kmin = minLevelCell(iCell)
-           kmax = maxLevelCell(iCell)
+           kmin = 1 !minLevelCell(iCell)
+           kmax = nVertLevels !maxLevelCell(iCell)
            do k=kmin,kmax
               tracerMin(k,iCell) = tracerCur(k,iCell)
               tracerMax(k,iCell) = tracerCur(k,iCell)
            end do
-           do i = 1, nEdgesOnCell(iCell)
-              cell2 = cellsOnCell(i,iCell)
-              kmin1 = max(kmin, minLevelCell(cell2))
-              kmax1 = min(kmax, maxLevelCell(cell2))
-              do k=kmin1,kmax1
-                 tracerMax(k,iCell) = max(tracerMax(k,iCell), &
-                                          tracerCur(k,cell2))
-                 tracerMin(k,iCell) = min(tracerMin(k,iCell), &
-                                          tracerCur(k,cell2))
-              end do ! k loop
-           end do ! i loop over nEdgesOnCell
+           ! TODO: Determine how/if this translates to MALI
+           !do i = 1, nEdgesOnCell(iCell)
+           !   cell2 = cellsOnCell(i,iCell)
+           !   kmin1 = max(kmin, minLevelCell(cell2))
+           !   kmax1 = min(kmax, maxLevelCell(cell2))
+           !   do k=kmin1,kmax1
+           !      tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+           !                               tracerCur(k,cell2))
+           !      tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+           !                               tracerCur(k,cell2))
+           !   end do ! k loop
+           !end do ! i loop over nEdgesOnCell
         end do ! cell loop
 #ifndef MPAS_OPENACC
         !$omp end do
@@ -340,7 +341,7 @@ module li_tracer_advection_fct
               iCell = advCellsForEdge(i,iEdge)
               coef1 = advCoefs       (i,iEdge)
               coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
-              do k = minLevelCell(iCell), maxLevelCell(iCell)
+              do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
                  flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
                              wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
               end do ! k loop
@@ -354,7 +355,7 @@ module li_tracer_advection_fct
            ! Also compute low order upwind horizontal flux (monotonic)
            ! Remove low order flux from the high order flux
            ! Store left over high order flux in highOrderFlx array
-           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+           do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
                            * (dvEdge(iEdge) * 0.5_RKIND)             &
                            * normalThicknessFlux(k, iEdge)
@@ -390,7 +391,7 @@ module li_tracer_advection_fct
         !$omp parallel
         !$omp do schedule(runtime)
 #endif
-        do iCell = 1, nCellsAll+1
+        do iCell = 1, nCells+1
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
            flxIn   (k, iCell) = 0.0_RKIND
@@ -434,7 +435,7 @@ module li_tracer_advection_fct
               cell2 = cellsOnEdge(2,iEdge)
               signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
 
-              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
                  ! Here workTend is the advection tendency due to the
                  ! upwind (low order) fluxes.
@@ -454,7 +455,7 @@ module li_tracer_advection_fct
            ! Computed using the bounds that were computed previously,
            ! and the bounds on the newly updated value
            ! Factors are placed in the flxIn and flxOut arrays
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
+           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
               ! Here workTend is the upwind tendency
               tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
                               + dt*workTend(k,iCell))*hProvInv(k,iCell)
@@ -498,7 +499,7 @@ module li_tracer_advection_fct
         do iEdge = 1, nEdges
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
-           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+           do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
               highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
                                       min(flxOut(k,cell1), flxIn (k,cell2)) &
                                     + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
@@ -530,14 +531,14 @@ module li_tracer_advection_fct
         !$omp do schedule(runtime) &
         !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
 #endif
-        do iCell = 1, nCellsOwned
+        do iCell = 1, nCellsSolve
            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
            ! Accumulate the scaled high order horizontal tendencies
            do i = 1, nEdgesOnCell(iCell)
               iEdge = edgesOnCell(i, iCell)
               signedFactor = invAreaCell1*edgeSignOnCell(i,iCell)
-              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
                  ! workTend on RHS is upwind tendency
                  ! workTend on LHS is total horiz advect tendency
                  workTend(k,iCell) = workTend(k,iCell) &
@@ -545,7 +546,7 @@ module li_tracer_advection_fct
               end do
            end do
 
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
+           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
               ! workTend  on RHS is total horiz advection tendency
               ! tracerCur on LHS is provisional tracer after
               !                     horizontal fluxes only.
@@ -576,39 +577,49 @@ module li_tracer_advection_fct
            !$acc    present(activeTracerHorizontalAdvectionEdgeFlux, &
            !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
            !$acc            lowOrderFlx, highOrderFlx, dvEdge)
-#else
-           !$omp parallel
-           !$omp do schedule(runtime) private(k)
 #endif
-           do iEdge = 1,nEdges
-           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-              ! Save u*h*T flux on edge for analysis. This variable will be
-              ! divided by h at the end of the time step.
-              activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
-                 (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
-           enddo
-           enddo
-#ifndef MPAS_OPENACC
-           !$omp end do
-#endif
+
+!#else
+!           !$omp parallel
+!           !$omp do schedule(runtime) private(k)
+!#endif
+!
+!           ! TODO: Determine if it is necessary to define activeTracerHorizontalAdvectionEdgeFlux
+!           !do iEdge = 1,nEdges
+!           !do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+!           !   ! Save u*h*T flux on edge for analysis. This variable will be
+!           !   ! divided by h at the end of the time step.
+!           !   activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+!           !      (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+!           !enddo
+!           !enddo
+!
+!#ifndef MPAS_OPENACC
+!          !$omp end do
+!#endif
 
 #ifdef MPAS_OPENACC
            !$acc parallel loop private(k) &
            !$acc    present(activeTracerHorizontalAdvectionTendency, &
            !$acc            minLevelCell, maxLevelCell, workTend)
-#else
-           !$omp do schedule(runtime) private(k)
+
 #endif
-           do iCell = 1, nCellsOwned
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
-              activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
-                                                     workTend(k,iCell)
-           end do
-           end do ! iCell loop
-#ifndef MPAS_OPENACC
-           !$omp end do
-           !$omp end parallel
-#endif
+
+!#else
+!           !$omp do schedule(runtime) private(k)
+!#endif
+!           ! TODO: Determine if it is necessary to define activeTracerHorizontalAdvectionTendency
+!           ! for MALI
+!           !do iCell = 1, nCellsSolve
+!           !do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
+!           !   activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+!           !                                          workTend(k,iCell)
+!           !end do
+!           !end do ! iCell loop
+!#ifndef MPAS_OPENACC
+!           !$omp end do
+!           !$omp end parallel
+!#endif
 
         end if ! computeBudgets
 
@@ -621,8 +632,8 @@ module li_tracer_advection_fct
 
            !$omp parallel
            !$omp do schedule(runtime) private(k)
-           do iCell = 1, nCellsOwned
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
+           do iCell = 1, nCellsSolve
+           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
               if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
                  call mpas_log_write( &
                     'Horizontal minimum out of bounds on tracer: $i $r $r ', &
@@ -663,7 +674,7 @@ module li_tracer_advection_fct
         !$omp parallel
         !$omp do schedule(runtime) private(k)
 #endif
-        do iCell = 1, nCellsAll
+        do iCell = 1, nCells
         do k=1, nVertLevels
            workTend(k, iCell) = 0.0_RKIND
         end do ! k loop
@@ -692,8 +703,8 @@ module li_tracer_advection_fct
         !$omp do schedule(runtime) private(k, kmin, kmax)
 #endif
         do iCell = 1, nCells
-           kmin = minLevelCell(iCell)
-           kmax = maxLevelCell(iCell)
+           kmin = 1 !minLevelCell(iCell)
+           kmax = nVertLevels !maxLevelCell(iCell)
 
            ! take care of top cell
            tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
@@ -749,8 +760,8 @@ module li_tracer_advection_fct
         !$omp do schedule(runtime) private(k, kmin, kmax)
 #endif
         do iCell = 1, nCells
-           kmin = minLevelCell(iCell)
-           kmax = maxLevelCell(iCell)
+           kmin = 1 !minLevelCell(iCell)
+           kmax = nVertLevels !maxLevelCell(iCell)
 
            lowOrderFlx(kmin,iCell) = 0.0_RKIND
            do k = kmin+1, kmax
@@ -808,7 +819,7 @@ module li_tracer_advection_fct
 #endif
         do iCell = 1, nCells
 
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
+           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
               ! workTend on the RHS is the upwind tendency
               tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
                            + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
@@ -852,9 +863,9 @@ module li_tracer_advection_fct
         !$omp parallel
         !$omp do schedule(runtime) private(k, kmin, kmax, flux)
 #endif
-        do iCell = 1, nCellsOwned
-           kmin = minLevelCell(iCell)
-           kmax = maxLevelCell(iCell)
+        do iCell = 1, nCellsSolve
+           kmin = 1 !minLevelCell(iCell)
+           kmax = nVertLevels !maxLevelCell(iCell)
            ! rescale the high order vertical flux
            do k = kmin+1, kmax
               flux =  highOrderFlx(k,iCell)
@@ -896,26 +907,28 @@ module li_tracer_advection_fct
            !$acc            activeTracerVerticalAdvectionTendency, &
            !$acc            minLevelCell, maxLevelCell) &
            !$acc    private(k, kmin, kmax)
-#else
-           !$omp parallel
-           !$omp do schedule(runtime) private(k,kmin,kmax)
 #endif
-           do iCell = 1, nCellsOwned
-              kmin = minLevelCell(iCell)
-              kmax = maxLevelCell(iCell)
-              do k = kmin+1,kmax
-                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
-                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
-              end do
-              do k = kmin,kmax
-                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
-                    workTend(k,iCell)
-              end do
-           end do ! iCell loop
-#ifndef MPAS_OPENACC
-           !$omp end do
-           !$omp end parallel
-#endif
+
+!#else
+!           !$omp parallel
+!           !$omp do schedule(runtime) private(k,kmin,kmax)
+!#endif
+!           do iCell = 1, nCellsSolve
+!              kmin = minLevelCell(iCell)
+!              kmax = maxLevelCell(iCell)
+!              do k = kmin+1,kmax
+!                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
+!                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
+!              end do
+!              do k = kmin,kmax
+!                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+!                    workTend(k,iCell)
+!              end do
+!           end do ! iCell loop
+!#ifndef MPAS_OPENACC
+!           !$omp end do
+!           !$omp end parallel
+!#endif
         end if ! computeBudgets
 
         if (monotonicityCheck) then
@@ -931,7 +944,7 @@ module li_tracer_advection_fct
            !$omp parallel
            !$omp do schedule(runtime) private(k)
 #endif
-           do iCell = 1,nCellsOwned
+           do iCell = 1,nCellsSolve
            do k = 1,nVertLevels
               ! workTend on the RHS is total vertical advection tendency
               flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
@@ -949,8 +962,8 @@ module li_tracer_advection_fct
 
            ! Print out info for cells that are out of bounds
            ! flxIn holds new tracer values
-           do iCell = 1, nCellsOwned
-           do k = minLevelCell(iCell), maxLevelCell(iCell)
+           do iCell = 1, nCellsSolve
+           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
               if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
                  call mpas_log_write( &
                    'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
@@ -1040,7 +1053,7 @@ module li_tracer_advection_fct
       case (2)
          coef3rdOrder = 0.0_RKIND
       case (3)
-         coef3rdOrder = config_coef_3rd_order
+         coef3rdOrder = config_advection_coef_3rd_order
       case (4)
          coef3rdOrder = 0.0_RKIND
       case default

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -79,7 +79,7 @@ module li_tracer_advection_fct
       ! Input parameters
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
          tracers               !< [in] Current tracer values
 
       real (kind=RKIND), dimension(:,:), intent(in) :: &
@@ -659,6 +659,7 @@ module li_tracer_advection_fct
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('advect diags horiz')
 #endif
+
 !TODO: implement vertical advection?
         !-----------------------------------------------------------------------
         !
@@ -986,6 +987,8 @@ module li_tracer_advection_fct
 !#ifdef _ADV_TIMERS
 !        call mpas_timer_stop('advect diags vert')
 !#endif
+        ! Update tracer array
+        tracers(iTracer,:,:) = tracerCur(:,:)
       end do ! iTracer loop
 !
 #ifdef _ADV_TIMERS

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -1,0 +1,1062 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  ocn_tracer_advection_mono
+!
+!> \brief MPAS monotonic tracer advection with FCT
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
+!> \details
+!>  This module contains routines for monotonic advection of tracers
+!>  using a Flux Corrected Transport (FCT) algorithm
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_advection_mono
+
+   ! module includes
+#ifdef _ADV_TIMERS
+   use mpas_timer
+#endif
+   use mpas_kind_types
+
+   use ocn_config
+   use ocn_mesh
+   use ocn_diagnostics_variables
+   use ocn_tracer_advection_shared
+   use ocn_tracer_advection_vert
+
+   implicit none
+   private
+   save
+
+   ! module private variables
+   real (kind=RKIND) ::  &
+      coef3rdOrder        !< high-order horizontal coefficient
+   logical ::            &
+      monotonicityCheck   !< flag to check monotonicity
+
+   ! public method interfaces
+   public :: ocn_tracer_advection_mono_tend, &
+             ocn_tracer_advection_mono_init
+
+!**********************************************************************
+
+   contains
+
+!**********************************************************************
+!
+!  routine ocn_tracer_advection_mono_tend
+!
+!> \brief MPAS monotonic tracer horizontal advection tendency with FCT
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
+!> \details
+!>  This routine computes the monotonic tracer horizontal advection
+!>  tendency using a flux-corrected transport (FCT) algorithm.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_advection_mono_tend( &
+                                        tend, tracers, layerThickness, &
+                                        normalThicknessFlux, w, dt,    &
+                                        computeBudgets)!{{{
+
+      !-----------------------------------------------------------------
+      ! Input/Output parameters
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+         tend    !< [inout] Tracer tendency to which advection added
+
+      !-----------------------------------------------------------------
+      ! Input parameters
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(in) :: &
+         tracers               !< [in] Current tracer values
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         layerThickness,      &!< [in] Thickness
+         normalThicknessFlux, &!< [in] Thichness weighted velocitiy
+         w                     !< [in] Vertical velocity
+
+      real (kind=RKIND), intent(in) :: &
+         dt                    !< [in] Timestep
+
+      logical, intent(in) :: &
+         computeBudgets        !< [in] Flag to compute active tracer budgets
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer ::          &
+         i, iCell, iEdge, &! horz indices
+         cell1, cell2,    &! neighbor cell indices
+         nCells, nEdges,  &! numbers of cells or edges
+         k,kmin, kmax, &! vert index variants
+         kmin1, kmax1,    &! vert index variants
+         iTracer,         &! tracer index
+         numTracers        ! total number of tracers
+
+      real (kind=RKIND) ::  &
+         signedFactor,      &! temp factor including flux sign
+         tracerMinNew,      &! updated tracer minimum
+         tracerMaxNew,      &! updated tracer maximum
+         tracerUpwindNew,   &! tracer updated with upwind flx
+         scaleFactor,       &! factor for normalizing fluxes
+         flux,              &! flux temporary
+         tracerWeight,      &! tracer weighting temporary
+         invAreaCell1,      &! inverse cell area
+         coef1, coef3        ! temporary coefficients
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         wgtTmp,            &! vertical temporaries for
+         flxTmp, sgnTmp      !   high-order flux computation
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         tracerCur,     &! reordered current tracer
+         tracerMax,     &! max tracer in neighbors for limiting
+         tracerMin,     &! min tracer in neighbors for limiting
+         hNewInv,       &! inverse of new layer thickness
+         hProv,         &! provisional layer thickness
+         hProvInv,      &! inverse of provisional layer thickness
+         flxIn,         &! flux coming into each cell
+         flxOut,        &! flux going out of each cell
+         workTend,      &! temp for holding some tendency values
+         lowOrderFlx,   &! low order flux for FCT
+         highOrderFlx    ! high order flux for FCT
+
+      real (kind=RKIND), parameter :: &
+         eps = 1.e-10_RKIND  ! small number to avoid numerical difficulties
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('allocates')
+#endif
+      ! Get dimensions
+      numTracers  = size(tracers,dim=1)
+
+      ! allocate temporary arrays
+      allocate(wgtTmp      (nVertLevels), &
+               flxTmp      (nVertLevels), &
+               sgnTmp      (nVertLevels), &
+               tracerCur   (nVertLevels  ,nCellsAll+1), &
+               tracerMin   (nVertLevels  ,nCellsAll), &
+               tracerMax   (nVertLevels  ,nCellsAll), &
+               hNewInv     (nVertLevels  ,nCellsAll), &
+               hProv       (nVertLevels  ,nCellsAll), &
+               hProvInv    (nVertLevels  ,nCellsAll), &
+               flxIn       (nVertLevels  ,nCellsAll+1), &
+               flxOut      (nVertLevels  ,nCellsAll+1), &
+               workTend    (nVertLevels  ,nCellsAll+1), &
+               lowOrderFlx (nVertLevels+1,max(nCellsAll,nEdgesAll)+1), &
+               highOrderFlx(nVertLevels+1,max(nCellsAll,nEdgesAll)+1))
+
+      !$acc enter data create(wgtTmp, flxTmp, sgnTmp, &
+      !$acc                   tracerCur, tracerMin, tracerMax, &
+      !$acc                   hNewInv, hProv, hProvInv, flxIn, flxOut, &
+      !$acc                   workTend, lowOrderFlx, highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('allocates')
+      call mpas_timer_start('prov thickness')
+#endif
+
+      ! Compute some provisional layer thicknesses
+      ! Note: This assumes we are in the first part of the horizontal/
+      ! vertical operator splitting, which is true because currently
+      ! we dont flip order and horizontal is always first.
+      ! See notes in commit 2cd4a89d.
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(areaCell, dvEdge, minLevelCell, maxLevelCell, &
+      !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+      !$acc            layerThickness, normalThicknessFlux, w, &
+      !$acc            hProv, hProvInv, hNewInv) &
+      !$acc    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k,kmin,kmax,i,iEdge, invAreaCell1, signedFactor) 
+#endif
+      do iCell = 1, nCellsAll
+         invAreaCell1 = dt/areaCell(iCell)
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         do k = kmin, kmax
+            hProv(k, iCell) = layerThickness(k, iCell)
+         end do
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i,iCell)
+            signedFactor = invAreaCell1*dvEdge(iEdge)* &
+                           edgeSignOnCell(i,iCell)
+            ! Provisional layer thickness is after horizontal
+            ! thickness flux only
+            do k = kmin, kmax
+               hProv(k,iCell) = hProv(k,iCell) &
+                              + signedFactor*normalThicknessFlux(k,iEdge)
+            end do
+         end do
+         ! New layer thickness is after horizontal and vertical
+         ! thickness flux
+         do k = kmin, kmax
+            hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+            hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                dt*w(k,iCell) + dt*w(k+1, iCell))
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('prov thickness')
+#endif
+
+      ! Loop over tracers. One tracer is advected at a time.
+      do iTracer = 1, numTracers
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init')
+#endif
+
+        ! Extract current tracer and change index order to improve locality
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) &
+        !$acc    present(tracerCur, tracers)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+#endif
+        do iCell = 1, nCellsAll+1
+        do k=1, nVertLevels
+           tracerCur(k,iCell) = tracers(iTracer,k,iCell)
+        end do ! k loop
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+        ! Compute the high and low order horizontal fluxes.
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init')
+        call mpas_timer_start('tracer bounds')
+#endif
+
+        ! set nCells to first halo level
+        nCells = nCellsHalo(1)
+
+        ! Determine bounds on tracer (tracerMin and tracerMax) from
+        ! surrounding cells for later limiting.
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, nEdgesOnCell, &
+        !$acc            cellsOnCell, tracerCur, tracerMin, tracerMax) &
+        !$acc    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
+#endif
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+           do k=kmin,kmax
+              tracerMin(k,iCell) = tracerCur(k,iCell)
+              tracerMax(k,iCell) = tracerCur(k,iCell)
+           end do
+           do i = 1, nEdgesOnCell(iCell)
+              cell2 = cellsOnCell(i,iCell)
+              kmin1 = max(kmin, minLevelCell(cell2))
+              kmax1 = min(kmax, maxLevelCell(cell2))
+              do k=kmin1,kmax1
+                 tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+                                          tracerCur(k,cell2))
+                 tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+                                          tracerCur(k,cell2))
+              end do ! k loop
+           end do ! i loop over nEdgesOnCell
+        end do ! cell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('tracer bounds')
+        call mpas_timer_start('horiz flux')
+#endif
+        ! Need all the edges around the 1 halo cells and owned cells
+        nEdges = nEdgesHalo(2)
+
+        ! Compute the high order horizontal flux
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, minLevelEdgeBot, &
+        !$acc            maxLevelEdgeTop, nAdvCellsForEdge, & 
+        !$acc            advCellsForEdge, cellsOnEdge, dvEdge, &
+        !$acc            advMaskHighOrder, advCoefs, advCoefs3rd, &
+        !$acc            tracerCur, normalThicknessFlux, &
+        !$acc            highOrderFlx, lowOrderFlx) &
+        !$acc    private(i, k, icell, cell1, cell2, coef1, coef3, &
+        !$acc            wgtTmp, sgnTmp, flxTmp, tracerWeight)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, icell, cell1, cell2, coef1, coef3, &
+        !$omp            wgtTmp, sgnTmp, flxTmp, tracerWeight)
+#endif
+        do iEdge = 1, nEdges
+           cell1 = cellsOnEdge(1, iEdge)
+           cell2 = cellsOnEdge(2, iEdge)
+
+           ! compute some common intermediate factors
+           do k = 1, nVertLevels
+              wgtTmp(k) = normalThicknessFlux(k,iEdge)* &
+                          advMaskHighOrder(k,iEdge)
+              sgnTmp(k) = sign(1.0_RKIND, &
+                               normalThicknessFlux(k,iEdge))
+              flxTmp(k) = 0.0_RKIND
+           end do
+
+           ! Compute 3rd or 4th fluxes where requested.
+           do i = 1, nAdvCellsForEdge(iEdge)
+              iCell = advCellsForEdge(i,iEdge)
+              coef1 = advCoefs       (i,iEdge)
+              coef3 = advCoefs3rd    (i,iEdge)*coef3rdOrder
+              do k = minLevelCell(iCell), maxLevelCell(iCell)
+                 flxTmp(k) = flxTmp(k) + tracerCur(k,iCell)* &
+                             wgtTmp(k)*(coef1 + coef3*sgnTmp(k))
+              end do ! k loop
+           end do ! i loop over nAdvCellsForEdge
+
+           do k=1,nVertLevels
+              highOrderFlx(k,iEdge) = flxTmp(k)
+           end do
+
+           ! Compute 2nd order fluxes where needed.
+           ! Also compute low order upwind horizontal flux (monotonic)
+           ! Remove low order flux from the high order flux
+           ! Store left over high order flux in highOrderFlx array
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              tracerWeight = (1.0_RKIND - advMaskHighOrder(k,iEdge)) &
+                           * (dvEdge(iEdge) * 0.5_RKIND)             &
+                           * normalThicknessFlux(k, iEdge)
+
+              lowOrderFlx(k,iEdge) = dvEdge(iEdge) * &
+               (max(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell1) &
+              + min(0.0_RKIND,normalThicknessFlux(k,iEdge))*tracerCur(k,cell2))
+
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iedge) &
+                                    + tracerWeight*(tracerCur(k,cell1) &
+                                                  + tracerCur(k,cell2))
+
+              highOrderFlx(k,iEdge) = highOrderFlx(k,iEdge) &
+                                    -  lowOrderFlx(k,iEdge)
+           end do ! k loop
+        end do ! iEdge loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('horiz flux')
+        call mpas_timer_start('scale factor build')
+#endif
+
+        ! Initialize flux arrays for all cells
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present (workTend, flxIn, flxOut)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime)
+#endif
+        do iCell = 1, nCellsAll+1
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+           flxIn   (k, iCell) = 0.0_RKIND
+           flxOut  (k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+        ! Need one halo of cells around owned cells
+        nCells = nCellsHalo(1)
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            minLevelCell, maxLevelCell, areaCell, &
+        !$acc            nEdgesOnCell, edgesOnCell, cellsOnEdge, &
+        !$acc            edgeSignOnCell, layerThickness, hProvInv, &
+        !$acc            tracerCur, tracerMax, tracerMin, workTend, &
+        !$acc            flxOut, flxIn, lowOrderFlx, highOrderFlx) &
+        !$acc    private(i, k, iEdge, cell1, cell2, &
+        !$acc            invAreaCell1, signedFactor, scaleFactor, &
+        !$acc            tracerUpwindNew, tracerMinNew, tracerMaxNew)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, iEdge, cell1, cell2, &
+        !$omp            invAreaCell1, signedFactor, scaleFactor, &
+        !$omp            tracerUpwindNew, tracerMinNew, tracerMaxNew)
+#endif
+        do iCell = 1, nCells
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+           ! Finish computing the low order horizontal fluxes
+           ! Upwind fluxes are accumulated in workTend
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              signedFactor = edgeSignOnCell(i, iCell) * invAreaCell1
+
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+
+                 ! Here workTend is the advection tendency due to the
+                 ! upwind (low order) fluxes.
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*lowOrderFlx(k,iEdge)
+
+                 ! Accumulate remaining high order fluxes
+                 flxOut(k,iCell) = flxOut(k,iCell) + min(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
+                 flxIn (k,iCell) = flxIn (k,iCell) + max(0.0_RKIND,  &
+                                   signedFactor*highOrderFlx(k,iEdge))
+
+              end do
+           end do
+
+           ! Build the factors for the FCT
+           ! Computed using the bounds that were computed previously,
+           ! and the bounds on the newly updated value
+           ! Factors are placed in the flxIn and flxOut arrays
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! Here workTend is the upwind tendency
+              tracerUpwindNew = (tracerCur(k,iCell)*layerThickness(k,iCell) &
+                              + dt*workTend(k,iCell))*hProvInv(k,iCell)
+              tracerMinNew = tracerUpwindNew &
+                           + dt*flxOut(k,iCell)*hProvInv(k,iCell)
+              tracerMaxNew = tracerUpwindNew &
+                           + dt*flxIn (k,iCell)*hProvInv(k,iCell)
+
+              scaleFactor = (tracerMax(k,iCell) - tracerUpwindNew)/ &
+                            (tracerMaxNew - tracerUpwindNew + eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+              scaleFactor = (tracerUpwindNew - tracerMin(k,iCell))/ &
+                            (tracerUpwindNew - tracerMinNew + eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('rescale horiz fluxes')
+#endif
+        ! Need all of the edges around owned cells
+        nEdges = nEdgesHalo(1)
+        !  rescale the high order horizontal fluxes
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            cellsOnEdge, highOrderFlx, flxIn, flxOut) &
+        !$acc    private(k, cell1, cell2)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, cell1, cell2)
+#endif
+        do iEdge = 1, nEdges
+           cell1 = cellsOnEdge(1,iEdge)
+           cell2 = cellsOnEdge(2,iEdge)
+           do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+              highOrderFlx(k,iEdge) = max(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxOut(k,cell1), flxIn (k,cell2)) &
+                                    + min(0.0_RKIND,highOrderFlx(k,iEdge))* &
+                                      min(flxIn (k,cell1), flxOut(k,cell2))
+           end do ! k loop
+        end do ! iEdge loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('rescale horiz fluxes')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelEdgeBot, maxLevelEdgeTop, &
+        !$acc            minLevelCell, maxLevelCell, areaCell, &
+        !$acc            nEdgesOnCell, edgesOnCell, edgeSignOnCell, &
+        !$acc            workTend, highOrderFlx, layerThickness, &
+        !$acc            tracerCur, hProvInv, tend) &
+        !$acc    private(i, k, iEdge, invAreaCell1, signedFactor) 
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(i, k, iEdge, invAreaCell1, signedFactor) 
+#endif
+        do iCell = 1, nCellsOwned
+           invAreaCell1 = 1.0_RKIND / areaCell(iCell)
+
+           ! Accumulate the scaled high order horizontal tendencies
+           do i = 1, nEdgesOnCell(iCell)
+              iEdge = edgesOnCell(i, iCell)
+              signedFactor = invAreaCell1*edgeSignOnCell(i,iCell)
+              do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
+                 ! workTend on RHS is upwind tendency
+                 ! workTend on LHS is total horiz advect tendency
+                 workTend(k,iCell) = workTend(k,iCell) &
+                                   + signedFactor*highOrderFlx(k,iEdge)
+              end do
+           end do
+
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend  on RHS is total horiz advection tendency
+              ! tracerCur on LHS is provisional tracer after
+              !                     horizontal fluxes only.
+              tracerCur(k,iCell) = (tracerCur(k,iCell)* &
+                                    layerThickness(k,iCell) &
+                                    + dt*workTend(k,iCell)) &
+                                 * hProvInv(k,iCell)
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do
+
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags horiz')
+#endif
+        ! Compute budget and monotonicity diagnostics if needed
+        if (computeBudgets) then
+
+           nEdges = nEdgesHalo(2)
+#ifdef MPAS_OPENACC
+           !$acc parallel loop private(k) &
+           !$acc    present(activeTracerHorizontalAdvectionEdgeFlux, &
+           !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+           !$acc            lowOrderFlx, highOrderFlx, dvEdge)
+#else
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+#endif
+           do iEdge = 1,nEdges
+           do k = minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+              ! Save u*h*T flux on edge for analysis. This variable will be
+              ! divided by h at the end of the time step.
+              activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                 (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
+           enddo
+           enddo
+#ifndef MPAS_OPENACC
+           !$omp end do
+#endif
+
+#ifdef MPAS_OPENACC
+           !$acc parallel loop private(k) &
+           !$acc    present(activeTracerHorizontalAdvectionTendency, &
+           !$acc            minLevelCell, maxLevelCell, workTend)
+#else
+           !$omp do schedule(runtime) private(k)
+#endif
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              activeTracerHorizontalAdvectionTendency(iTracer,k,iCell) = &
+                                                     workTend(k,iCell)
+           end do
+           end do ! iCell loop
+#ifndef MPAS_OPENACC
+           !$omp end do
+           !$omp end parallel
+#endif
+
+        end if ! computeBudgets
+
+        if (monotonicityCheck) then
+           ! Check tracer values against local min,max to detect
+           ! non-monotone values and write warning if found
+
+           ! Perform check on host since print involved
+           !$acc update host(tracerCur, tracerMin, tracerMax)
+
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              if(tracerCur(k,iCell) < tracerMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                    'Horizontal minimum out of bounds on tracer: $i $r $r ', &
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMin(k, iCell), tracerCur(k,iCell) /) )
+              end if
+
+              if(tracerCur(k,iCell) > tracerMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                    'Horizontal maximum out of bounds on tracer: $i $r $r ', &
+                    MPAS_LOG_WARN, intArgs=(/iTracer/),                      &
+                    realArgs=(/ tracerMax(k, iCell), tracerCur(k,iCell) /) )
+              end if
+           end do
+           end do
+           !$omp end do
+           !$omp end parallel
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags horiz')
+#endif
+
+        !-----------------------------------------------------------------------
+        !
+        !  Horizontal advection complete
+        !  Begin vertical advection
+        !
+        !-----------------------------------------------------------------------
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_start('cell init vert')
+#endif
+        ! Initialize variables for use in this iTracer iteration
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop collapse(2) present(workTend)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k)
+#endif
+        do iCell = 1, nCellsAll
+        do k=1, nVertLevels
+           workTend(k, iCell) = 0.0_RKIND
+        end do ! k loop
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('cell init vert')
+        call mpas_timer_start('vertical bounds')
+#endif
+
+        ! Need all owned and 1 halo cells
+        nCells = nCellsHalo(1)
+
+        ! Determine bounds on tracerCur from neighbor values for limiting
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(tracerCur, tracerMin, tracerMax, &
+        !$acc            minLevelCell, maxLevelCell) &
+        !$acc    private(k, kmin, kmax)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           ! take care of top cell
+           tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+           tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
+                                       tracerCur(2,iCell))
+           do k=kmin+1,kmax-1
+              tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+              tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
+                                       tracerCur(k  ,iCell), &
+                                       tracerCur(k+1,iCell))
+           end do
+           ! finish with bottom cell
+           tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
+           tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
+                                       tracerCur(kmax-1,iCell))
+        end do ! cell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical bounds')
+        call mpas_timer_start('vertical flux high')
+#endif
+
+        ! Compute the high order vertical fluxes based on order selected.
+
+        call ocn_tracer_advection_vert_flx(tracerCur, w, hProv, &
+                                           highOrderFlx)
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux high')
+        call mpas_timer_start('vertical flux')
+#endif
+
+        ! Compute low order upwind vertical flux (monotonic)
+        ! Remove low order flux from the high order flux.
+        ! Store left over high order flux in highOrderFlx array.
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, w, tracerCur, &
+        !$acc            lowOrderFlx, highOrderFlx, workTend, &
+        !$acc            flxIn, flxOut) &
+        !$acc    private(k, kmin, kmax)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax)
+#endif
+        do iCell = 1, nCells
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+
+           lowOrderFlx(kmin,iCell) = 0.0_RKIND
+           do k = kmin+1, kmax
+              lowOrderFlx(k,iCell) = &
+                    min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
+                    max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
+              highOrderFlx(k,iCell) = highOrderFlx(k,iCell) &
+                                    -  lowOrderFlx(k,iCell)
+           end do ! k loop
+           lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+
+           ! Upwind fluxes are accumulated in workTend
+           ! flxIn  contains total remaining high order flux into iCell
+           !          it is positive.
+           ! flxOut contains total remaining high order flux out of iCell
+           !          it is negative
+           do k = kmin,kmax
+              workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+                                - lowOrderFlx(k  ,iCell)
+              flxIn (k,iCell) = max(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - min(0.0_RKIND, highOrderFlx(k  ,iCell))
+              flxOut(k,iCell) = min(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+                              - max(0.0_RKIND, highOrderFlx(k  ,iCell))
+           end do ! k Loop
+        end do ! iCell Loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('vertical flux')
+        call mpas_timer_start('scale factor build')
+#endif
+
+        ! Build the scale factors to limit flux for FCT
+        ! Computed using the bounds that were computed previously,
+        ! and the bounds on the newly updated value
+        ! Factors are placed in the flxIn and flxOut arrays
+
+        nCells = nCellsHalo(1) ! Need one halo around owned cells
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, hProv, hNewInv, &
+        !$acc            tracerCur, tracerMax, tracerMin, &
+        !$acc            workTend, flxIn, flxOut) &
+        !$acc    private(k, tracerMinNew, tracerMaxNew, &
+        !$acc            tracerUpwindNew, scaleFactor) 
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) &
+        !$omp    private(k, tracerMinNew, tracerMaxNew, &
+        !$omp            tracerUpwindNew, scaleFactor)
+#endif
+        do iCell = 1, nCells
+
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              ! workTend on the RHS is the upwind tendency
+              tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                           + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+                           * hNewInv(k,iCell)
+              tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+                              + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+
+              scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
+                            (tracerMaxNew-tracerUpwindNew+eps)
+              flxIn (k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+
+              scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
+                            (tracerUpwindNew-tracerMinNew+eps)
+              flxOut(k,iCell) = min(1.0_RKIND, &
+                                max(0.0_RKIND, scaleFactor))
+           end do ! k loop
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('scale factor build')
+        call mpas_timer_start('flux accumulate')
+#endif
+
+        ! Accumulate the scaled high order vertical tendencies
+        ! and the upwind tendencies
+
+#ifdef MPAS_OPENACC
+        !$acc parallel loop &
+        !$acc    present(minLevelCell, maxLevelCell, highOrderFlx, &
+        !$acc            flxIn, flxOut, workTend, tend) &
+        !$acc    private(k, kmin, kmax, flux)
+#else
+        !$omp parallel
+        !$omp do schedule(runtime) private(k, kmin, kmax, flux)
+#endif
+        do iCell = 1, nCellsOwned
+           kmin = minLevelCell(iCell)
+           kmax = maxLevelCell(iCell)
+           ! rescale the high order vertical flux
+           do k = kmin+1, kmax
+              flux =  highOrderFlx(k,iCell)
+              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+                                      min(flxOut(k  ,iCell), &
+                                          flxIn (k-1,iCell)) &
+                                    + min(0.0_RKIND,flux)*   &
+                                      min(flxOut(k-1,iCell), &
+                                          flxIn (k  ,iCell))
+           end do ! k loop
+
+           do k = kmin,kmax
+              ! workTend on the RHS is upwind tendency
+              ! workTend on the LHS is total vertical advection tendency
+              workTend(k, iCell) = workTend(k, iCell)       &
+                                 + (highOrderFlx(k+1,iCell) &
+                                  - highOrderFlx(k  ,iCell))
+              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+                                    + workTend(k,iCell)
+           end do ! k loop
+
+        end do ! iCell loop
+#ifndef MPAS_OPENACC
+        !$omp end do
+        !$omp end parallel
+#endif
+
+        ! Compute advection diagnostics and monotonicity checks if requested
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('flux accumulate')
+        call mpas_timer_start('advect diags vert')
+#endif
+        if (computeBudgets) then
+
+#ifdef MPAS_OPENACC
+           !$acc parallel loop &
+           !$acc    present(lowOrderFlx, highOrderFlx, workTend, &
+           !$acc            activeTracerVerticalAdvectionTopFlux, &
+           !$acc            activeTracerVerticalAdvectionTendency, &
+           !$acc            minLevelCell, maxLevelCell) &
+           !$acc    private(k, kmin, kmax)
+#else
+           !$omp parallel
+           !$omp do schedule(runtime) private(k,kmin,kmax)
+#endif
+           do iCell = 1, nCellsOwned
+              kmin = minLevelCell(iCell)
+              kmax = maxLevelCell(iCell)
+              do k = kmin+1,kmax
+                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
+                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
+              end do
+              do k = kmin,kmax
+                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+                    workTend(k,iCell)
+              end do
+           end do ! iCell loop
+#ifndef MPAS_OPENACC
+           !$omp end do
+           !$omp end parallel
+#endif
+        end if ! computeBudgets
+
+        if (monotonicityCheck) then
+
+           ! Check for monotonicity of new tracer value
+           ! Use flxIn as a temp for new tracer value
+
+#ifdef MPAS_OPENACC
+           !$acc parallel loop collapse(2) &
+           !$acc    present(flxIn, tracerCur, hProv, hNewInv, &
+           !$acc            workTend, cellMask)
+#else
+           !$omp parallel
+           !$omp do schedule(runtime) private(k)
+#endif
+           do iCell = 1,nCellsOwned
+           do k = 1,nVertLevels
+              ! workTend on the RHS is total vertical advection tendency
+              flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
+                             + dt*workTend(k, iCell)) &
+                             * hNewInv(k,iCell)*cellMask(k,iCell)
+           end do ! vert
+           end do ! cell loop
+#ifndef MPAS_OPENACC
+           !$omp end do
+           !$omp end parallel
+#endif
+
+           ! Transfer new tracer values to host for diagnostic check
+           !$acc update host(flxIn)
+
+           ! Print out info for cells that are out of bounds
+           ! flxIn holds new tracer values
+           do iCell = 1, nCellsOwned
+           do k = minLevelCell(iCell), maxLevelCell(iCell)
+              if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
+                 call mpas_log_write( &
+                   'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
+                   MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                   realArgs=(/ tracerMin(k,iCell), flxIn(k,iCell) /) )
+              end if
+              if (flxIn(k,iCell) > tracerMax(k,iCell)+eps) then
+                 call mpas_log_write( &
+                   'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
+                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+                    realArgs=(/ tracerMax(k,iCell), flxIn(k,iCell) /) )
+              end if
+           end do
+           end do
+
+        end if ! monotonicity check
+#ifdef _ADV_TIMERS
+        call mpas_timer_stop('advect diags vert')
+#endif
+      end do ! iTracer loop
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_start('deallocates')
+#endif
+      !$acc exit data delete(wgtTmp, flxTmp, sgnTmp, &
+      !$acc                  tracerCur, tracerMin, tracerMax, &
+      !$acc                  hNewInv, hProv, hProvInv, flxIn, flxOut, &
+      !$acc                  workTend, lowOrderFlx, highOrderFlx)
+
+      deallocate(wgtTmp,       &
+                 flxTmp,       &
+                 sgnTmp,       &
+                 tracerCur,    &
+                 tracerMin,    &
+                 tracerMax,    &
+                 hNewInv,      &
+                 hProv,        &
+                 hProvInv,     &
+                 flxIn,        &
+                 flxOut,       &
+                 workTend,     &
+                 lowOrderFlx,  &
+                 highOrderFlx)
+
+#ifdef _ADV_TIMERS
+      call mpas_timer_stop('deallocates')
+#endif
+
+   end subroutine ocn_tracer_advection_mono_tend!}}}
+
+!**********************************************************************
+!
+!  routine ocn_tracer_advection_mono_init
+!
+!> \brief MPAS initialize monotonic tracer advection tendency with FCT
+!> \author Mark Petersen, David Lee, Doug Jacobsen, Phil Jones
+!> \date   October 2017, updated May 2019
+!> \details
+!>  This routine initializes monotonic tracer advection quantities for
+!>  the flux-corrected transport (FCT) algorithm.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_advection_mono_init(err)!{{{
+
+      !*** output parameters
+
+      integer, intent(out) :: &
+         err                   !< [out] error flag
+
+      ! end of preamble
+      !----------------
+      ! begin code
+
+      err = 0 ! initialize error code to success
+
+      ! Check that the halo is wide enough for FCT
+      if (config_num_halos < 3) then
+         call mpas_log_write( &
+            'Monotonic advection cannot be used with less than 3 halos.', &
+            MPAS_LOG_CRIT)
+         err = -1
+      end if
+
+      ! Set blending coefficient if 3rd order horizontal advection chosen
+      select case (config_horiz_tracer_adv_order)
+      case (2)
+         coef3rdOrder = 0.0_RKIND
+      case (3)
+         coef3rdOrder = config_coef_3rd_order
+      case (4)
+         coef3rdOrder = 0.0_RKIND
+      case default
+         coef3rdOrder = 0.0_RKIND
+         call mpas_log_write( &
+            'Invalid value for horizontal advection order, defaulting to 2',&
+            MPAS_LOG_WARN)
+      end select ! horizontal advection order
+
+      ! Set flag for checking monotonicity
+      monotonicityCheck = config_check_tracer_monotonicity
+
+   end subroutine ocn_tracer_advection_mono_init!}}}
+
+!***********************************************************************
+
+end module ocn_tracer_advection_mono
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -1,5 +1,5 @@
-! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 ! and the University Corporation for Atmospheric Research (UCAR).
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file
@@ -67,7 +67,7 @@ module li_tracer_advection_fct
                                         tend, tracers, layerThickness, &
                                         normalThicknessFlux, w, dt,    &
                                         computeBudgets)!{{{
-
+      use li_mesh
       !-----------------------------------------------------------------
       ! Input/Output parameters
       !-----------------------------------------------------------------
@@ -100,7 +100,6 @@ module li_tracer_advection_fct
       integer ::          &
          i, iCell, iEdge, &! horz indices
          cell1, cell2,    &! neighbor cell indices
-         nCells, nEdges,  &! numbers of cells or edges
          k,kmin, kmax, &! vert index variants
          kmin1, kmax1,    &! vert index variants
          iTracer,         &! tracer index
@@ -212,9 +211,14 @@ module li_tracer_advection_fct
          ! New layer thickness is after horizontal and vertical
          ! thickness flux
          do k = kmin, kmax
-            hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
-            hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
-                                dt*w(k,iCell) + dt*w(k+1, iCell))
+            if (hProv(k, iCell) > 0.0_RKIND) then
+               hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
+               hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
+                                   dt*w(k,iCell) + dt*w(k+1, iCell))
+            else
+               hProvInv(k, iCell) = 0.0_RKIND
+               hNewInv(k, iCell)  = 0.0_RKIND
+            endif
          end do
       end do
 #ifndef MPAS_OPENACC
@@ -258,7 +262,7 @@ module li_tracer_advection_fct
 #endif
 
         ! set nCells to first halo level
-        nCells = nCellsHalo(1)
+        ! nCells = nCellsHalo(1)
 
         ! Determine bounds on tracer (tracerMin and tracerMax) from
         ! surrounding cells for later limiting.
@@ -273,7 +277,7 @@ module li_tracer_advection_fct
         !$omp do schedule(runtime) &
         !$omp    private(k, kmin, kmax, kmin1, kmax1, i, cell2)
 #endif
-        do iCell = 1, nCells
+        do iCell = 1, nCellsHalo(1)
            kmin = 1 !minLevelCell(iCell)
            kmax = nVertLevels !maxLevelCell(iCell)
            do k=kmin,kmax
@@ -281,17 +285,17 @@ module li_tracer_advection_fct
               tracerMax(k,iCell) = tracerCur(k,iCell)
            end do
            ! TODO: Determine how/if this translates to MALI
-           !do i = 1, nEdgesOnCell(iCell)
-           !   cell2 = cellsOnCell(i,iCell)
-           !   kmin1 = max(kmin, minLevelCell(cell2))
-           !   kmax1 = min(kmax, maxLevelCell(cell2))
-           !   do k=kmin1,kmax1
-           !      tracerMax(k,iCell) = max(tracerMax(k,iCell), &
-           !                               tracerCur(k,cell2))
-           !      tracerMin(k,iCell) = min(tracerMin(k,iCell), &
-           !                               tracerCur(k,cell2))
-           !   end do ! k loop
-           !end do ! i loop over nEdgesOnCell
+           do i = 1, nEdgesOnCell(iCell)
+              cell2 = cellsOnCell(i,iCell)
+              !kmin1 = max(kmin, minLevelCell(cell2))
+              !kmax1 = min(kmax, maxLevelCell(cell2))
+              do k=kmin, kmax !kmin1,kmax1
+                 tracerMax(k,iCell) = max(tracerMax(k,iCell), &
+                                          tracerCur(k,cell2))
+                 tracerMin(k,iCell) = min(tracerMin(k,iCell), &
+                                          tracerCur(k,cell2))
+              end do ! k loop
+           end do ! i loop over nEdgesOnCell
         end do ! cell loop
 #ifndef MPAS_OPENACC
         !$omp end do
@@ -303,7 +307,7 @@ module li_tracer_advection_fct
         call mpas_timer_start('horiz flux')
 #endif
         ! Need all the edges around the 1 halo cells and owned cells
-        nEdges = nEdgesHalo(2)
+        ! nEdges = nEdgesHalo(2)
 
         ! Compute the high order horizontal flux
 
@@ -323,7 +327,7 @@ module li_tracer_advection_fct
         !$omp    private(i, k, icell, cell1, cell2, coef1, coef3, &
         !$omp            wgtTmp, sgnTmp, flxTmp, tracerWeight)
 #endif
-        do iEdge = 1, nEdges
+        do iEdge = 1, nEdgesHalo(2)
            cell1 = cellsOnEdge(1, iEdge)
            cell2 = cellsOnEdge(2, iEdge)
 
@@ -404,7 +408,7 @@ module li_tracer_advection_fct
 #endif
 
         ! Need one halo of cells around owned cells
-        nCells = nCellsHalo(1)
+        ! nCells = nCellsHalo(1)
 
 #ifdef MPAS_OPENACC
         !$acc parallel loop &
@@ -424,7 +428,7 @@ module li_tracer_advection_fct
         !$omp            invAreaCell1, signedFactor, scaleFactor, &
         !$omp            tracerUpwindNew, tracerMinNew, tracerMaxNew)
 #endif
-        do iCell = 1, nCells
+        do iCell = 1, nCellsHalo(1)
            invAreaCell1 = 1.0_RKIND / areaCell(iCell)
 
            ! Finish computing the low order horizontal fluxes
@@ -484,7 +488,7 @@ module li_tracer_advection_fct
         call mpas_timer_start('rescale horiz fluxes')
 #endif
         ! Need all of the edges around owned cells
-        nEdges = nEdgesHalo(1)
+        ! nEdges = nEdgesHalo(1)
         !  rescale the high order horizontal fluxes
 
 #ifdef MPAS_OPENACC
@@ -496,7 +500,7 @@ module li_tracer_advection_fct
         !$omp parallel
         !$omp do schedule(runtime) private(k, cell1, cell2)
 #endif
-        do iEdge = 1, nEdges
+        do iEdge = 1, nEdgesHalo(1)
            cell1 = cellsOnEdge(1,iEdge)
            cell2 = cellsOnEdge(2,iEdge)
            do k = 1, nVertLevels !minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
@@ -569,9 +573,9 @@ module li_tracer_advection_fct
         call mpas_timer_start('advect diags horiz')
 #endif
         ! Compute budget and monotonicity diagnostics if needed
-        if (computeBudgets) then
+!        if (computeBudgets) then
 
-           nEdges = nEdgesHalo(2)
+           !nEdges = nEdgesHalo(2)
 #ifdef MPAS_OPENACC
            !$acc parallel loop private(k) &
            !$acc    present(activeTracerHorizontalAdvectionEdgeFlux, &
@@ -621,7 +625,7 @@ module li_tracer_advection_fct
 !           !$omp end parallel
 !#endif
 
-        end if ! computeBudgets
+!        end if ! computeBudgets
 
         if (monotonicityCheck) then
            ! Check tracer values against local min,max to detect
@@ -655,7 +659,7 @@ module li_tracer_advection_fct
 #ifdef _ADV_TIMERS
         call mpas_timer_stop('advect diags horiz')
 #endif
-
+!TODO: implement vertical advection?
         !-----------------------------------------------------------------------
         !
         !  Horizontal advection complete
@@ -663,328 +667,327 @@ module li_tracer_advection_fct
         !
         !-----------------------------------------------------------------------
 
-#ifdef _ADV_TIMERS
-        call mpas_timer_start('cell init vert')
-#endif
-        ! Initialize variables for use in this iTracer iteration
-
-#ifdef MPAS_OPENACC
-        !$acc parallel loop collapse(2) present(workTend)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k)
-#endif
-        do iCell = 1, nCells
-        do k=1, nVertLevels
-           workTend(k, iCell) = 0.0_RKIND
-        end do ! k loop
-        end do ! iCell loop
-#ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
-#endif
-
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('cell init vert')
-        call mpas_timer_start('vertical bounds')
-#endif
-
-        ! Need all owned and 1 halo cells
-        nCells = nCellsHalo(1)
-
-        ! Determine bounds on tracerCur from neighbor values for limiting
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(tracerCur, tracerMin, tracerMax, &
-        !$acc            minLevelCell, maxLevelCell) &
-        !$acc    private(k, kmin, kmax)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
-        do iCell = 1, nCells
-           kmin = 1 !minLevelCell(iCell)
-           kmax = nVertLevels !maxLevelCell(iCell)
-
-           ! take care of top cell
-           tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
-                                       tracerCur(2,iCell))
-           tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
-                                       tracerCur(2,iCell))
-           do k=kmin+1,kmax-1
-              tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
-                                       tracerCur(k  ,iCell), &
-                                       tracerCur(k+1,iCell))
-              tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
-                                       tracerCur(k  ,iCell), &
-                                       tracerCur(k+1,iCell))
-           end do
-           ! finish with bottom cell
-           tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
-                                       tracerCur(kmax-1,iCell))
-           tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
-                                       tracerCur(kmax-1,iCell))
-        end do ! cell loop
-#ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
-#endif
-
 !#ifdef _ADV_TIMERS
-!        call mpas_timer_stop('vertical bounds')
-!        call mpas_timer_start('vertical flux high')
+!        call mpas_timer_start('cell init vert')
+!#endif
+!        ! Initialize variables for use in this iTracer iteration
+!
+!#ifdef MPAS_OPENACC
+!        !$acc parallel loop collapse(2) present(workTend)
+!#else
+!        !$omp parallel
+!        !$omp do schedule(runtime) private(k)
+!#endif
+!        do iCell = 1, nCells
+!        do k=1, nVertLevels
+!           workTend(k, iCell) = 0.0_RKIND
+!        end do ! k loop
+!        end do ! iCell loop
+!#ifndef MPAS_OPENACC
+!        !$omp end do
+!        !$omp end parallel
 !#endif
 !
-!        ! Compute the high order vertical fluxes based on order selected.
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('cell init vert')
+!        call mpas_timer_start('vertical bounds')
+!#endif
 !
-!        call tracer_advection_vert_flx(tracerCur, w, hProv, &
-!                                           highOrderFlx)
+!        ! Need all owned and 1 halo cells
+!        ! nCells = nCellsHalo(1)
+!
+!        ! Determine bounds on tracerCur from neighbor values for limiting
+!#ifdef MPAS_OPENACC
+!        !$acc parallel loop &
+!        !$acc    present(tracerCur, tracerMin, tracerMax, &
+!        !$acc            minLevelCell, maxLevelCell) &
+!        !$acc    private(k, kmin, kmax)
+!#else
+!        !$omp parallel
+!        !$omp do schedule(runtime) private(k, kmin, kmax)
+!#endif
+!        do iCell = 1, nCellsHalo(1)
+!           kmin = 1 !minLevelCell(iCell)
+!           kmax = nVertLevels !maxLevelCell(iCell)
+!
+!           ! take care of top cell
+!           tracerMax(kmin,iCell) = max(tracerCur(1,iCell), &
+!                                       tracerCur(2,iCell))
+!           tracerMin(kmin,iCell) = min(tracerCur(1,iCell), &
+!                                       tracerCur(2,iCell))
+!           do k=kmin+1,kmax-1
+!              tracerMax(k,iCell) = max(tracerCur(k-1,iCell), &
+!                                       tracerCur(k  ,iCell), &
+!                                       tracerCur(k+1,iCell))
+!              tracerMin(k,iCell) = min(tracerCur(k-1,iCell), &
+!                                       tracerCur(k  ,iCell), &
+!                                       tracerCur(k+1,iCell))
+!           end do
+!           ! finish with bottom cell
+!           tracerMax(kmax,iCell) = max(tracerCur(kmax  ,iCell), &
+!                                       tracerCur(kmax-1,iCell))
+!           tracerMin(kmax,iCell) = min(tracerCur(kmax  ,iCell), &
+!                                       tracerCur(kmax-1,iCell))
+!        end do ! cell loop
+!#ifndef MPAS_OPENACC
+!        !$omp end do
+!        !$omp end parallel
+!#endif
+!
+!!#ifdef _ADV_TIMERS
+!!        call mpas_timer_stop('vertical bounds')
+!!        call mpas_timer_start('vertical flux high')
+!!#endif
+!!
+!!        ! Compute the high order vertical fluxes based on order selected.
+!!
+!!        call tracer_advection_vert_flx(tracerCur, w, hProv, &
+!!                                           highOrderFlx)
+!!
+!!#ifdef _ADV_TIMERS
+!!        call mpas_timer_stop('vertical flux high')
+!!        call mpas_timer_start('vertical flux')
+!!#endif
+!
+!        ! Compute low order upwind vertical flux (monotonic)
+!        ! Remove low order flux from the high order flux.
+!        ! Store left over high order flux in highOrderFlx array.
+!
+!#ifdef MPAS_OPENACC
+!        !$acc parallel loop &
+!        !$acc    present(minLevelCell, maxLevelCell, w, tracerCur, &
+!        !$acc            lowOrderFlx, highOrderFlx, workTend, &
+!        !$acc            flxIn, flxOut) &
+!        !$acc    private(k, kmin, kmax)
+!#else
+!        !$omp parallel
+!        !$omp do schedule(runtime) private(k, kmin, kmax)
+!#endif
+!        do iCell = 1, nCellsHalo(1)
+!           kmin = 1 !minLevelCell(iCell)
+!           kmax = nVertLevels !maxLevelCell(iCell)
+!
+!           lowOrderFlx(kmin,iCell) = 0.0_RKIND
+!           do k = kmin+1, kmax
+!              lowOrderFlx(k,iCell) = &
+!                    min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
+!                    max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
+!              highOrderFlx(k,iCell) = highOrderFlx(k,iCell) &
+!                                    -  lowOrderFlx(k,iCell)
+!           end do ! k loop
+!           lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
+!
+!           ! Upwind fluxes are accumulated in workTend
+!           ! flxIn  contains total remaining high order flux into iCell
+!           !          it is positive.
+!           ! flxOut contains total remaining high order flux out of iCell
+!           !          it is negative
+!           do k = kmin,kmax
+!              workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
+!                                - lowOrderFlx(k  ,iCell)
+!              flxIn (k,iCell) = max(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+!                              - min(0.0_RKIND, highOrderFlx(k  ,iCell))
+!              flxOut(k,iCell) = min(0.0_RKIND, highOrderFlx(k+1,iCell)) &
+!                              - max(0.0_RKIND, highOrderFlx(k  ,iCell))
+!           end do ! k Loop
+!        end do ! iCell Loop
+!#ifndef MPAS_OPENACC
+!        !$omp end do
+!        !$omp end parallel
+!#endif
 !
 !#ifdef _ADV_TIMERS
-!        call mpas_timer_stop('vertical flux high')
-!        call mpas_timer_start('vertical flux')
+!        call mpas_timer_stop('vertical flux')
+!        call mpas_timer_start('scale factor build')
 !#endif
-
-        ! Compute low order upwind vertical flux (monotonic)
-        ! Remove low order flux from the high order flux.
-        ! Store left over high order flux in highOrderFlx array.
-
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, w, tracerCur, &
-        !$acc            lowOrderFlx, highOrderFlx, workTend, &
-        !$acc            flxIn, flxOut) &
-        !$acc    private(k, kmin, kmax)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k, kmin, kmax)
-#endif
-        do iCell = 1, nCells
-           kmin = 1 !minLevelCell(iCell)
-           kmax = nVertLevels !maxLevelCell(iCell)
-
-           lowOrderFlx(kmin,iCell) = 0.0_RKIND
-           do k = kmin+1, kmax
-              lowOrderFlx(k,iCell) = &
-                    min(0.0_RKIND,w(k,iCell))*tracerCur(k-1,iCell) + &
-                    max(0.0_RKIND,w(k,iCell))*tracerCur(k  ,iCell)
-              highOrderFlx(k,iCell) = highOrderFlx(k,iCell) &
-                                    -  lowOrderFlx(k,iCell)
-           end do ! k loop
-           lowOrderFlx(kmax+1,iCell) = 0.0_RKIND
-
-           ! Upwind fluxes are accumulated in workTend
-           ! flxIn  contains total remaining high order flux into iCell
-           !          it is positive.
-           ! flxOut contains total remaining high order flux out of iCell
-           !          it is negative
-           do k = kmin,kmax
-              workTend(k,iCell) = lowOrderFlx(k+1,iCell) &
-                                - lowOrderFlx(k  ,iCell)
-              flxIn (k,iCell) = max(0.0_RKIND, highOrderFlx(k+1,iCell)) &
-                              - min(0.0_RKIND, highOrderFlx(k  ,iCell))
-              flxOut(k,iCell) = min(0.0_RKIND, highOrderFlx(k+1,iCell)) &
-                              - max(0.0_RKIND, highOrderFlx(k  ,iCell))
-           end do ! k Loop
-        end do ! iCell Loop
-#ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
-#endif
-
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('vertical flux')
-        call mpas_timer_start('scale factor build')
-#endif
-
-        ! Build the scale factors to limit flux for FCT
-        ! Computed using the bounds that were computed previously,
-        ! and the bounds on the newly updated value
-        ! Factors are placed in the flxIn and flxOut arrays
-
-        nCells = nCellsHalo(1) ! Need one halo around owned cells
-
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, hProv, hNewInv, &
-        !$acc            tracerCur, tracerMax, tracerMin, &
-        !$acc            workTend, flxIn, flxOut) &
-        !$acc    private(k, tracerMinNew, tracerMaxNew, &
-        !$acc            tracerUpwindNew, scaleFactor) 
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) &
-        !$omp    private(k, tracerMinNew, tracerMaxNew, &
-        !$omp            tracerUpwindNew, scaleFactor)
-#endif
-        do iCell = 1, nCells
-
-           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
-              ! workTend on the RHS is the upwind tendency
-              tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                           + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
-                           * hNewInv(k,iCell)
-              tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                           + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
-                           * hNewInv(k,iCell)
-              tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
-                              + dt*workTend(k,iCell)) * hNewInv(k,iCell)
-
-              scaleFactor = (tracerMax(k,iCell)-tracerUpwindNew)/ &
-                            (tracerMaxNew-tracerUpwindNew+eps)
-              flxIn (k,iCell) = min(1.0_RKIND, &
-                                max(0.0_RKIND, scaleFactor))
-
-              scaleFactor = (tracerUpwindNew-tracerMin(k,iCell))/ &
-                            (tracerUpwindNew-tracerMinNew+eps)
-              flxOut(k,iCell) = min(1.0_RKIND, &
-                                max(0.0_RKIND, scaleFactor))
-           end do ! k loop
-        end do ! iCell loop
-#ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
-#endif
-
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('scale factor build')
-        call mpas_timer_start('flux accumulate')
-#endif
-
-        ! Accumulate the scaled high order vertical tendencies
-        ! and the upwind tendencies
-
-#ifdef MPAS_OPENACC
-        !$acc parallel loop &
-        !$acc    present(minLevelCell, maxLevelCell, highOrderFlx, &
-        !$acc            flxIn, flxOut, workTend, tend) &
-        !$acc    private(k, kmin, kmax, flux)
-#else
-        !$omp parallel
-        !$omp do schedule(runtime) private(k, kmin, kmax, flux)
-#endif
-        do iCell = 1, nCellsSolve
-           kmin = 1 !minLevelCell(iCell)
-           kmax = nVertLevels !maxLevelCell(iCell)
-           ! rescale the high order vertical flux
-           do k = kmin+1, kmax
-              flux =  highOrderFlx(k,iCell)
-              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
-                                      min(flxOut(k  ,iCell), &
-                                          flxIn (k-1,iCell)) &
-                                    + min(0.0_RKIND,flux)*   &
-                                      min(flxOut(k-1,iCell), &
-                                          flxIn (k  ,iCell))
-           end do ! k loop
-
-           do k = kmin,kmax
-              ! workTend on the RHS is upwind tendency
-              ! workTend on the LHS is total vertical advection tendency
-              workTend(k, iCell) = workTend(k, iCell)       &
-                                 + (highOrderFlx(k+1,iCell) &
-                                  - highOrderFlx(k  ,iCell))
-              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
-                                    + workTend(k,iCell)
-           end do ! k loop
-
-        end do ! iCell loop
-#ifndef MPAS_OPENACC
-        !$omp end do
-        !$omp end parallel
-#endif
-
-        ! Compute advection diagnostics and monotonicity checks if requested
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('flux accumulate')
-        call mpas_timer_start('advect diags vert')
-#endif
-        if (computeBudgets) then
-
-#ifdef MPAS_OPENACC
-           !$acc parallel loop &
-           !$acc    present(lowOrderFlx, highOrderFlx, workTend, &
-           !$acc            activeTracerVerticalAdvectionTopFlux, &
-           !$acc            activeTracerVerticalAdvectionTendency, &
-           !$acc            minLevelCell, maxLevelCell) &
-           !$acc    private(k, kmin, kmax)
-#endif
-
+!
+!        ! Build the scale factors to limit flux for FCT
+!        ! Computed using the bounds that were computed previously,
+!        ! and the bounds on the newly updated value
+!        ! Factors are placed in the flxIn and flxOut arrays
+!
+!        !nCells = nCellsHalo(1) ! Need one halo around owned cells
+! 
+!#ifdef MPAS_OPENACC
+!        !$acc parallel loop &
+!        !$acc    present(minLevelCell, maxLevelCell, hProv, hNewInv, &
+!        !$acc            tracerCur, tracerMax, tracerMin, &
+!        !$acc            workTend, flxIn, flxOut) &
+!        !$acc    private(k, tracerMinNew, tracerMaxNew, &
+!        !$acc            tracerUpwindNew, scaleFactor) 
+!#else
+!        !$omp parallel
+!        !$omp do schedule(runtime) &
+!        !$omp    private(k, tracerMinNew, tracerMaxNew, &
+!        !$omp            tracerUpwindNew, scaleFactor)
+!#endif
+!        do iCell = 1, nCellsHalo(1)
+!
+!           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
+!              ! workTend on the RHS is the upwind tendency
+!              tracerMinNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+!                           + dt*(workTend(k,iCell)+flxOut(k,iCell))) &
+!                           * hNewInv(k,iCell)
+!              tracerMaxNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+!                           + dt*(workTend(k,iCell)+flxIn(k,iCell))) &
+!                           * hNewInv(k,iCell)
+!              tracerUpwindNew = (tracerCur(k,iCell)*hProv(k,iCell) &
+!                              + dt*workTend(k,iCell)) * hNewInv(k,iCell)
+!
+!              scaleFactor = max(0.0_RKIND, (tracerMax(k,iCell)-tracerUpwindNew)/ &
+!                            (tracerMaxNew-tracerUpwindNew+eps) )
+!              flxIn (k,iCell) = min(1.0_RKIND, scaleFactor)
+!
+!
+!              scaleFactor = max(0.0_RKIND, (tracerUpwindNew-tracerMin(k,iCell))/ &
+!                            (tracerUpwindNew-tracerMinNew+eps) )
+!              flxOut(k,iCell) = min(1.0_RKIND, scaleFactor)
+!           end do ! k loop
+!        end do ! iCell loop
+!#ifndef MPAS_OPENACC
+!        !$omp end do
+!        !$omp end parallel
+!#endif
+!
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('scale factor build')
+!        call mpas_timer_start('flux accumulate')
+!#endif
+!
+!        ! Accumulate the scaled high order vertical tendencies
+!        ! and the upwind tendencies
+!
+!#ifdef MPAS_OPENACC
+!        !$acc parallel loop &
+!        !$acc    present(minLevelCell, maxLevelCell, highOrderFlx, &
+!        !$acc            flxIn, flxOut, workTend, tend) &
+!        !$acc    private(k, kmin, kmax, flux)
+!#else
+!        !$omp parallel
+!        !$omp do schedule(runtime) private(k, kmin, kmax, flux)
+!#endif
+!        do iCell = 1, nCellsSolve
+!           kmin = 1 !minLevelCell(iCell)
+!           kmax = nVertLevels !maxLevelCell(iCell)
+!           ! rescale the high order vertical flux
+!           do k = kmin+1, kmax
+!              flux =  highOrderFlx(k,iCell)
+!              highOrderFlx(k,iCell) = max(0.0_RKIND,flux)*   &
+!                                      min(flxOut(k  ,iCell), &
+!                                          flxIn (k-1,iCell)) &
+!                                    + min(0.0_RKIND,flux)*   &
+!                                      min(flxOut(k-1,iCell), &
+!                                          flxIn (k  ,iCell))
+!           end do ! k loop
+!
+!           do k = kmin,kmax
+!              ! workTend on the RHS is upwind tendency
+!              ! workTend on the LHS is total vertical advection tendency
+!              workTend(k, iCell) = workTend(k, iCell)       &
+!                                 + (highOrderFlx(k+1,iCell) &
+!                                  - highOrderFlx(k  ,iCell))
+!              tend(iTracer,k,iCell) = tend(iTracer,k,iCell) &
+!                                    + workTend(k,iCell)
+!           end do ! k loop
+!
+!        end do ! iCell loop
+!#ifndef MPAS_OPENACC
+!        !$omp end do
+!        !$omp end parallel
+!#endif
+!
+!        ! Compute advection diagnostics and monotonicity checks if requested
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('flux accumulate')
+!        call mpas_timer_start('advect diags vert')
+!#endif
+!        if (computeBudgets) then
+!
+!#ifdef MPAS_OPENACC
+!           !$acc parallel loop &
+!           !$acc    present(lowOrderFlx, highOrderFlx, workTend, &
+!           !$acc            activeTracerVerticalAdvectionTopFlux, &
+!           !$acc            activeTracerVerticalAdvectionTendency, &
+!           !$acc            minLevelCell, maxLevelCell) &
+!           !$acc    private(k, kmin, kmax)
+!#endif
+!
+!!#else
+!!           !$omp parallel
+!!           !$omp do schedule(runtime) private(k,kmin,kmax)
+!!#endif
+!!           do iCell = 1, nCellsSolve
+!!              kmin = minLevelCell(iCell)
+!!              kmax = maxLevelCell(iCell)
+!!              do k = kmin+1,kmax
+!!                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
+!!                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
+!!              end do
+!!              do k = kmin,kmax
+!!                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
+!!                    workTend(k,iCell)
+!!              end do
+!!           end do ! iCell loop
+!!#ifndef MPAS_OPENACC
+!!           !$omp end do
+!!           !$omp end parallel
+!!#endif
+!        end if ! computeBudgets
+!
+!        if (monotonicityCheck) then
+!
+!           ! Check for monotonicity of new tracer value
+!           ! Use flxIn as a temp for new tracer value
+!
+!#ifdef MPAS_OPENACC
+!           !$acc parallel loop collapse(2) &
+!           !$acc    present(flxIn, tracerCur, hProv, hNewInv, &
+!           !$acc            workTend, cellMask)
 !#else
 !           !$omp parallel
-!           !$omp do schedule(runtime) private(k,kmin,kmax)
+!           !$omp do schedule(runtime) private(k)
 !#endif
-!           do iCell = 1, nCellsSolve
-!              kmin = minLevelCell(iCell)
-!              kmax = maxLevelCell(iCell)
-!              do k = kmin+1,kmax
-!                 activeTracerVerticalAdvectionTopFlux(iTracer,k,iCell) = &
-!                    lowOrderFlx(k,iCell) + highOrderFlx(k,iCell)
-!              end do
-!              do k = kmin,kmax
-!                 activeTracerVerticalAdvectionTendency(iTracer,k,iCell) = &
-!                    workTend(k,iCell)
-!              end do
-!           end do ! iCell loop
+!           do iCell = 1,nCellsSolve
+!           do k = 1,nVertLevels
+!              ! workTend on the RHS is total vertical advection tendency
+!              flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
+!                             + dt*workTend(k, iCell)) &
+!                             * hNewInv(k,iCell)*cellMask(iCell)
+!           end do ! vert
+!           end do ! cell loop
 !#ifndef MPAS_OPENACC
 !           !$omp end do
 !           !$omp end parallel
 !#endif
-        end if ! computeBudgets
-
-        if (monotonicityCheck) then
-
-           ! Check for monotonicity of new tracer value
-           ! Use flxIn as a temp for new tracer value
-
-#ifdef MPAS_OPENACC
-           !$acc parallel loop collapse(2) &
-           !$acc    present(flxIn, tracerCur, hProv, hNewInv, &
-           !$acc            workTend, cellMask)
-#else
-           !$omp parallel
-           !$omp do schedule(runtime) private(k)
-#endif
-           do iCell = 1,nCellsSolve
-           do k = 1,nVertLevels
-              ! workTend on the RHS is total vertical advection tendency
-              flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
-                             + dt*workTend(k, iCell)) &
-                             * hNewInv(k,iCell)*cellMask(iCell)
-           end do ! vert
-           end do ! cell loop
-#ifndef MPAS_OPENACC
-           !$omp end do
-           !$omp end parallel
-#endif
-
-           ! Transfer new tracer values to host for diagnostic check
-           !$acc update host(flxIn)
-
-           ! Print out info for cells that are out of bounds
-           ! flxIn holds new tracer values
-           do iCell = 1, nCellsSolve
-           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
-              if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
-                 call mpas_log_write( &
-                   'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
-                   MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
-                   realArgs=(/ tracerMin(k,iCell), flxIn(k,iCell) /) )
-              end if
-              if (flxIn(k,iCell) > tracerMax(k,iCell)+eps) then
-                 call mpas_log_write( &
-                   'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
-                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
-                    realArgs=(/ tracerMax(k,iCell), flxIn(k,iCell) /) )
-              end if
-           end do
-           end do
-
-        end if ! monotonicity check
-#ifdef _ADV_TIMERS
-        call mpas_timer_stop('advect diags vert')
-#endif
+!
+!           ! Transfer new tracer values to host for diagnostic check
+!           !$acc update host(flxIn)
+!
+!           ! Print out info for cells that are out of bounds
+!           ! flxIn holds new tracer values
+!           do iCell = 1, nCellsSolve
+!           do k = 1, nVertLevels !minLevelCell(iCell), maxLevelCell(iCell)
+!              if (flxIn(k,iCell) < tracerMin(k, iCell)-eps) then
+!                 call mpas_log_write( &
+!                   'Vertical minimum out of bounds on tracer: $i $i $i $r $r ',&
+!                   MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+!                   realArgs=(/ tracerMin(k,iCell), flxIn(k,iCell) /) )
+!              end if
+!              if (flxIn(k,iCell) > tracerMax(k,iCell)+eps) then
+!                 call mpas_log_write( &
+!                   'Vertical maximum out of bounds on tracer: $i $i $i $r $r ',&
+!                    MPAS_LOG_WARN, intArgs=(/iTracer, k, iCell/), &
+!                    realArgs=(/ tracerMax(k,iCell), flxIn(k,iCell) /) )
+!              end if
+!           end do
+!           end do
+!
+!        end if ! monotonicity check
+!#ifdef _ADV_TIMERS
+!        call mpas_timer_stop('advect diags vert')
+!#endif
       end do ! iTracer loop
-
+!
 #ifdef _ADV_TIMERS
       call mpas_timer_start('deallocates')
 #endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -90,6 +90,8 @@ module li_tracer_advection_fct
       real (kind=RKIND), intent(in) :: &
          dt                    !< [in] Timestep
 
+      integer, intent(in) :: nTracers
+
       logical, intent(in) :: &
          computeBudgets    !< [in] Flag to compute active tracer budgets
       !-----------------------------------------------------------------
@@ -101,8 +103,7 @@ module li_tracer_advection_fct
          cell1, cell2,    &! neighbor cell indices
          k,kmin, kmax, &! vert index variants
          kmin1, kmax1,    &! vert index variants
-         iTracer,         &! tracer index
-         nTracers        ! total number of tracers
+         iTracer           ! tracer index
 
       real (kind=RKIND) ::  &
          signedFactor,      &! temp factor including flux sign

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -949,7 +949,7 @@ module li_tracer_advection_fct
               ! workTend on the RHS is total vertical advection tendency
               flxIn(k,iCell) = (tracerCur(k, iCell)*hProv(k, iCell) &
                              + dt*workTend(k, iCell)) &
-                             * hNewInv(k,iCell)*cellMask(k,iCell)
+                             * hNewInv(k,iCell)*cellMask(iCell)
            end do ! vert
            end do ! cell loop
 #ifndef MPAS_OPENACC

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -132,9 +132,19 @@ module li_tracer_advection_fct_shared
                 advCellsForEdge (nAdvCellsMax,nEdges), &
                 advCoefs        (nAdvCellsMax,nEdges), &
                 advCoefs3rd     (nAdvCellsMax,nEdges), &
-                advMaskHighOrder(nVertLevels ,nEdges), &
-                advMask2ndOrder(nVertLevels ,nEdges), &
+                advMaskHighOrder(nVertLevels, nEdges), &
+                advMask2ndOrder(nVertLevels,  nEdges), &
                 derivTwo      (nAdvCellsMax,2,nEdges))
+
+      ! Initialize all these allocatable arrays
+      nAdvCellsForEdge(:) = 0
+      advCellsForEdge(:,:) = 0
+      advCoefs(:,:) = 0.0_RKIND
+      advCoefs3rd(:,:) = 0.0_RKIND
+      advMaskHighOrder(:,:) = 0.0_RKIND
+      advMask2ndOrder(:,:) = 0.0_RKIND
+      derivTwo(:,:,:) = 0.0_RKIND
+
       ! Compute derivTwo array
       call computeDerivTwo(derivTwo, err)
       if (err /= 0) then
@@ -148,6 +158,9 @@ module li_tracer_advection_fct_shared
       allocate(cellIndx      (   maxEdges2 + 2), &
                cellIndxSorted(2, maxEdges2 + 2))
 
+      cellIndx(:) = 0
+      cellIndxSorted(:,:) = 0
+      
       ! calculate boundaryCell. A boundary cell is one that
       ! has at least one empty or non-dynamic neighbor
       boundaryCell(:) = 0

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -51,8 +51,8 @@ module li_tracer_advection_fct_shared
    real (kind=RKIND), public, dimension(:,:), allocatable :: &
       advCoefs,       &! common advection coefficients
       advCoefs3rd,    &! common advection coeffs for high order
-      advMaskHighOrder, & ! mask for high order advection terms
-      advMask2ndOrder
+      advMaskHighOrder, & ! mask where high order advection terms are valid
+      advMask2ndOrder  ! mask where 2nd order advection terms are valid
 
    !--------------------------------------------------------------------
    ! Public member functions 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -180,8 +180,8 @@ module li_tracer_advection_fct_shared
 
          ! second order mask must have ice on both sides and one boundary cell
          if ( (li_mask_is_dynamic_ice(cellMask(cell1)) .and.  li_mask_is_dynamic_ice(cellMask(cell2)) ) &
-              .and. (boundaryCell(cell1) == 1 .or. boundaryCell(cell2) == 1) ) then
-              !.and. (advMaskHighOrder(:,iEdge) == 0.0_RKIND) ) then  ! not sure about this
+              .and. (boundaryCell(cell1) == 1 .or. boundaryCell(cell2) == 1) &
+              .and. all(advMaskHighOrder(:,iEdge) == 0.0_RKIND) ) then  ! not sure about this
              advMask2ndOrder(:,iEdge) = 1.0_RKIND
          else
              advMask2ndOrder(:,iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -51,7 +51,8 @@ module li_tracer_advection_fct_shared
    real (kind=RKIND), public, dimension(:,:), allocatable :: &
       advCoefs,       &! common advection coefficients
       advCoefs3rd,    &! common advection coeffs for high order
-      advMaskHighOrder ! mask for high order advection terms
+      advMaskHighOrder, & ! mask for high order advection terms
+      advMask2ndOrder
 
    !--------------------------------------------------------------------
    ! Public member functions 
@@ -132,6 +133,7 @@ module li_tracer_advection_fct_shared
                 advCoefs        (nAdvCellsMax,nEdges), &
                 advCoefs3rd     (nAdvCellsMax,nEdges), &
                 advMaskHighOrder(nVertLevels ,nEdges), &
+                advMask2ndOrder(nVertLevels ,nEdges), &
                 derivTwo      (nAdvCellsMax,2,nEdges))
       ! Compute derivTwo array
       call computeDerivTwo(derivTwo, err)
@@ -174,6 +176,15 @@ module li_tracer_advection_fct_shared
             advMaskHighOrder(:,iEdge) = 0.0_RKIND
          else
             advMaskHighOrder(:,iEdge) = 1.0_RKIND
+         end if
+
+         ! second order mask must have ice on both sides and one boundary cell
+         if ( (li_mask_is_dynamic_ice(cellMask(cell1)) .and.  li_mask_is_dynamic_ice(cellMask(cell2)) ) &
+              .and. (boundaryCell(cell1) == 1 .or. boundaryCell(cell2) == 1) ) then
+              !.and. (advMaskHighOrder(:,iEdge) == 0.0_RKIND) ) then  ! not sure about this
+             advMask2ndOrder(:,iEdge) = 1.0_RKIND
+         else
+             advMask2ndOrder(:,iEdge) = 0.0_RKIND
          end if
 
          ! do only if this edge flux is needed to update owned cells

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -178,10 +178,8 @@ module li_tracer_advection_fct_shared
             advMaskHighOrder(:,iEdge) = 1.0_RKIND
          end if
 
-         ! second order mask must have ice on both sides and one boundary cell
-         if ( (li_mask_is_dynamic_ice(cellMask(cell1)) .and.  li_mask_is_dynamic_ice(cellMask(cell2)) ) &
-              .and. (boundaryCell(cell1) == 1 .or. boundaryCell(cell2) == 1) &
-              .and. all(advMaskHighOrder(:,iEdge) == 0.0_RKIND) ) then  ! not sure about this
+         ! second order mask must have ice on both sides
+         if ( li_mask_is_dynamic_ice(cellMask(cell1)) .and.  li_mask_is_dynamic_ice(cellMask(cell2)) ) then
              advMask2ndOrder(:,iEdge) = 1.0_RKIND
          else
              advMask2ndOrder(:,iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -104,6 +104,8 @@ module li_tracer_advection_fct_shared
       integer, dimension(:), allocatable :: &
          cellIndx       ! cell indices gathered from neighbors 
 
+      integer, dimension(:), pointer :: cellMask
+
       integer, dimension(:,:), allocatable :: &
          cellIndxSorted ! nbr cell indices sorted
 
@@ -150,8 +152,8 @@ module li_tracer_advection_fct_shared
          cell2 = cellsOnEdge(2,iEdge)
 
          ! at boundaries, must stay at low order
-         if ( li_mask_is_dynamic_margin(cellMask(cell1)) .or. &
-              li_mask_is_dynamic_margin(cellMask(cell2)) ) then
+         if ( (.not. li_mask_is_dynamic_ice(cellMask(cell1))) .or. &
+              (.not. li_mask_is_dynamic_ice(cellMask(cell2))) ) then
             advMaskHighOrder(:,iEdge) = 0.0_RKIND
          else
             advMaskHighOrder(:,iEdge) = 1.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -27,7 +27,7 @@ module li_tracer_advection_fct_shared
    use mpas_geometry_utils
    use mpas_log
 
-!   use ocn_config
+   use li_config
    use li_mesh
 
    implicit none
@@ -77,7 +77,8 @@ module li_tracer_advection_fct_shared
 !-----------------------------------------------------------------------
 
    subroutine li_tracer_advection_fct_shared_init(err)!{{{
-
+      use li_config
+      use li_mesh
       !-----------------------------------------------------------------
       ! Output variables
       !-----------------------------------------------------------------
@@ -99,8 +100,6 @@ module li_tracer_advection_fct_shared
       integer, dimension(:,:), allocatable :: &
          cellIndxSorted ! nbr cell indices sorted
 
-      integer, pointer :: config_horiz_tracer_adv_order
-
       real (kind=RKIND), dimension(:,:,:), allocatable :: &
          derivTwo !< 2nd derivative values for polynomial fit to tracers
 
@@ -116,13 +115,12 @@ module li_tracer_advection_fct_shared
       nAdvCellsMax = maxEdges2
 
       ! Allocate common variables
-      allocate(nAdvCellsForEdge (             nEdges),   &
+      allocate( nAdvCellsForEdge (            nEdges), &
                 advCellsForEdge (nAdvCellsMax,nEdges), &
                 advCoefs        (nAdvCellsMax,nEdges), &
                 advCoefs3rd     (nAdvCellsMax,nEdges), &
                 advMaskHighOrder(nVertLevels ,nEdges), &
                 derivTwo      (nAdvCellsMax,2,nEdges))
-
       ! Compute derivTwo array
       call computeDerivTwo(derivTwo, err)
       if (err /= 0) then
@@ -310,8 +308,9 @@ module li_tracer_advection_fct_shared
 
       ! If 2nd order advection, disable high-order terms by
       ! setting mask to zero.
-      if (config_horiz_tracer_adv_order == 2) &
+      if (config_horiz_tracer_adv_order == 2) then
          advMaskHighOrder(:,:) = 0.0_RKIND
+      endif
 
       ! Copy module variables to device
       !$acc enter data copyin(nAdvCellsForEdge, advCellsForEdge, &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -29,6 +29,7 @@ module li_tracer_advection_fct_shared
 
    use li_config
    use li_mesh
+   use li_mask
 
    implicit none
    private
@@ -76,7 +77,7 @@ module li_tracer_advection_fct_shared
 !
 !-----------------------------------------------------------------------
 
-   subroutine li_tracer_advection_fct_shared_init(err)!{{{
+   subroutine li_tracer_advection_fct_shared_init(geometryPool, err)!{{{
       use li_config
       use li_mesh
       !-----------------------------------------------------------------
@@ -84,6 +85,12 @@ module li_tracer_advection_fct_shared
       !-----------------------------------------------------------------
 
       integer, intent(out) :: err !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! Input variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), intent(in) :: geometryPool
 
       !-----------------------------------------------------------------
       ! Local variables
@@ -108,6 +115,8 @@ module li_tracer_advection_fct_shared
       ! End preamble
       !-------------
       ! Begin code
+
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
       err = 0 ! initialize error code
 
@@ -141,14 +150,12 @@ module li_tracer_advection_fct_shared
          cell2 = cellsOnEdge(2,iEdge)
 
          ! at boundaries, must stay at low order
-         do k = 1, nVertLevels
-            if (boundaryCell(k,cell1) == 1 .or. &
-                boundaryCell(k,cell2) == 1) then
-               advMaskHighOrder(k,iEdge) = 0.0_RKIND
-            else
-               advMaskHighOrder(k,iEdge) = 1.0_RKIND
-            end if
-         end do
+         if ( li_mask_is_dynamic_margin(cellMask(cell1)) .or. &
+              li_mask_is_dynamic_margin(cellMask(cell2)) ) then
+            advMaskHighOrder(:,iEdge) = 0.0_RKIND
+         else
+            advMaskHighOrder(:,iEdge) = 1.0_RKIND
+         end if
 
          ! do only if this edge flux is needed to update owned cells
          if (cell1 <= nCells .and. cell2 <= nCells) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -99,7 +99,8 @@ module li_tracer_advection_fct_shared
       integer :: &
          n, i, k,      &! loop indices for neighbor, vertical loops
          iEdge, iCell, &! loop indices for edge, cell loops
-         cell1, cell2   ! neighbor cell indices across edge
+         cell1, cell2, &   ! neighbor cell indices across edge
+         iNeighbor, jCell
 
       integer, dimension(:), allocatable :: &
          cellIndx       ! cell indices gathered from neighbors 
@@ -145,6 +146,18 @@ module li_tracer_advection_fct_shared
       allocate(cellIndx      (   maxEdges2 + 2), &
                cellIndxSorted(2, maxEdges2 + 2))
 
+      ! calculate boundaryCell. A boundary cell is one that
+      ! has at least one empty or non-dynamic neighbor
+      do iCell = 1, nCells
+         do iNeighbor = 1, nEdgesOnCell(iCell)
+            jCell = cellsOnCell(iNeighbor, iCell)
+            if (.not. li_mask_is_dynamic_ice(jCell)) then
+               boundaryCell(iCell) = 1.0_RKIND
+               exit ! no need to loop over more neigbors
+            endif
+         enddo
+      enddo
+
       ! Compute masks and coefficients
       do iEdge = 1, nEdges
          nAdvCellsForEdge(iEdge) = 0
@@ -152,8 +165,8 @@ module li_tracer_advection_fct_shared
          cell2 = cellsOnEdge(2,iEdge)
 
          ! at boundaries, must stay at low order
-         if ( (.not. li_mask_is_dynamic_ice(cellMask(cell1))) .or. &
-              (.not. li_mask_is_dynamic_ice(cellMask(cell2))) ) then
+         if (boundaryCell(cell1) == 1 .or. &
+             boundaryCell(cell2) == 1) then
             advMaskHighOrder(:,iEdge) = 0.0_RKIND
          else
             advMaskHighOrder(:,iEdge) = 1.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -1,0 +1,729 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.com/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  mpas_ocn_tracer_advection_shared
+!
+!> \brief MPAS ocean tracer advection common coefficients and variables
+!> \author Doug Jacobsen
+!> \date   03/09/12
+!> \details
+!>  This module contains the routines and arrays for some common 
+!>  tracer advection quantities.
+!
+!-----------------------------------------------------------------------
+
+module ocn_tracer_advection_shared
+
+   use mpas_kind_types
+   use mpas_derived_types
+   use mpas_hash
+   use mpas_sort
+   use mpas_geometry_utils
+   use mpas_log
+
+   use ocn_config
+   use ocn_mesh
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   ! Public variables (should only be used by other advection modules)
+   !--------------------------------------------------------------------
+
+   integer, public :: &
+      nAdvCellsMax     ! largest number of advection cells for any edge
+
+   integer, public, dimension(:), allocatable :: &
+      nAdvCellsForEdge ! number of cells contrib to advection at edge
+
+   integer, public, dimension(:,:), allocatable :: &
+      advCellsForEdge ! index of cells contributing to advection at edge
+
+   real (kind=RKIND), public, dimension(:,:), allocatable :: &
+      advCoefs,       &! common advection coefficients
+      advCoefs3rd,    &! common advection coeffs for high order
+      advMaskHighOrder ! mask for high order advection terms
+
+   !--------------------------------------------------------------------
+   ! Public member functions 
+   !-------------------------------------------------------------------- 
+
+   public :: ocn_tracer_advection_shared_init
+
+!***********************************************************************
+
+   contains
+
+!***********************************************************************
+!
+!  routine ocn_tracer_advection_shared_init
+!
+!> \brief MPAS tracer advection coefficients
+!> \author Doug Jacobsen, Bill Skamarock
+!> \date   03/09/12
+!> \details
+!>  This routine precomputes advection coefficients for horizontal
+!>  advection of tracers.
+!
+!-----------------------------------------------------------------------
+
+   subroutine ocn_tracer_advection_shared_init(err)!{{{
+
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] Error flag
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         n, i, k,      &! loop indices for neighbor, vertical loops
+         iEdge, iCell, &! loop indices for edge, cell loops
+         cell1, cell2   ! neighbor cell indices across edge
+
+      integer, dimension(:), allocatable :: &
+         cellIndx       ! cell indices gathered from neighbors 
+
+      integer, dimension(:,:), allocatable :: &
+         cellIndxSorted ! nbr cell indices sorted
+
+      real (kind=RKIND), dimension(:,:,:), allocatable :: &
+         derivTwo !< 2nd derivative values for polynomial fit to tracers
+
+      type (hashtable) :: cell_hash
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      err = 0 ! initialize error code
+
+      ! define max number of advection cells as max number of edges*2
+      nAdvCellsMax = maxEdges2
+
+      ! Allocate common variables
+      allocate(nAdvCellsForEdge (             nEdgesAll),   &
+                advCellsForEdge (nAdvCellsMax,nEdgesAll), &
+                advCoefs        (nAdvCellsMax,nEdgesAll), &
+                advCoefs3rd     (nAdvCellsMax,nEdgesAll), &
+                advMaskHighOrder(nVertLevels ,nEdgesAll), &
+                derivTwo      (nAdvCellsMax,2,nEdgesAll))
+
+      ! Compute derivTwo array
+      call computeDerivTwo(derivTwo, err)
+      if (err /= 0) then
+         call mpas_log_write( &
+            'Error computing derivTwo in ocn advect shared init ', &
+             MPAS_LOG_CRIT)
+         deallocate (derivTwo)
+         return
+      endif
+
+      allocate(cellIndx      (   maxEdges2 + 2), &
+               cellIndxSorted(2, maxEdges2 + 2))
+
+      ! Compute masks and coefficients
+      do iEdge = 1, nEdgesAll
+         nAdvCellsForEdge(iEdge) = 0
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+
+         ! at boundaries, must stay at low order
+         do k = 1, nVertLevels
+            if (boundaryCell(k,cell1) == 1 .or. &
+                boundaryCell(k,cell2) == 1) then
+               advMaskHighOrder(k,iEdge) = 0.0_RKIND
+            else
+               advMaskHighOrder(k,iEdge) = 1.0_RKIND
+            end if
+         end do
+
+         ! do only if this edge flux is needed to update owned cells
+         if (cell1 <= nCellsAll .and. cell2 <= nCellsAll) then
+            ! Insert cellsOnEdge to list of advection cells
+            call mpas_hash_init(cell_hash)
+            call mpas_hash_insert(cell_hash, cell1)
+            call mpas_hash_insert(cell_hash, cell2)
+            cellIndx(1) = cell1
+            cellIndx(2) = cell2
+            cellIndxSorted(1,1) = indexToCellID(cell1)
+            cellIndxSorted(2,1) = cell1
+            cellIndxSorted(1,2) = indexToCellID(cell2)
+            cellIndxSorted(2,2) = cell2
+            n = 2
+
+            ! Build unique list of cells used for advection on edge
+            ! by expanding to the extended neighbor cells
+            do i = 1, nEdgesOnCell(cell1)
+               if (.not. mpas_hash_search(cell_hash, &
+                                          cellsOnCell(i,cell1))) then
+                  n = n + 1
+                  cellIndx(n) = cellsOnCell(i, cell1)
+                  cellIndxSorted(1,n) = indexToCellID(cellsOnCell(i,cell1))
+                  cellIndxSorted(2,n) = cellsOnCell(i,cell1)
+                  call mpas_hash_insert(cell_hash,cellsOnCell(i,cell1))
+               end if
+            end do
+
+            do i = 1, nEdgesOnCell(cell2)
+               if(.not. mpas_hash_search(cell_hash, &
+                                         cellsOnCell(i, cell2))) then
+                  n = n + 1
+                  cellIndx(n) = cellsOnCell(i, cell2)
+                  cellIndxSorted(1,n) = indexToCellID(cellsOnCell(i,cell2))
+                  cellIndxSorted(2,n) = cellsOnCell(i,cell2)
+                  call mpas_hash_insert(cell_hash, cellsOnCell(i,cell2))
+               end if
+            end do
+
+            call mpas_hash_destroy(cell_hash)
+
+            ! sort the cell indices by cellID
+            call mpas_quicksort(n, cellIndxSorted)
+
+            ! store local cell indices for high-order calculations
+            nAdvCellsForEdge(iEdge) = n
+            do iCell = 1, nAdvCellsForEdge(iEdge)
+               advCellsForEdge(iCell,iEdge) = cellIndxSorted(2,iCell)
+            end do
+
+            ! equation 7 in Skamarock, W. C., & Gassmann, A. (2011):
+            ! F(u,psi)_{i+1/2} = u_{i+1/2} *
+            !  [   1/2 (psi_{i+1} + psi_i)                       term 1
+            !    - 1/12(dx^2psi_{i+1} + dx^2psi_i)               term 2
+            !    + sign(u) beta/12 (dx^2psi_{i+1} - dx^2psi_i)]  term 3
+            !                                         (note minus sign)
+            !
+            ! advCoefs accounts for terms 1 and 2 in SG11 equation 7.
+            ! Term 1 is the 2nd-order flux-function term. advCoefs
+            ! accounts for this with the "+ 0.5" lines below. In the
+            ! advection routines that use these coefficients, the
+            ! 2nd-order flux loop is then skipped. Term 2 is the
+            ! 4th-order flux-function term. advCoefs accounts for
+            ! term 3, the beta term. beta > 0 corresponds to the
+            ! third-order flux function. The - sign in the derivTwo
+            ! accumulation is for the i+1 part of term 3, while
+            ! the + sign is for the i part.
+
+            do i=1,nAdvCellsMax
+               advCoefs   (i,iEdge) = 0.0_RKIND
+               advCoefs3rd(i,iEdge) = 0.0_RKIND
+            end do
+
+            ! pull together third and fourth order contributions to the
+            ! flux first from cell1
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                    nAdvCellsForEdge(iEdge), indexToCellID(cell1))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                    +  derivTwo(1,1,iEdge)
+               advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                    +  derivTwo(1,1,iEdge)
+            end if
+
+            do iCell = 1, nEdgesOnCell(cell1)
+               i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                              nAdvCellsForEdge(iEdge), &
+                              indexToCellID(cellsOnCell(iCell,cell1)))
+               if (i <= nAdvCellsForEdge(iEdge)) then
+                  advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                       + derivTwo(iCell+1,1,iEdge)
+                  advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                       + derivTwo(iCell+1,1,iEdge)
+               end if
+            end do
+
+            ! pull together third and fourth order contributions to the
+            ! flux now from cell2
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                       nAdvCellsForEdge(iEdge), indexToCellID(cell2))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                    +  derivTwo(1,2,iEdge)
+               advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                    -  derivTwo(1,2,iEdge)
+            end if
+
+            do iCell = 1, nEdgesOnCell(cell2)
+               i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                           nAdvCellsForEdge(iEdge), &
+                           indexToCellID(cellsOnCell(iCell,cell2)))
+               if (i <= nAdvCellsForEdge(iEdge)) then
+                  advCoefs   (i,iEdge) = advCoefs   (i,iEdge) &
+                                       + derivTwo(iCell+1,2,iEdge)
+                  advCoefs3rd(i,iEdge) = advCoefs3rd(i,iEdge) &
+                                       - derivTwo(iCell+1,2,iEdge)
+               end if
+            end do
+
+            do iCell = 1,nAdvCellsForEdge(iEdge)
+               advCoefs   (iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                     advCoefs(iCell,iEdge) / 12.
+               advCoefs3rd(iCell,iEdge) = - (dcEdge(iEdge)**2)* &
+                                  advCoefs3rd(iCell,iEdge) / 12.
+            end do
+
+            ! 2nd order centered contribution
+            ! place this in the main flux weights
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                                   nAdvCellsForEdge(iEdge), &
+                                   indexToCellID(cell1))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs(i,iEdge) = advCoefs(i, iEdge) + 0.5
+            end if
+
+            i = mpas_binary_search(cellIndxSorted, 2, 1, &
+                                   nAdvCellsForEdge(iEdge), &
+                                   indexToCellID(cell2))
+            if (i <= nAdvCellsForEdge(iEdge)) then
+               advCoefs(i,iEdge) = advCoefs(i, iEdge) + 0.5
+            end if
+
+            ! multiply by edge length - thus the flux is just dt*ru
+            ! times the results of the vector-vector multiply
+            do iCell=1,nAdvCellsForEdge(iEdge)
+               advCoefs   (iCell,iEdge) = dvEdge(iEdge)* &
+                                          advCoefs   (iCell,iEdge)
+               advCoefs3rd(iCell,iEdge) = dvEdge(iEdge)* &
+                                          advCoefs3rd(iCell,iEdge)
+            end do
+         end if  ! only do for edges of owned-cells
+      end do ! end loop over edges
+
+      deallocate(cellIndx, &
+                 cellIndxSorted, &
+                 derivTwo)
+
+      ! If 2nd order advection, disable high-order terms by
+      ! setting mask to zero.
+      if (config_horiz_tracer_adv_order == 2) &
+         advMaskHighOrder(:,:) = 0.0_RKIND
+
+      ! Copy module variables to device
+      !$acc enter data copyin(nAdvCellsForEdge, advCellsForEdge, &
+      !$acc                   advCoefs, advCoefs3rd, advMaskHighOrder)
+
+   !--------------------------------------------------------------------
+
+   end subroutine ocn_tracer_advection_shared_init !}}}
+
+!***********************************************************************
+!
+!  routine computeDerivTwo
+!
+!> \brief MPAS deriv two computation
+!> \author Doug Jacobsen, Bill Skamarock
+!> \date   03/09/12
+!> \details
+!>  This routine precomputes the second derivative values for tracer
+!>  advection. It computes cell coefficients for the polynomial fit
+!>  as described in:
+!>  Skamarock, W. C., & Gassmann, A. (2011). 
+!>    Conservative Transport Schemes for Spherical Geodesic Meshs:
+!>    High-Order Flux Operators for ODE-Based Time Integration. 
+!>    Monthly Weather Review, 139(9), 2962-2975.
+!>    doi:10.1175/MWR-D-10-05056.1
+!>  This is performed during model initialization.
+!
+!-----------------------------------------------------------------------
+
+   subroutine computeDerivTwo(derivTwo, err)!{{{
+                                      
+      !-----------------------------------------------------------------
+      ! Output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:,:), intent(out) :: &
+         derivTwo !< [out] 2nd deriv values of polynomial for tracer fit
+
+      integer, intent(out) :: err !< [out] returned error flag
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      logical :: &
+         addCell,      &! flag for adding cell add to list 
+         doCell         ! flag for whether to process cell
+
+      integer, parameter :: &
+         polynomial_order = 2  ! option for polynomial order, forced to 2
+
+      integer :: &
+         i, j, n,   &! loop counters
+         ip1, ip2,     &! temps for i+1, i+2
+         iCell, iEdge, &! loop indices for cell, edge loops
+         ma, na, cell_add, mw
+
+      real (kind=RKIND) :: &
+         xec, yec, zec,    &! arc bisection coords
+         thetae_tmp,       &! angle
+         xv1, xv2, yv1, yv2, zv1, zv2, &! vertex cart coords
+         pii,              &! pi math constant
+         length_scale,     &! length scale
+         cos2t, costsint, sin2t  ! trig function temps
+
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         thetae          ! sphere angle between vectors 
+
+      real (kind=RKIND), dimension(:), allocatable :: &
+         theta_abs,     &! sphere angle
+         angle_2d        ! 2d angle
+
+      integer, dimension(25) :: cell_list
+
+      real (kind=RKIND), dimension(25) :: &
+         xc, yc, zc,    &! cell center coordinates
+         xp, yp,        &!
+         thetav, thetat, dl_sphere
+
+      real (kind=RKIND) :: &
+         amatrix(25,25), bmatrix(25,25), wmatrix(25,25)
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! set return code and check proper poly order
+      err = 0
+
+      if (polynomial_order > 2) then
+        call mpas_log_write( &
+           'Polynomial for second derivitave can only be 2',  &
+           MPAS_LOG_ERR)
+        err = 1
+        return
+      end if
+
+      ! allocate local arrays
+      allocate(thetae(2, nEdgesAll))
+      allocate(theta_abs(nCellsAll))
+      allocate(angle_2d(maxEdges))
+
+      ! Initialize derivTwo and pi
+
+      pii = 2.*asin(1.0)
+      derivTwo(:,:,:) = 0.0_RKIND
+
+      do iCell = 1, nCellsAll
+
+         cell_list(1) = iCell
+         do i=2, nEdgesOnCell(iCell)+1
+            cell_list(i) = cellsOnCell(i-1,iCell)
+         end do
+         n = nEdgesOnCell(iCell) + 1
+
+         !if ( polynomial_order > 2 ) then
+         !   do i=2, nEdgesOnCell(iCell) + 1
+         !      do j=1, nEdgesOnCell( cell_list(i) )
+         !         cell_add = cellsOnCell(j,cell_list(i))
+         !         addCell = .true.
+         !         do k=1,n
+         !            if ( cell_add == cell_list(k) ) addCell = .false.
+         !         end do
+         !         if (addCell) then
+         !            n = n+1
+         !            cell_list(n) = cell_add
+         !         end if
+         !      end do
+         !   end do
+         !end if
+ 
+         ! check to see if we are reaching outside the halo
+
+         doCell = .true.
+         do i=1,n
+            if (cell_list(i) > nCellsAll) doCell = .false.
+         end do
+
+         if ( .not. doCell ) cycle
+
+         ! compute poynomial fit for this cell if all needed
+         ! neighbors exist
+         if ( onSphere ) then
+
+            do i=1,n
+               j = cell_list(i)
+               xc(i) = xCell(j) / sphereRadius
+               yc(i) = yCell(j) / sphereRadius
+               zc(i) = zCell(j) / sphereRadius
+            end do
+
+            if ( zc(1) == 1.0_RKIND) then
+               theta_abs(iCell) = pii/2.0_RKIND
+            else
+               theta_abs(iCell) = pii/2.0_RKIND &
+                        - mpas_sphere_angle( xc(1), yc(1), zc(1), &
+                                             xc(2), yc(2), zc(2), &
+                                   0.0_RKIND, 0.0_RKIND, 1.0_RKIND) 
+            end if
+
+            ! angles from cell center to neighbor centers (thetav)
+
+            do i=1,n-1
+   
+               ip2 = i+2
+               if (ip2 > n) ip2 = 2
+    
+               thetav(i) = mpas_sphere_angle(xc(  1), yc(  1), zc(  1),&
+                                             xc(i+1), yc(i+1), zc(i+1),&
+                                             xc(ip2), yc(ip2), zc(ip2))
+
+               dl_sphere(i) = sphereRadius* &
+                              mpas_arc_length(xc(  1),yc(  1),zc(  1), &
+                                              xc(i+1),yc(i+1),zc(i+1))
+            end do
+
+            length_scale = 1.0_RKIND
+            do i=1,n-1
+               dl_sphere(i) = dl_sphere(i)/length_scale
+            end do
+
+            ! thetat(1) = 0.  !  this defines the x direction, cell center 1 -> 
+            ! this defines the x direction, longitude line
+            thetat(1) = theta_abs(iCell)
+            do i=2,n-1
+               thetat(i) = thetat(i-1) + thetav(i-1)
+            end do
+   
+            do i=1,n-1
+               xp(i) = cos(thetat(i)) * dl_sphere(i)
+               yp(i) = sin(thetat(i)) * dl_sphere(i)
+            end do
+
+         else     ! On an x-y plane
+
+            do i=1,n-1
+
+               angle_2d(i) = angleEdge(edgesOnCell(i,iCell))
+               iEdge = edgesOnCell(i,iCell)
+               if ( iCell .ne. cellsOnEdge(1,iEdge)) &
+                  angle_2d(i) = angle_2d(i) - pii
+
+               xp(i) = dcEdge(edgesOnCell(i,iCell)) * cos(angle_2d(i))
+               yp(i) = dcEdge(edgesOnCell(i,iCell)) * sin(angle_2d(i))
+
+            end do
+
+         end if
+
+         ma = n-1
+         mw = nEdgesOnCell(iCell)
+
+         bmatrix = 0.
+         amatrix = 0.
+         wmatrix = 0.
+
+         if (polynomial_order == 2) then
+            na = 6
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               wmatrix(i,i) = 1.
+            end do
+ 
+         else if (polynomial_order == 3) then
+            na = 10
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+   
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               amatrix(i,7) = xp(i-1)**3
+               amatrix(i,8) = yp(i-1) * (xp(i-1)**2)
+               amatrix(i,9) = xp(i-1) * (yp(i-1)**2)
+               amatrix(i,10) = yp(i-1)**3
+   
+               wmatrix(i,i) = 1.
+ 
+            end do
+
+         else
+            na = 15
+            ma = ma+1
+  
+            amatrix(1,1) = 1.
+            wmatrix(1,1) = 1.
+            do i=2,ma
+               amatrix(i,1) = 1.
+               amatrix(i,2) = xp(i-1)
+               amatrix(i,3) = yp(i-1)
+   
+               amatrix(i,4) = xp(i-1)**2
+               amatrix(i,5) = xp(i-1) * yp(i-1)
+               amatrix(i,6) = yp(i-1)**2
+   
+               amatrix(i,7) = xp(i-1)**3
+               amatrix(i,8) = yp(i-1) * (xp(i-1)**2)
+               amatrix(i,9) = xp(i-1) * (yp(i-1)**2)
+               amatrix(i,10) = yp(i-1)**3
+   
+               amatrix(i,11) = xp(i-1)**4
+               amatrix(i,12) = yp(i-1) * (xp(i-1)**3)
+               amatrix(i,13) = (xp(i-1)**2)*(yp(i-1)**2)
+               amatrix(i,14) = xp(i-1) * (yp(i-1)**3)
+               amatrix(i,15) = yp(i-1)**4
+   
+               wmatrix(i,i) = 1.
+  
+            end do
+ 
+            do i=1,mw
+               wmatrix(i,i) = 1.
+            end do
+ 
+         end if
+ 
+         call mpas_poly_fit_2( amatrix, bmatrix, wmatrix, ma, na, 25 )
+
+         do i=1, nEdgesOnCell(iCell)
+            ip1 = i+1
+            if (ip1 > n-1) ip1 = 1
+  
+            iEdge = edgesOnCell(i,iCell)
+
+            if ( onSphere ) then
+              xv1 = xVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              yv1 = yVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              zv1 = zVertex(verticesOnEdge(1,iedge)) / sphereRadius
+              xv2 = xVertex(verticesOnEdge(2,iedge)) / sphereRadius
+              yv2 = yVertex(verticesOnEdge(2,iedge)) / sphereRadius
+              zv2 = zVertex(verticesOnEdge(2,iedge)) / sphereRadius
+            else
+              xv1 = xVertex(verticesOnEdge(1,iedge))
+              yv1 = yVertex(verticesOnEdge(1,iedge))
+              zv1 = zVertex(verticesOnEdge(1,iedge))
+              xv2 = xVertex(verticesOnEdge(2,iedge))
+              yv2 = yVertex(verticesOnEdge(2,iedge))
+              zv2 = zVertex(verticesOnEdge(2,iedge))
+            end if
+  
+            if ( onSphere ) then
+               call mpas_arc_bisect( xv1, yv1, zv1,  &
+                                     xv2, yv2, zv2,  &
+                                     xec, yec, zec   )
+  
+               thetae_tmp = mpas_sphere_angle( &
+                                          xc(  1), yc(  1), zc(  1), &
+                                          xc(i+1), yc(i+1), zc(i+1), &
+                                          xec,     yec,     zec      )
+               thetae_tmp = thetae_tmp + thetat(i)
+               if (iCell == cellsOnEdge(1,iEdge)) then
+                  thetae(1, edgesOnCell(i,iCell)) = thetae_tmp
+               else
+                  thetae(2, edgesOnCell(i,iCell)) = thetae_tmp
+               end if
+            end if
+  
+         end do
+
+         ! fill second derivative stencil for rk advection 
+
+         do i=1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i,iCell)
+  
+            if ( onSphere ) then
+               if (iCell == cellsOnEdge(1,iEdge)) then
+  
+                  cos2t = cos(thetae(1, edgesOnCell(i,iCell)))
+                  sin2t = sin(thetae(1, edgesOnCell(i,iCell)))
+                  costsint = cos2t*sin2t
+                  cos2t = cos2t**2
+                  sin2t = sin2t**2
+   
+                  do j=1,n
+                     derivTwo(j,1,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
+                  end do
+
+               else
+     
+                  cos2t = cos(thetae(2, edgesOnCell(i,iCell)))
+                  sin2t = sin(thetae(2, edgesOnCell(i,iCell)))
+                  costsint = cos2t*sin2t
+                  cos2t = cos2t**2
+                  sin2t = sin2t**2
+      
+                  do j=1,n
+                     derivTwo(j,2,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
+                  end do
+               end if
+
+            else
+
+               cos2t = cos(angle_2d(i))
+               sin2t = sin(angle_2d(i))
+               costsint = cos2t*sin2t
+               cos2t = cos2t**2
+               sin2t = sin2t**2
+
+!               do j=1,n
+!
+!                  derivTwo(j,1,iEdge) =   2.*xe(iEdge)*xe(iEdge)*bmatrix(4,j)  &
+!                                         + 2.*xe(iEdge)*ye(iEdge)*bmatrix(5,j)  &
+!                                         + 2.*ye(iEdge)*ye(iEdge)*bmatrix(6,j)
+!               end do
+
+               if (iCell == cellsOnEdge(1,iEdge)) then
+                  do j=1,n
+                     derivTwo(j,1,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
+                  end do
+               else
+                  do j=1,n
+                     derivTwo(j,2,iEdge) = 2.*cos2t   *bmatrix(4,j) &
+                                         + 2.*costsint*bmatrix(5,j) &
+                                         + 2.*sin2t   *bmatrix(6,j)
+                  end do
+               end if
+
+            end if
+         end do
+ 
+      end do ! end of loop over cells
+
+      deallocate(thetae)
+      deallocate(theta_abs)
+      deallocate(angle_2d)
+
+   !--------------------------------------------------------------------
+
+   end subroutine computeDerivTwo !}}}
+
+!***********************************************************************
+
+end module ocn_tracer_advection_shared
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -28,7 +28,7 @@ module li_tracer_advection_fct_shared
    use mpas_log
 
 !   use ocn_config
-!   use ocn_mesh
+   use li_mesh
 
    implicit none
    private
@@ -99,6 +99,8 @@ module li_tracer_advection_fct_shared
       integer, dimension(:,:), allocatable :: &
          cellIndxSorted ! nbr cell indices sorted
 
+      integer, pointer :: config_horiz_tracer_adv_order
+
       real (kind=RKIND), dimension(:,:,:), allocatable :: &
          derivTwo !< 2nd derivative values for polynomial fit to tracers
 
@@ -114,12 +116,12 @@ module li_tracer_advection_fct_shared
       nAdvCellsMax = maxEdges2
 
       ! Allocate common variables
-      allocate(nAdvCellsForEdge (             nEdgesAll),   &
-                advCellsForEdge (nAdvCellsMax,nEdgesAll), &
-                advCoefs        (nAdvCellsMax,nEdgesAll), &
-                advCoefs3rd     (nAdvCellsMax,nEdgesAll), &
-                advMaskHighOrder(nVertLevels ,nEdgesAll), &
-                derivTwo      (nAdvCellsMax,2,nEdgesAll))
+      allocate(nAdvCellsForEdge (             nEdges),   &
+                advCellsForEdge (nAdvCellsMax,nEdges), &
+                advCoefs        (nAdvCellsMax,nEdges), &
+                advCoefs3rd     (nAdvCellsMax,nEdges), &
+                advMaskHighOrder(nVertLevels ,nEdges), &
+                derivTwo      (nAdvCellsMax,2,nEdges))
 
       ! Compute derivTwo array
       call computeDerivTwo(derivTwo, err)
@@ -135,7 +137,7 @@ module li_tracer_advection_fct_shared
                cellIndxSorted(2, maxEdges2 + 2))
 
       ! Compute masks and coefficients
-      do iEdge = 1, nEdgesAll
+      do iEdge = 1, nEdges
          nAdvCellsForEdge(iEdge) = 0
          cell1 = cellsOnEdge(1,iEdge)
          cell2 = cellsOnEdge(2,iEdge)
@@ -151,7 +153,7 @@ module li_tracer_advection_fct_shared
          end do
 
          ! do only if this edge flux is needed to update owned cells
-         if (cell1 <= nCellsAll .and. cell2 <= nCellsAll) then
+         if (cell1 <= nCells .and. cell2 <= nCells) then
             ! Insert cellsOnEdge to list of advection cells
             call mpas_hash_init(cell_hash)
             call mpas_hash_insert(cell_hash, cell1)
@@ -339,7 +341,7 @@ module li_tracer_advection_fct_shared
 !
 !-----------------------------------------------------------------------
 
-   subroutine computeDerivTwo(domain, derivTwo, err)!{{{
+   subroutine computeDerivTwo(derivTwo, err)!{{{
                                       
       !-----------------------------------------------------------------
       ! Output variables
@@ -410,8 +412,8 @@ module li_tracer_advection_fct_shared
       end if
 
       ! allocate local arrays
-      allocate(thetae(2, nEdgesAll))
-      allocate(theta_abs(nCellsAll))
+      allocate(thetae(2, nEdges))
+      allocate(theta_abs(nCells))
       allocate(angle_2d(maxEdges))
 
       ! Initialize derivTwo and pi
@@ -419,7 +421,7 @@ module li_tracer_advection_fct_shared
       pii = 2.*asin(1.0)
       derivTwo(:,:,:) = 0.0_RKIND
 
-      do iCell = 1, nCellsAll
+      do iCell = 1, nCells
 
          cell_list(1) = iCell
          do i=2, nEdgesOnCell(iCell)+1
@@ -447,7 +449,7 @@ module li_tracer_advection_fct_shared
 
          doCell = .true.
          do i=1,n
-            if (cell_list(i) > nCellsAll) doCell = .false.
+            if (cell_list(i) > nCells) doCell = .false.
          end do
 
          if ( .not. doCell ) cycle

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -7,7 +7,7 @@
 !
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  mpas_ocn_tracer_advection_shared
+!  mpas_tracer_advection_shared
 !
 !> \brief MPAS ocean tracer advection common coefficients and variables
 !> \author Doug Jacobsen
@@ -18,7 +18,7 @@
 !
 !-----------------------------------------------------------------------
 
-module ocn_tracer_advection_shared
+module li_tracer_advection_fct_shared
 
    use mpas_kind_types
    use mpas_derived_types
@@ -27,8 +27,8 @@ module ocn_tracer_advection_shared
    use mpas_geometry_utils
    use mpas_log
 
-   use ocn_config
-   use ocn_mesh
+!   use ocn_config
+!   use ocn_mesh
 
    implicit none
    private
@@ -56,7 +56,7 @@ module ocn_tracer_advection_shared
    ! Public member functions 
    !-------------------------------------------------------------------- 
 
-   public :: ocn_tracer_advection_shared_init
+   public :: li_tracer_advection_fct_shared_init
 
 !***********************************************************************
 
@@ -64,18 +64,19 @@ module ocn_tracer_advection_shared
 
 !***********************************************************************
 !
-!  routine ocn_tracer_advection_shared_init
+!  routine li_tracer_advection_fct_shared_init
 !
 !> \brief MPAS tracer advection coefficients
-!> \author Doug Jacobsen, Bill Skamarock
-!> \date   03/09/12
+!> \author Doug Jacobsen, Bill Skamarock,
+!>         adapted for MALI by Trevor Hillebrand and Matt Hoffman
+!> \date   03/09/12, adapted for MALI 03/2023
 !> \details
 !>  This routine precomputes advection coefficients for horizontal
 !>  advection of tracers.
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_tracer_advection_shared_init(err)!{{{
+   subroutine li_tracer_advection_fct_shared_init(err)!{{{
 
       !-----------------------------------------------------------------
       ! Output variables
@@ -316,7 +317,7 @@ module ocn_tracer_advection_shared
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_tracer_advection_shared_init !}}}
+   end subroutine li_tracer_advection_fct_shared_init !}}}
 
 !***********************************************************************
 !
@@ -338,7 +339,7 @@ module ocn_tracer_advection_shared
 !
 !-----------------------------------------------------------------------
 
-   subroutine computeDerivTwo(derivTwo, err)!{{{
+   subroutine computeDerivTwo(domain, derivTwo, err)!{{{
                                       
       !-----------------------------------------------------------------
       ! Output variables
@@ -390,6 +391,8 @@ module ocn_tracer_advection_shared
 
       real (kind=RKIND) :: &
          amatrix(25,25), bmatrix(25,25), wmatrix(25,25)
+
+      logical, parameter :: onSphere=.false.
 
       ! End preamble
       !-------------
@@ -724,6 +727,6 @@ module ocn_tracer_advection_shared
 
 !***********************************************************************
 
-end module ocn_tracer_advection_shared
+end module li_tracer_advection_fct_shared
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct_shared.F
@@ -148,15 +148,19 @@ module li_tracer_advection_fct_shared
 
       ! calculate boundaryCell. A boundary cell is one that
       ! has at least one empty or non-dynamic neighbor
+      boundaryCell(:) = 0
       do iCell = 1, nCells
          do iNeighbor = 1, nEdgesOnCell(iCell)
             jCell = cellsOnCell(iNeighbor, iCell)
-            if (.not. li_mask_is_dynamic_ice(jCell)) then
-               boundaryCell(iCell) = 1.0_RKIND
+            if (.not. li_mask_is_dynamic_ice(cellMask(jCell))) then
+               boundaryCell(iCell) = 1
                exit ! no need to loop over more neigbors
             endif
          enddo
       enddo
+
+      call mpas_log_write('Marked $i boundary cells out of $i cells belonging to this processor', &
+                 intArgs=(/sum(boundaryCell(1:nCellsSolve)), nCellsSolve/))
 
       ! Compute masks and coefficients
       do iEdge = 1, nEdges

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -15,6 +15,7 @@ module li_core
    use li_velocity
    use li_setup
    use li_mask
+   use li_mesh
 
    implicit none
    private
@@ -207,6 +208,11 @@ module li_core
       call mpas_log_write("Finished processing recurring input streams at initial time.")
 
       ! ===
+      ! Initialize land ice mesh public paramters
+      call li_meshCreate(domain)
+      ! ===
+
+      ! ===
       ! Initialize some time stuff on each block
       ! ===
       ! Set startTimeStamp based on the start time of the simulation clock
@@ -253,6 +259,11 @@ module li_core
 
          block => block % next
       end do
+
+      ! ===
+      ! This is where li_updateMeshFIelds would be called if we wanted to be consistent with mpas-ocean.
+      ! We don't currently think this needs to be called, so leaving it out for now.
+      ! ===
 
       ! ===
       ! === Initialize modules ===
@@ -309,8 +320,6 @@ module li_core
       ! which occurs in landice_init_block and 2. have li_velocity_init.
       ! ===
       call li_velocity_external_write_albany_mesh(domain)
-
-      ! check for errors and exit
 
       call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
       if (globalErr > 0) then
@@ -647,6 +656,9 @@ module li_core
 
       call mpas_decomp_destroy_decomp_list(domain % decompositions)
 
+      err = ior(err, err_tmp)
+
+      call li_meshDestroy(err_tmp)
       err = ior(err, err_tmp)
 
       ! === error check and exit

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -123,7 +123,7 @@ module li_core
       err_tmp = 0
       globalErr = 0
 
-      call li_config_init((domain % configs)
+      call li_config_init(domain % configs)
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
 
       !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -16,6 +16,7 @@ module li_core
    use li_setup
    use li_mask
    use li_mesh
+   use li_config
 
    implicit none
    private
@@ -122,6 +123,7 @@ module li_core
       err_tmp = 0
       globalErr = 0
 
+      call li_config_init((domain % configs)
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
 
       !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -699,7 +699,7 @@ module li_time_integration_fe
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
          if ( (trim(config_thickness_advection) == 'fo' .and. trim(config_tracer_advection) == 'fo') .or. &
-              (trim(config_thickness_advection) == 'fct' .and. trim(config_tracer_advection) == 'fct') .or. &
+              (trim(config_thickness_advection) == 'fct') .or. &
               (trim(config_thickness_advection) == 'fo' .and. trim(config_tracer_advection) == 'fct') ) then
 
             ! Note: This subroutine requires that thickness and tracers are correct in halos

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -791,7 +791,7 @@ module li_time_integration_fe
       call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
       call mpas_dmpar_field_halo_exch(domain, 'enthalpy')
       call mpas_dmpar_field_halo_exch(domain, 'damage')
-      call mpas_dmpar_field_halo_exch(domain, 'passiveTracer')
+      call mpas_dmpar_field_halo_exch(domain, 'passiveTracer2d')
 
       call mpas_timer_stop("halo updates")
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -755,7 +755,6 @@ module li_time_integration_fe
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness, timeLevel=1)
 
-
          allocate( masktmp(nCells + 1) )
          masktmp = 0
 
@@ -792,6 +791,7 @@ module li_time_integration_fe
       call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
       call mpas_dmpar_field_halo_exch(domain, 'enthalpy')
       call mpas_dmpar_field_halo_exch(domain, 'damage')
+      call mpas_dmpar_field_halo_exch(domain, 'passiveTracer')
 
       call mpas_timer_stop("halo updates")
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -697,7 +697,9 @@ module li_time_integration_fe
          call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
 
-         if (trim(config_thickness_advection) == 'fo' .and. trim(config_tracer_advection) == 'fo') then
+         if ( (trim(config_thickness_advection) == 'fo' .and. trim(config_tracer_advection) == 'fo') .or. &
+              (trim(config_thickness_advection) == 'fct' .and. trim(config_tracer_advection) == 'fct') .or. &
+              (trim(config_thickness_advection) == 'fo' .and. trim(config_tracer_advection) == 'fct') ) then
 
             ! Note: This subroutine requires that thickness and tracers are correct in halos
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -661,7 +661,8 @@ module li_time_integration_fe
       ! ===
       ! === Calculate layerThicknessEdge, which is needed for advection
       ! ===
-      if (trim(config_thickness_advection) == 'fo' .or. trim(config_tracer_advection) == 'fo') then
+      if (trim(config_thickness_advection) == 'fo' .or. trim(config_tracer_advection) == 'fo' .or. &
+          trim(config_thickness_advection) == 'fct' .or. trim(config_tracer_advection) == 'fct') then
          block => domain % blocklist
          do while (associated(block))
 

--- a/components/mpas-albany-landice/src/shared/Makefile
+++ b/components/mpas-albany-landice/src/shared/Makefile
@@ -4,6 +4,7 @@
 OBJS =  mpas_li_constants.o \
         mpas_li_mask.o \
         mpas_li_mesh.o \
+        mpas_li_config.o \
         mpas_li_setup.o
 
 all: $(OBJS)
@@ -16,6 +17,7 @@ mpas_li_mask.o: mpas_li_setup.o
 
 mpas_li_mesh.o:
 
+mpas_li_config.o:
 
 clean:
 	$(RM) *.o *.mod *.f90

--- a/components/mpas-albany-landice/src/shared/Makefile
+++ b/components/mpas-albany-landice/src/shared/Makefile
@@ -3,6 +3,7 @@
 
 OBJS =  mpas_li_constants.o \
         mpas_li_mask.o \
+        mpas_li_mesh.o \
         mpas_li_setup.o
 
 all: $(OBJS)
@@ -13,6 +14,7 @@ mpas_li_setup.o:
 
 mpas_li_mask.o: mpas_li_setup.o
 
+mpas_li_mesh.o:
 
 
 clean:

--- a/components/mpas-albany-landice/src/shared/mpas_li_config.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_config.F
@@ -1,0 +1,55 @@
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  li_config
+!
+!> \brief MALI specific config
+!> \details
+!>  This module contains config specific to MALI.
+!
+!-----------------------------------------------------------------------
+
+module li_config
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_kind_types
+
+   implicit none
+   public
+   save
+
+#include "../inc/config_declare.inc"
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  routine li_config_init
+!
+!> \brief   Initializes the MALI config
+!> \details
+!>  This routine sets up config for use in MALI.
+!
+!-----------------------------------------------------------------------
+   subroutine li_config_init(configPool)!{{{
+       type (mpas_pool_type), pointer :: configPool
+
+#include "../inc/config_get.inc"
+
+   end subroutine li_config_init!}}}
+
+!***********************************************************************
+
+end module li_config
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -72,6 +72,9 @@ module li_mesh
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
       nEdgesOnCell, & ! number of edges associated with each cell center
+      cellMask, &
+      edgeMask, &
+      vertexMask, &
 !      minLevelCell, &! max ocean level at bottom of cell
 !      minLevelEdgeTop, &! max ocean level at top    of edge column
 !      minLevelEdgeBot, &! max ocean level at bottom of edge column
@@ -94,8 +97,10 @@ module li_mesh
       edgesOnCell, &! index of edges connected to each cell
       verticesOnCell, &! index of vertices connected to each cell
       cellsOnVertex, &! index of cells connected to each vertex
-      edgesOnVertex, &! index of edges connected to each vertex
-      kiteIndexOnCell ! index of kite associated with each cell
+      edgesOnVertex, & ! index of edges connected to each vertex
+      edgeSignOnCell, &! sign of edge contributions to a cell
+      edgeSignOnVertex ! sign of edge contributions to a vertex
+!      kiteIndexOnCell ! index of kite associated with each cell
 
    real(kind=RKIND), public, dimension(:), pointer :: &
       latCell, &! latitude  of cell centers
@@ -134,15 +139,10 @@ module li_mesh
       invAreaCell   ! inverse of area of each cell
 
    ! Multiplicative masks and vectors for various conditions
-   real(kind=RKIND), public, dimension(:, :), allocatable :: &
-      edgeMask, &! mask to denote active edges    with depth
-      cellMask, &! mask to denote active cells    with depth
-      vertexMask, &! mask to denote active vertices with depth
+   integer, public, dimension(:, :), allocatable :: &
       boundaryEdge, &! mask for boundary edges    at each level
       boundaryCell, &! mask for boundary cells    at each level
-      boundaryVertex, &! mask for boundary vertices at each level
-      edgeSignOnCell, &! sign of edge contributions to a cell
-      edgeSignOnVertex ! sign of edge contributions to a vertex
+      boundaryVertex ! mask for boundary vertices at each level
 
    real(kind=RKIND), public, dimension(:, :), pointer :: &
       weightsOnEdge, &! weights on each edge
@@ -239,14 +239,8 @@ contains
       ! temporary pointers for converting masks
       integer i, k, n          ! loop indices
       integer, dimension(:, :), pointer :: &
-         edgeMaskTmp, &
-         vertexMaskTmp, &
-         cellMaskTmp, &
          edgeSignOnCellTmp, &
-         edgeSignOnVertexTmp, &
-         boundaryEdgeTmp, &
-         boundaryVertexTmp, &
-         boundaryCellTmp
+         edgeSignOnVertexTmp
 
       !***
       !*** end of preamble, begin code
@@ -388,8 +382,8 @@ contains
                                cellsOnVertex)
       call mpas_pool_get_array(meshPool, 'edgesOnVertex', &
                                edgesOnVertex)
-      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
-                               kiteIndexOnCell)
+!      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
+!                               kiteIndexOnCell)
 
       ! now set a number of physics and numerical properties of mesh
       call mpas_pool_get_array(meshPool, 'latCell', &
@@ -476,31 +470,20 @@ contains
       ! so retrieve integer version pointers and allocate real masks
       ! Once these are converted in Registry, we can eliminate this.
       call mpas_pool_get_array(meshPool, 'edgeMask', &
-                               edgeMaskTmp)
+                               edgeMask)
       call mpas_pool_get_array(meshPool, 'vertexMask', &
-                               vertexMaskTmp)
+                               vertexMask)
       call mpas_pool_get_array(meshPool, 'cellMask', &
-                               cellMaskTmp)
+                               cellMask)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
-                               edgeSignOnCellTmp)
+                               edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
-                               edgeSignOnVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
-                               boundaryEdgeTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
-                               boundaryVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', &
-                               boundaryCellTmp)
+                               edgeSignOnVertex)
 
       allocate ( &
-            edgeMask(nVertLevels, nEdges+1), &
-            cellMask(nVertLevels, nCells+1), &
-            vertexMask(nVertLevels, nVertices+1), &
             boundaryEdge(nVertLevels, nEdges+1), &
             boundaryCell(nVertLevels, nCells+1), &
             boundaryVertex(nVertLevels, nVertices+1), &
-            edgeSignOnCell(maxEdges, nCells+1), &
-            edgeSignOnVertex(maxEdges, nVertices+1), &
             invAreaCell(nCells+1))
 
       !-----------------------------------------------------------------
@@ -525,38 +508,35 @@ contains
    
       ! Routine calls above initialized the real mask arrays
       ! so convert the meshPool integer pointers here
-      do n = 1, nCells+1
-      do k = 1, nVertLevels
-         cellMaskTmp(k,n)     = nint(cellMask(k,n))
-         boundaryCellTmp(k,n) = nint(boundaryCell(k,n))
-      end do
-      end do
-
-      do n = 1, nCells+1
-      do k = 1, maxEdges
-         edgeSignOnCellTmp(k, n) = nint(edgeSignOnCell(k,n))
-      end do
-      end do
-
-      do n = 1, nEdges+1
-      do k = 1, nVertLevels
-         edgeMaskTmp(k, n) = nint(edgeMask(k,n))
-         boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
-      end do
-      end do
-
-      do n = 1, nVertices+1
-      do k = 1, nVertLevels
-         vertexMaskTmp(k, n) = nint(vertexMask(k,n))
-         boundaryVertexTmp(k, n) = nint(boundaryVertex(k,n))
-      end do
-      end do
-
-      do n = 1, nVertices+1
-      do k = 1, vertexDegree
-         edgeSignOnVertexTmp(k,n) = nint(edgeSignOnVertex(k,n))
-      end do
-      end do
+!      do n = 1, nCells+1
+!      do k = 1, nVertLevels
+!         boundaryCellTmp(k,n) = nint(boundaryCell(k,n))
+!      end do
+!      end do
+!
+!      do n = 1, nCells+1
+!      do k = 1, maxEdges
+!         edgeSignOnCellTmp(k, n) = nint(edgeSignOnCell(k,n))
+!      end do
+!      end do
+!
+!      do n = 1, nEdges+1
+!      do k = 1, nVertLevels
+!         boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
+!      end do
+!      end do
+!
+!      do n = 1, nVertices+1
+!      do k = 1, nVertLevels
+!         boundaryVertexTmp(k, n) = nint(boundaryVertex(k,n))
+!      end do
+!      end do
+!
+!      do n = 1, nVertices+1
+!      do k = 1, vertexDegree
+!         edgeSignOnVertexTmp(k,n) = nint(edgeSignOnVertex(k,n))
+!      end do
+!      end do
 
       ! Compute area weighting for some interpolation
       call meshAreaWeights()
@@ -810,7 +790,10 @@ contains
       ! If this becomes the only mesh structure and mesh pool is eliminated,
       !  then we will want to deallocate here instead of nullify.
 
-      nullify (nEdgesOnEdge, &
+      nullify (edgeMask, &
+               cellMask, &
+               vertexMask, & 
+               nEdgesOnEdge, &
                nEdgesOnCell, &
                !minLevelCell, &
                !minLevelEdgeTop, &
@@ -833,7 +816,7 @@ contains
                verticesOnCell, &
                cellsOnVertex, &
                edgesOnVertex, &
-               kiteIndexOnCell, &
+               !kiteIndexOnCell, &
                latCell, &
                lonCell, &
                xCell, &
@@ -871,6 +854,8 @@ contains
                edgeNormalVectors, &
                localVerticalUnitVectors, &
                cellTangentPlane, &
+               edgeSignOnCell, &
+               edgeSignOnVertex, &
                coeffs_reconstruct)
 
 #ifdef MPAS_OPENACC
@@ -879,14 +864,9 @@ contains
       deallocate (nEdgesHalo, &
                   nCellsHalo, &
                   nVerticesHalo, &
-                  edgeMask, &
-                  cellMask, &
-                  vertexMask, &
                   boundaryEdge, &
                   boundaryCell, &
                   boundaryVertex, &
-                  edgeSignOnCell, &
-                  edgeSignOnVertex, &
                   edgeAreaFractionOfCell, &
                   invAreaCell)
 
@@ -928,14 +908,8 @@ contains
       ! temporary pointers for converting masks
       integer k, n          ! loop indices
       integer, dimension(:, :), pointer :: &
-         edgeMaskTmp, &
-         vertexMaskTmp, &
-         cellMaskTmp, &
          edgeSignOnCellTmp, &
-         edgeSignOnVertexTmp, &
-         boundaryEdgeTmp, &
-         boundaryVertexTmp, &
-         boundaryCellTmp
+         edgeSignOnVertexTmp
 
       !***
       !*** end of preamble, begin code
@@ -1076,59 +1050,50 @@ contains
       ! updated values. Probably only the edgeSign masks need updating, but
       ! do them all to be sure.
       call mpas_pool_get_array(meshPool, 'edgeMask', &
-                               edgeMaskTmp)
+                               edgeMask)
       call mpas_pool_get_array(meshPool, 'vertexMask', &
-                               vertexMaskTmp)
+                               vertexMask)
       call mpas_pool_get_array(meshPool, 'cellMask', &
-                               cellMaskTmp)
+                               cellMask)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
-                               edgeSignOnCellTmp)
+                               edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
-                               edgeSignOnVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
-                               boundaryEdgeTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
-                               boundaryVertexTmp)
-      call mpas_pool_get_array(meshPool, 'boundaryCell', &
-                               boundaryCellTmp)
+                               edgeSignOnVertex)
 
-      do n = 1, nCells+1
-      do k = 1, nVertLevels
-         cellMask(k, n) = real(cellMaskTmp(k, n), RKIND)
-         boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
-      end do
-      end do
-
-      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
-      ! pointer needs to be udpated
-      do n = 1, nCells+1
-      do k = 1, maxEdges
-         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
-      end do
-      end do
-
-      do n = 1, nEdges+1
-      do k = 1, nVertLevels
-         edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
-         boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
-      end do
-      end do
-
-      do n = 1, nVertices+1
-      do k = 1, nVertLevels
-         vertexMask(k, n) = real(vertexMaskTmp(k, n), RKIND)
-         boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
-      end do
-      end do
-
-      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
-      ! pointer needs to be udpated
-      do n = 1, nVertices+1
-      do k = 1, vertexDegree
-         edgeSignOnVertexTmp(k, n) = &
-            int(edgeSignOnVertex(k, n))
-      end do
-      end do
+!      do n = 1, nCells+1
+!      do k = 1, nVertLevels
+!         boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
+!      end do
+!      end do
+!
+!      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+!      ! pointer needs to be udpated
+!      do n = 1, nCells+1
+!      do k = 1, maxEdges
+!         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
+!      end do
+!      end do
+!
+!      do n = 1, nEdges+1
+!      do k = 1, nVertLevels
+!         boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
+!      end do
+!      end do
+!
+!      do n = 1, nVertices+1
+!      do k = 1, nVertLevels
+!         boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
+!      end do
+!      end do
+!
+!      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+!      ! pointer needs to be udpated
+!      do n = 1, nVertices+1
+!      do k = 1, vertexDegree
+!         edgeSignOnVertexTmp(k, n) = &
+!            int(edgeSignOnVertex(k, n))
+!      end do
+!      end do
 
       ! Go ahead and update all fields on device to be safe.
       ! NOTE: if we end up computing some fields on the device during
@@ -1350,7 +1315,7 @@ contains
 
       ! set boundary edge
       boundaryEdge(:,1:nEdges+1)=1.0_RKIND
-      edgeMask(:,1:nEdges+1)=0.0_RKIND
+      !edgeMask(1:nEdges+1)=0
 
       ! TODO: Replace this loop over levels with MALI levels
       !do iEdge = 1, nEdges
@@ -1362,9 +1327,9 @@ contains
 
       ! Find cells and vertices that have an edge on the boundary
       boundaryCell(:,1:nCells+1) = 0.0_RKIND
-      cellMask(:,1:nCells+1) = 0.0_RKIND
+      !cellMask(1:nCells+1) = 0
       boundaryVertex(:,1:nVertices+1) = 0.0_RKIND
-      vertexMask(:,1:nVertices+1) = 0.0_RKIND
+      !vertexMask(1:nVertices+1) = 0
 
       do iEdge = 1, nEdges
       do k = 1, nVertLevels
@@ -1429,7 +1394,6 @@ contains
       ! Initialize to zero
       edgeSignOnCell   = 0.0_RKIND
       edgeSignOnVertex = 0.0_RKIND
-      kiteIndexOnCell  = 0
 
       do iCell = 1, nCells
          do i = 1, nEdgesOnCell(iCell)
@@ -1443,11 +1407,6 @@ contains
                edgeSignOnCell(i, iCell) =  1.0_RKIND
             end if
 
-            do j = 1, vertexDegree
-               if (cellsOnVertex(j,iVertex) == iCell) then
-                  kiteIndexOnCell(i,iCell) = j
-               end if
-            end do
          end do
       end do
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -72,9 +72,6 @@ module li_mesh
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
       nEdgesOnCell, & ! number of edges associated with each cell center
-      cellMask, &
-      edgeMask, &
-      vertexMask, &
 !      minLevelCell, &! max ocean level at bottom of cell
 !      minLevelEdgeTop, &! max ocean level at top    of edge column
 !      minLevelEdgeBot, &! max ocean level at bottom of edge column
@@ -469,12 +466,6 @@ contains
       ! For masks, we wish to convert to real multiplicative masks
       ! so retrieve integer version pointers and allocate real masks
       ! Once these are converted in Registry, we can eliminate this.
-      call mpas_pool_get_array(meshPool, 'edgeMask', &
-                               edgeMask)
-      call mpas_pool_get_array(meshPool, 'vertexMask', &
-                               vertexMask)
-      call mpas_pool_get_array(meshPool, 'cellMask', &
-                               cellMask)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
@@ -625,9 +616,6 @@ contains
          !$acc                   meshDensity,              &
          !$acc                   angleEdge,                &
          !$acc                   distanceToCoast,          &
-         !$acc                   edgeMask,                 &
-         !$acc                   cellMask,                 &
-         !$acc                   vertexMask,               &
          !$acc                   boundaryEdge,             &
          !$acc                   boundaryCell,             &
          !$acc                   boundaryVertex,           &
@@ -755,9 +743,6 @@ contains
       !$acc                  meshDensity,       &
       !$acc                  angleEdge,         &
       !$acc                  distanceToCoast,   &
-      !$acc                  edgeMask,          &
-      !$acc                  cellMask,          &
-      !$acc                  vertexMask,        &
       !$acc                  boundaryEdge,      &
       !$acc                  boundaryCell,      &
       !$acc                  boundaryVertex,    &
@@ -790,10 +775,7 @@ contains
       ! If this becomes the only mesh structure and mesh pool is eliminated,
       !  then we will want to deallocate here instead of nullify.
 
-      nullify (edgeMask, &
-               cellMask, &
-               vertexMask, & 
-               nEdgesOnEdge, &
+      nullify (nEdgesOnEdge, &
                nEdgesOnCell, &
                !minLevelCell, &
                !minLevelEdgeTop, &
@@ -1049,12 +1031,6 @@ contains
       ! For masks, we converted to real masks, so need to recompute for
       ! updated values. Probably only the edgeSign masks need updating, but
       ! do them all to be sure.
-      call mpas_pool_get_array(meshPool, 'edgeMask', &
-                               edgeMask)
-      call mpas_pool_get_array(meshPool, 'vertexMask', &
-                               vertexMask)
-      call mpas_pool_get_array(meshPool, 'cellMask', &
-                               cellMask)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
                                edgeSignOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
@@ -1171,9 +1147,6 @@ contains
       !$acc               meshDensity,              &
       !$acc               angleEdge,                &
       !$acc               distanceToCoast,          &
-      !$acc               edgeMask,                 &
-      !$acc               cellMask,                 &
-      !$acc               vertexMask,               &
       !$acc               boundaryEdge,             &
       !$acc               boundaryCell,             &
       !$acc               boundaryVertex,           &
@@ -1321,15 +1294,12 @@ contains
       !do iEdge = 1, nEdges
       !do k= minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
       !   boundaryEdge(k,iEdge)=0.0_RKIND
-      !   edgeMask(k,iEdge)=1.0_RKIND
       !end do
       !end do
 
       ! Find cells and vertices that have an edge on the boundary
       boundaryCell(:,1:nCells+1) = 0.0_RKIND
-      !cellMask(1:nCells+1) = 0
       boundaryVertex(:,1:nVertices+1) = 0.0_RKIND
-      !vertexMask(1:nVertices+1) = 0
 
       do iEdge = 1, nEdges
       do k = 1, nVertLevels
@@ -1346,7 +1316,6 @@ contains
       !do k = 1, nVertLevels
       !   if ( minLevelCell(iCell) <= k .and. &
       !        maxLevelCell(iCell) >= k ) then
-      !      cellMask(k, iCell) = 1.0_RKIND
       !   end if
       !end do
       !end do
@@ -1355,7 +1324,6 @@ contains
       !do k = 1, nVertLevels
       !   if ( minLevelVertexTop(iVertex) <= k .and. &
       !        maxLevelVertexBot(iVertex) >= k ) then
-      !      vertexMask(k, iVertex) = 1.0_RKIND
       !   end if
       !end do
       !end do

--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -61,7 +61,7 @@ module li_mesh
       maxEdges, &! largest number of edges any polygon has
       maxEdges2, &! 2x the largest number of edges any polygon has
       vertexDegree, &! number of cells or edges touching each vertex
-      nVertLevels, &! number of vertical levels
+      nVertLevels ! number of vertical levels
 !      nVertLevelsP1 ! number of vertical interfaces (levels plus one)
 
    integer, public, dimension(:), allocatable :: &
@@ -71,7 +71,7 @@ module li_mesh
 
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
-      nEdgesOnCell, &! number of edges associated with each cell center
+      nEdgesOnCell, & ! number of edges associated with each cell center
 !      minLevelCell, &! max ocean level at bottom of cell
 !      minLevelEdgeTop, &! max ocean level at top    of edge column
 !      minLevelEdgeBot, &! max ocean level at bottom of edge column
@@ -127,7 +127,7 @@ module li_mesh
 !      meshScalingDel2, &! mesh scaling factor for use in del2 diffusion
 !      meshScalingDel4, &! mesh scaling factor for use in del4 diffusion
       meshDensity, &! density of mesh
-      angleEdge, &! angle the edge normal makes with local east
+      angleEdge ! angle the edge normal makes with local east
 !      distanceToCoast ! distance to nearest coast cell 
 
    real(kind=RKIND), public, dimension(:), allocatable :: &
@@ -157,7 +157,7 @@ module li_mesh
 
    ! Derived mesh values needed
    real(kind=RKIND), public, dimension(:, :), allocatable :: &
-!      edgeAreaFractionOfCell
+      edgeAreaFractionOfCell
 
    !}}}
 
@@ -227,8 +227,8 @@ contains
          maxEdgesTmp, &!
          maxEdges2Tmp, &!
          vertexDegreeTmp, &!
-         nVertLevelsTmp, &!
-         nVertLevelsP1Tmp !
+         nVertLevelsTmp !
+         !nVertLevelsP1Tmp !
 
       ! temporary pointers for converting index arrays
       integer, dimension(:), pointer :: &
@@ -297,8 +297,8 @@ contains
                                    vertexDegreeTmp)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', &
                                    nVertLevelsTmp)
-      call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', &
-                                   nVertLevelsP1Tmp)
+!      call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', &
+!                                   nVertLevelsP1Tmp)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', &
                                    nCellsArrayTmp)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', &
@@ -313,12 +313,12 @@ contains
       maxEdges2 = maxEdges2Tmp
       vertexDegree = vertexDegreeTmp
       nVertLevels = nVertLevelsTmp
-      nVertLevelsP1 = nVertLevelsP1Tmp
+!      nVertLevelsP1 = nVertLevelsP1Tmp
 
       ! convert previous index limits into new halo definitions
-      nCellsArray = nCellsTmp
-      nEdgesArray = nEdgesTmp
-      nVerticesArray = nVerticesTmp
+      nCells = nCellsTmp
+      nEdges = nEdgesTmp
+      nVertices = nVerticesTmp
 
       n = size(nCellsArrayTmp)
       allocate (nCellsHalo(n - 1))
@@ -346,26 +346,26 @@ contains
                                nEdgesOnEdge)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', &
                                nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'minLevelCell', &
-                               minLevelCell)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
-                               minLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
-                               minLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
-                               minLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
-                               minLevelVertexBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelCell', &
-                               maxLevelCell)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
-                               maxLevelEdgeTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', &
-                            maxLevelEdgeBot)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
-                               maxLevelVertexTop)
-      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
-                               maxLevelVertexBot)
+!      call mpas_pool_get_array(meshPool, 'minLevelCell', &
+!                               minLevelCell)
+!      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
+!                               minLevelEdgeTop)
+!      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+!                               minLevelEdgeBot)
+!      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
+!                               minLevelVertexTop)
+!      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
+!                               minLevelVertexBot)
+!      call mpas_pool_get_array(meshPool, 'maxLevelCell', &
+!                               maxLevelCell)
+!      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
+!                               maxLevelEdgeTop)
+!      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', &
+!                            maxLevelEdgeBot)
+!      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
+!                               maxLevelVertexTop)
+!      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
+!                               maxLevelVertexBot)
       call mpas_pool_get_array(meshPool, 'indexToCellID', &
                                indexToCellID)
       call mpas_pool_get_array(meshPool, 'indexToEdgeID', &
@@ -422,12 +422,12 @@ contains
                                yVertex)
       call mpas_pool_get_array(meshPool, 'zVertex', &
                                zVertex)
-      call mpas_pool_get_array(meshPool, 'fEdge', &
-                               fEdge)
-      call mpas_pool_get_array(meshPool, 'fVertex', &
-                               fVertex)
-      call mpas_pool_get_array(meshPool, 'fCell', &
-                               fCell)
+!      call mpas_pool_get_array(meshPool, 'fEdge', &
+!                               fEdge)
+!      call mpas_pool_get_array(meshPool, 'fVertex', &
+!                               fVertex)
+!      call mpas_pool_get_array(meshPool, 'fCell', &
+!                               fCell)
       call mpas_pool_get_array(meshPool, 'dcEdge', &
                                dcEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', &
@@ -438,24 +438,24 @@ contains
                                areaTriangle)
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
-      call mpas_pool_get_array(meshPool, 'bottomDepth', &
-                               bottomDepth)
-      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
-                               refBottomDepth)
-      call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', &
-                               refBottomDepthTopOfCell)
-      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', &
-                               vertCoordMovementWeights)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel2', &
-                               meshScalingDel2)
-      call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
-                               meshScalingDel4)
+!      call mpas_pool_get_array(meshPool, 'bottomDepth', &
+!                               bottomDepth)
+!      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
+!                               refBottomDepth)
+!      call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', &
+!                               refBottomDepthTopOfCell)
+!      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', &
+!                               vertCoordMovementWeights)
+!      call mpas_pool_get_array(meshPool, 'meshScalingDel2', &
+!                               meshScalingDel2)
+!      call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
+!                               meshScalingDel4)
       call mpas_pool_get_array(meshPool, 'meshDensity', &
                                meshDensity)
       call mpas_pool_get_array(meshPool, 'angleEdge', &
                                angleEdge)
-      call mpas_pool_get_array(meshPool, 'distanceToCoast', &
-                               distanceToCoast)
+!      call mpas_pool_get_array(meshPool, 'distanceToCoast', &
+!                               distanceToCoast)
 
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
@@ -493,15 +493,15 @@ contains
                                boundaryCellTmp)
 
       allocate ( &
-            edgeMask(nVertLevels, nEdgesArray+1), &
-            cellMask(nVertLevels, nCellsArray+1), &
-            vertexMask(nVertLevels, nVerticesArray+1), &
-            boundaryEdge(nVertLevels, nEdgesArray+1), &
-            boundaryCell(nVertLevels, nCellsArray+1), &
-            boundaryVertex(nVertLevels, nVerticesArray+1), &
-            edgeSignOnCell(maxEdges, nCellsArray+1), &
-            edgeSignOnVertex(maxEdges, nVerticesArray+1), &
-            invAreaCell(nCellsArray+1))
+            edgeMask(nVertLevels, nEdges+1), &
+            cellMask(nVertLevels, nCells+1), &
+            vertexMask(nVertLevels, nVertices+1), &
+            boundaryEdge(nVertLevels, nEdges+1), &
+            boundaryCell(nVertLevels, nCells+1), &
+            boundaryVertex(nVertLevels, nVertices+1), &
+            edgeSignOnCell(maxEdges, nCells+1), &
+            edgeSignOnVertex(maxEdges, nVertices+1), &
+            invAreaCell(nCells+1))
 
       !-----------------------------------------------------------------
       ! Now that all pointers are set and mesh variables allocated
@@ -510,63 +510,63 @@ contains
 
       ! Start by initializing vertical mesh, min/max cells and
       ! sign/index fields
-      call li_meshVertCoordInit(domain)
-      call li_meshMinMaxLevel()
-      call li_meshSignIndexFields()
+      !call meshVertCoordInit(domain)
+      call meshMinMaxLevel()
+      call meshSignIndexFields()
 
       ! Compute max mesh density and mesh scaling
-      if (config_maxMeshDensity < 0.0_RKIND) then
-         maxDensityLocal = maxval(meshDensity)
-         call mpas_dmpar_max_real(domain%dminfo, maxDensityLocal, &
-                                                 maxDensityGlobal)
-         config_maxMeshDensity = maxDensityGlobal 
-      endif
-      call li_meshScaling()
+!      if (config_maxMeshDensity < 0.0_RKIND) then
+!         maxDensityLocal = maxval(meshDensity)
+!         call mpas_dmpar_max_real(domain%dminfo, maxDensityLocal, &
+!                                                 maxDensityGlobal)
+!         config_maxMeshDensity = maxDensityGlobal 
+!      endif
+!      call meshScaling()
    
       ! Routine calls above initialized the real mask arrays
       ! so convert the meshPool integer pointers here
-      do n = 1, nCellsArray+1
+      do n = 1, nCells+1
       do k = 1, nVertLevels
          cellMaskTmp(k,n)     = nint(cellMask(k,n))
          boundaryCellTmp(k,n) = nint(boundaryCell(k,n))
       end do
       end do
 
-      do n = 1, nCellsArray+1
+      do n = 1, nCells+1
       do k = 1, maxEdges
          edgeSignOnCellTmp(k, n) = nint(edgeSignOnCell(k,n))
       end do
       end do
 
-      do n = 1, nEdgesArray+1
+      do n = 1, nEdges+1
       do k = 1, nVertLevels
          edgeMaskTmp(k, n) = nint(edgeMask(k,n))
          boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
       end do
       end do
 
-      do n = 1, nVerticesArray+1
+      do n = 1, nVertices+1
       do k = 1, nVertLevels
          vertexMaskTmp(k, n) = nint(vertexMask(k,n))
          boundaryVertexTmp(k, n) = nint(boundaryVertex(k,n))
       end do
       end do
 
-      do n = 1, nVerticesArray+1
+      do n = 1, nVertices+1
       do k = 1, vertexDegree
          edgeSignOnVertexTmp(k,n) = nint(edgeSignOnVertex(k,n))
       end do
       end do
 
       ! Compute area weighting for some interpolation
-      call li_meshAreaWeights()
-      areaCell(nCellsArray+1) = -1.0e34_RKIND
+      call meshAreaWeights()
+      areaCell(nCells+1) = -1.0e34_RKIND
 
       ! Compute the inverse of areaCell
-      do n = 1, nCellsArray
+      do n = 1, nCells
          invAreaCell(n) = 1.0_RKIND / areaCell(n)
       end do
-      invAreaCell(nCellsArray+1) = 0.0_RKIND
+      invAreaCell(nCells+1) = 0.0_RKIND
 
       !-----------------------------------------------------------------
       ! Copy mesh data to accelerator if needed.
@@ -575,9 +575,9 @@ contains
          !$acc enter data copyin( &
          !$acc                   onSphere,                 &
          !$acc                   sphereRadius,             &
-         !$acc                   nCellsArray,                &
-         !$acc                   nEdgesArray,                &
-         !$acc                   nVerticesArray,             &
+         !$acc                   nCells,                &
+         !$acc                   nEdges,                &
+         !$acc                   nVertices,             &
          !$acc                   nCellsSolve,              &
          !$acc                   nEdgesSolve,              &
          !$acc                   nVerticesSolve,           &
@@ -705,9 +705,9 @@ contains
 
       !$acc exit data delete(onSphere,          &
       !$acc                  sphereRadius,      &
-      !$acc                  nCellsArray,         &
-      !$acc                  nEdgesArray,         &
-      !$acc                  nVerticesArray,      &
+      !$acc                  nCells,         &
+      !$acc                  nEdges,         &
+      !$acc                  nVertices,      &
       !$acc                  nCellsSolve,       &
       !$acc                  nEdgesSolve,       &
       !$acc                  nVerticesSolve,    &
@@ -794,9 +794,9 @@ contains
       ! Reset all scalars to zero
       onSphere  = .false.
       sphereRadius = 0.0_RKIND
-      nCellsArray = 0
-      nEdgesArray = 0
-      nVerticesArray = 0
+      nCells = 0
+      nEdges = 0
+      nVertices = 0
       nCellsSolve = 0
       nEdgesSolve = 0
       nVerticesSolve = 0
@@ -804,7 +804,7 @@ contains
       maxEdges2 = 0
       vertexDegree = 0
       nVertLevels = 0
-      nVertLevelsP1 = 0
+!      nVertLevelsP1 = 0
 
       ! Now nullify all pointers to invalidate fields
       ! If this becomes the only mesh structure and mesh pool is eliminated,
@@ -812,16 +812,16 @@ contains
 
       nullify (nEdgesOnEdge, &
                nEdgesOnCell, &
-               minLevelCell, &
-               minLevelEdgeTop, &
-               minLevelEdgeBot, &
-               minLevelVertexTop, &
-               minLevelVertexBot, &
-               maxLevelCell, &
-               maxLevelEdgeTop, &
-               maxLevelEdgeBot, &
-               maxLevelVertexTop, &
-               maxLevelVertexBot, &
+               !minLevelCell, &
+               !minLevelEdgeTop, &
+               !minLevelEdgeBot, &
+               !minLevelVertexTop, &
+               !minLevelVertexBot, &
+               !maxLevelCell, &
+               !maxLevelEdgeTop, &
+               !maxLevelEdgeBot, &
+               !maxLevelVertexTop, &
+               !maxLevelVertexBot, &
                indexToCellID, &
                indexToEdgeID, &
                indexToVertexID, &
@@ -849,22 +849,22 @@ contains
                xVertex, &
                yVertex, &
                zVertex, &
-               fEdge, &
-               fVertex, &
-               fCell, &
+               !fEdge, &
+               !fVertex, &
+               !fCell, &
                dcEdge, &
                dvEdge, &
                areaCell, &
                areaTriangle, &
-               bottomDepth, &
-               refBottomDepth, &
-               refBottomDepthTopOfCell, &
-               vertCoordMovementWeights, &
-               meshScalingDel2, &
-               meshScalingDel4, &
+               !bottomDepth, &
+               !refBottomDepth, &
+               !refBottomDepthTopOfCell, &
+               !vertCoordMovementWeights, &
+               !meshScalingDel2, &
+               !meshScalingDel4, &
                meshDensity, &
                angleEdge, &
-               distanceToCoast, &
+               !distanceToCoast, &
                weightsOnEdge, &
                kiteAreasOnVertex, &
                edgeTangentVectors, &
@@ -1092,7 +1092,7 @@ contains
       call mpas_pool_get_array(meshPool, 'boundaryCell', &
                                boundaryCellTmp)
 
-      do n = 1, nCellsArray+1
+      do n = 1, nCells+1
       do k = 1, nVertLevels
          cellMask(k, n) = real(cellMaskTmp(k, n), RKIND)
          boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
@@ -1101,20 +1101,20 @@ contains
 
       ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
       ! pointer needs to be udpated
-      do n = 1, nCellsArray+1
+      do n = 1, nCells+1
       do k = 1, maxEdges
          edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
       end do
       end do
 
-      do n = 1, nEdgesArray+1
+      do n = 1, nEdges+1
       do k = 1, nVertLevels
          edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
          boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
       end do
       end do
 
-      do n = 1, nVerticesArray+1
+      do n = 1, nVertices+1
       do k = 1, nVertLevels
          vertexMask(k, n) = real(vertexMaskTmp(k, n), RKIND)
          boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
@@ -1123,7 +1123,7 @@ contains
 
       ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
       ! pointer needs to be udpated
-      do n = 1, nVerticesArray+1
+      do n = 1, nVertices+1
       do k = 1, vertexDegree
          edgeSignOnVertexTmp(k, n) = &
             int(edgeSignOnVertex(k, n))
@@ -1136,9 +1136,9 @@ contains
 
       !$acc update device(onSphere,                 &
       !$acc               sphereRadius,             &
-      !$acc               nCellsArray,                &
-      !$acc               nEdgesArray,                &
-      !$acc               nVerticesArray,             &
+      !$acc               nCells,                &
+      !$acc               nEdges,                &
+      !$acc               nVertices,             &
       !$acc               nCellsSolve,              &
       !$acc               nEdgesSolve,              &
       !$acc               nVerticesSolve,           &
@@ -1255,117 +1255,118 @@ contains
       ! minLevelEdgeTop is the minimum (shallowest) of surrounding cells
       ! if the water column is dry, set minLevelCell outside of bounds
       ! to prevent dry cells from determining minimum
-      do iCell = 1, nCellsArray+1
-         if (maxLevelCell(iCell) == 0) minLevelCell(iCell)=nVertLevels+1 
-      end do
-      do iEdge = 1, nEdgesArray
-         minLevelEdgeTop(iEdge) = &
-            min( minLevelCell(cellsOnEdge(1,iEdge)), &
-                 minLevelCell(cellsOnEdge(2,iEdge)) )
-      end do
-      minLevelEdgeTop(nEdgesArray+1) = 0
+      !do iCell = 1, nCells+1
+      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell)=nVertLevels+1 
+      !end do
+      !do iEdge = 1, nEdges
+      !   minLevelEdgeTop(iEdge) = &
+      !      min( minLevelCell(cellsOnEdge(1,iEdge)), &
+      !           minLevelCell(cellsOnEdge(2,iEdge)) )
+      !end do
+      !minLevelEdgeTop(nEdges+1) = 0
 
-      ! minLevelEdgeBot is the maximum (deepest) of surrounding cells
-      ! prevent dry cells from determining maximum
-      do iCell = 1, nCellsArray+1
-         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
-      end do
-      do iEdge = 1, nEdgesArray
-         minLevelEdgeBot(iEdge) = &
-            max( minLevelCell(cellsOnEdge(1,iEdge)), &
-                 minLevelCell(cellsOnEdge(2,iEdge)) )
-      end do
-      minLevelEdgeBot(nEdgesArray+1) = 0
+      !! minLevelEdgeBot is the maximum (deepest) of surrounding cells
+      !! prevent dry cells from determining maximum
+      !do iCell = 1, nCells+1
+      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
+      !end do
+      !do iEdge = 1, nEdges
+      !   minLevelEdgeBot(iEdge) = &
+      !      max( minLevelCell(cellsOnEdge(1,iEdge)), &
+      !           minLevelCell(cellsOnEdge(2,iEdge)) )
+      !end do
+      !minLevelEdgeBot(nEdges+1) = 0
 
-      ! minLevelVertexBot is the maximum (deepest) of surrounding cells
-      do iVertex = 1,nVerticesArray
-         minLevelVertexBot(iVertex) = &
-              minLevelCell(cellsOnVertex(1,iVertex))
-         do i = 2, vertexDegree
-            minLevelVertexBot(iVertex) = &
-               max( minLevelVertexBot(iVertex), &
-                    minLevelCell(cellsOnVertex(i,iVertex)))
-         end do
-      end do
-      minLevelVertexBot(nVerticesArray+1) = 0
+      !! minLevelVertexBot is the maximum (deepest) of surrounding cells
+      !do iVertex = 1,nVertices
+      !   minLevelVertexBot(iVertex) = &
+      !        minLevelCell(cellsOnVertex(1,iVertex))
+      !   do i = 2, vertexDegree
+      !      minLevelVertexBot(iVertex) = &
+      !         max( minLevelVertexBot(iVertex), &
+      !              minLevelCell(cellsOnVertex(i,iVertex)))
+      !   end do
+      !end do
+      !minLevelVertexBot(nVertices+1) = 0
 
-      ! minLevelVertexTop is the minimum (shallowest) of surrounding cells
-      ! if the water column is dry, set minLevelCell outside of bounds
-      ! to prevent dry cells from determining minimum
-      do iCell = 1, nCellsArray+1
-         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
-      end do
-      do iVertex = 1,nVerticesArray
-         minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
-         do i = 2, vertexDegree
-            minLevelVertexTop(iVertex) = &
-               min( minLevelVertexTop(iVertex), &
-                    minLevelCell(cellsOnVertex(i,iVertex)))
-         end do
-      end do
-      minLevelVertexTop(nVerticesArray+1) = 0
+      !! minLevelVertexTop is the minimum (shallowest) of surrounding cells
+      !! if the water column is dry, set minLevelCell outside of bounds
+      !! to prevent dry cells from determining minimum
+      !do iCell = 1, nCells+1
+      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
+      !end do
+      !do iVertex = 1,nVertices
+      !   minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
+      !   do i = 2, vertexDegree
+      !      minLevelVertexTop(iVertex) = &
+      !         min( minLevelVertexTop(iVertex), &
+      !              minLevelCell(cellsOnVertex(i,iVertex)))
+      !   end do
+      !end do
+      !minLevelVertexTop(nVertices+1) = 0
 
-      ! if the water column is dry, set minLevelCell = 1
-      do iCell = 1, nCellsArray+1
-         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1
-      end do
-      
-      ! maxLevelEdgeTop is the minimum (shallowest) of surrounding cells
-      do iEdge = 1, nEdgesArray
-         maxLevelEdgeTop(iEdge) = &
-            min( maxLevelCell(cellsOnEdge(1,iEdge)), &
-                 maxLevelCell(cellsOnEdge(2,iEdge)) )
-      end do
-      maxLevelEdgeTop(nEdgesArray+1) = 0
+      !! if the water column is dry, set minLevelCell = 1
+      !do iCell = 1, nCells+1
+      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1
+      !end do
+      !
+      !! maxLevelEdgeTop is the minimum (shallowest) of surrounding cells
+      !do iEdge = 1, nEdges
+      !   maxLevelEdgeTop(iEdge) = &
+      !      min( maxLevelCell(cellsOnEdge(1,iEdge)), &
+      !           maxLevelCell(cellsOnEdge(2,iEdge)) )
+      !end do
+      !maxLevelEdgeTop(nEdges+1) = 0
 
-      ! maxLevelEdgeBot is the maximum (deepest) of surrounding cells
-      do iEdge = 1, nEdgesArray
-         maxLevelEdgeBot(iEdge) = &
-            max( maxLevelCell(cellsOnEdge(1,iEdge)), &
-                 maxLevelCell(cellsOnEdge(2,iEdge)) )
-      end do
-      maxLevelEdgeBot(nEdgesArray+1) = 0
+      !! maxLevelEdgeBot is the maximum (deepest) of surrounding cells
+      !do iEdge = 1, nEdges
+      !   maxLevelEdgeBot(iEdge) = &
+      !      max( maxLevelCell(cellsOnEdge(1,iEdge)), &
+      !           maxLevelCell(cellsOnEdge(2,iEdge)) )
+      !end do
+      !maxLevelEdgeBot(nEdges+1) = 0
 
-      ! maxLevelVertexBot is the maximum (deepest) of surrounding cells
-      do iVertex = 1,nVerticesArray
-         maxLevelVertexBot(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
-         do i = 2, vertexDegree
-            maxLevelVertexBot(iVertex) = &
-               max( maxLevelVertexBot(iVertex), &
-                    maxLevelCell(cellsOnVertex(i,iVertex)))
-         end do
-      end do
-      maxLevelVertexBot(nVerticesArray+1) = 0
+      !! maxLevelVertexBot is the maximum (deepest) of surrounding cells
+      !do iVertex = 1,nVertices
+      !   maxLevelVertexBot(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
+      !   do i = 2, vertexDegree
+      !      maxLevelVertexBot(iVertex) = &
+      !         max( maxLevelVertexBot(iVertex), &
+      !              maxLevelCell(cellsOnVertex(i,iVertex)))
+      !   end do
+      !end do
+      !maxLevelVertexBot(nVertices+1) = 0
 
-      ! maxLevelVertexTop is the minimum (shallowest) of surrounding cells
-      do iVertex = 1,nVerticesArray
-         maxLevelVertexTop(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
-         do i = 2, vertexDegree
-            maxLevelVertexTop(iVertex) = &
-               min( maxLevelVertexTop(iVertex), &
-                    maxLevelCell(cellsOnVertex(i,iVertex)))
-         end do
-      end do
-      maxLevelVertexTop(nVerticesArray+1) = 0
+      !! maxLevelVertexTop is the minimum (shallowest) of surrounding cells
+      !do iVertex = 1,nVertices
+      !   maxLevelVertexTop(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
+      !   do i = 2, vertexDegree
+      !      maxLevelVertexTop(iVertex) = &
+      !         min( maxLevelVertexTop(iVertex), &
+      !              maxLevelCell(cellsOnVertex(i,iVertex)))
+      !   end do
+      !end do
+      !maxLevelVertexTop(nVertices+1) = 0
 
       ! set boundary edge
-      boundaryEdge(:,1:nEdgesArray+1)=1.0_RKIND
-      edgeMask(:,1:nEdgesArray+1)=0.0_RKIND
+      boundaryEdge(:,1:nEdges+1)=1.0_RKIND
+      edgeMask(:,1:nEdges+1)=0.0_RKIND
 
-      do iEdge = 1, nEdgesArray
-      do k= minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-         boundaryEdge(k,iEdge)=0.0_RKIND
-         edgeMask(k,iEdge)=1.0_RKIND
-      end do
-      end do
+      ! TODO: Replace this loop over levels with MALI levels
+      !do iEdge = 1, nEdges
+      !do k= minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+      !   boundaryEdge(k,iEdge)=0.0_RKIND
+      !   edgeMask(k,iEdge)=1.0_RKIND
+      !end do
+      !end do
 
       ! Find cells and vertices that have an edge on the boundary
-      boundaryCell(:,1:nCellsArray+1) = 0.0_RKIND
-      cellMask(:,1:nCellsArray+1) = 0.0_RKIND
-      boundaryVertex(:,1:nVerticesArray+1) = 0.0_RKIND
-      vertexMask(:,1:nVerticesArray+1) = 0.0_RKIND
+      boundaryCell(:,1:nCells+1) = 0.0_RKIND
+      cellMask(:,1:nCells+1) = 0.0_RKIND
+      boundaryVertex(:,1:nVertices+1) = 0.0_RKIND
+      vertexMask(:,1:nVertices+1) = 0.0_RKIND
 
-      do iEdge = 1, nEdgesArray
+      do iEdge = 1, nEdges
       do k = 1, nVertLevels
          if (boundaryEdge(k,iEdge) == 1) then
             boundaryCell(k,cellsOnEdge(1,iEdge)) = 1.0_RKIND
@@ -1376,23 +1377,23 @@ contains
       end do
       end do
 
-      do iCell = 1, nCellsArray
-      do k = 1, nVertLevels
-         if ( minLevelCell(iCell) <= k .and. &
-              maxLevelCell(iCell) >= k ) then
-            cellMask(k, iCell) = 1.0_RKIND
-         end if
-      end do
-      end do
+      !do iCell = 1, nCells
+      !do k = 1, nVertLevels
+      !   if ( minLevelCell(iCell) <= k .and. &
+      !        maxLevelCell(iCell) >= k ) then
+      !      cellMask(k, iCell) = 1.0_RKIND
+      !   end if
+      !end do
+      !end do
 
-      do iVertex = 1, nVerticesArray
-      do k = 1, nVertLevels
-         if ( minLevelVertexTop(iVertex) <= k .and. &
-              maxLevelVertexBot(iVertex) >= k ) then
-            vertexMask(k, iVertex) = 1.0_RKIND
-         end if
-      end do
-      end do
+      !do iVertex = 1, nVertices
+      !do k = 1, nVertLevels
+      !   if ( minLevelVertexTop(iVertex) <= k .and. &
+      !        maxLevelVertexBot(iVertex) >= k ) then
+      !      vertexMask(k, iVertex) = 1.0_RKIND
+      !   end if
+      !end do
+      !end do
 
       ! Note: We do not update halos on maxLevel* variables.  We want
       ! the outside edge of a halo to be zero on each processor.
@@ -1430,7 +1431,7 @@ contains
       edgeSignOnVertex = 0.0_RKIND
       kiteIndexOnCell  = 0
 
-      do iCell = 1, nCellsArray
+      do iCell = 1, nCells
          do i = 1, nEdgesOnCell(iCell)
             iEdge = edgesOnCell(i, iCell)
             iVertex = verticesOnCell(i, iCell)
@@ -1450,7 +1451,7 @@ contains
          end do
       end do
 
-      do iVertex = 1, nVerticesArray
+      do iVertex = 1, nVertices
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
 
@@ -1481,216 +1482,216 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine meshVertCoordInit(domain)!{{{
-
-      !-----------------------------------------------------------------
-      ! Input/output variables
-      !-----------------------------------------------------------------
-
-      type (domain_type), intent(inout) :: domain !< [inout] ocean state
-
-      !-----------------------------------------------------------------
-      ! Local variables
-      !-----------------------------------------------------------------
-
-      type (block_type), pointer :: block ! all ocn data in a block
-
-      type (mpas_pool_type), pointer :: &
-         verticalMeshPool, &! vertical mesh data
-         statePool,        &! ocean state (layer thickness)
-         forcingPool        ! forcing data (land ice mask)
-
-      integer :: &
-         iCell, k,         &! loop indices for cell, vertical loops
-         kmin, kmax         ! min, max active levels in column
-
-      logical :: &
-         consistentSSH,    &! flag if SSH consistent with depth
-         landIceFlag,      &! flag if land ice mask exists
-         checkSSH           ! flag for checking SSH in cell column
-
-      real (kind=RKIND) &
-         thickDepth         ! depth based on sum of layer thicknesses
-
-      integer, dimension(:), pointer :: &
-         landIceMask        ! land ice mask
-
-      real (kind=RKIND), dimension(:), pointer :: &
-         refZMid,                  &! reference depth at mid-layer
-         refLayerThickness          ! reference profile layer thickness
-
-      real (kind=RKIND), dimension(:,:), pointer :: &
-         layerThickness     ! current layer thickness
-
-      ! End preamble
-      !-------------
-      ! Begin code
-
-      ! Extract pools from domain
-      block => domain % blocklist
-      call mpas_pool_get_subpool(block%structs, 'state', statePool)
-      call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
-                                                 verticalMeshPool)
-      call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
-
-      ! Extract needed variables from pools
-      call mpas_pool_get_array(statePool, 'layerThickness', &
-                                           layerThickness, 1)
-
-      call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
-      call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', &
-                                                  refLayerThickness)
-
-      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-      if (associated(landIceMask)) then
-         landIceFlag = .true.  ! ice shelves
-      else
-         landIceFlag = .false. ! ice shelves
-      endif
-
-      ! Initialize reference z coordinates based on refBottomDepth
-      refBottomDepthTopOfCell(1) = 0.0_RKIND
-      do k = 1, nVertLevels
-         refBottomDepthTopOfCell(k+1) = refBottomDepth(k)
-         refLayerThickness(k) = refBottomDepth(k) - &
-                                refBottomDepthTopOfCell(k)
-         refZMid(k) = - refBottomDepthTopOfCell(k) - &
-                        refLayerThickness(k)/2.0_RKIND
-      end do
-
-      ! Initialization of vertCoordMovementWeights. 
-      ! This determines how SSH perturbations are distributed throughout
-      ! the column. Check for invalid choice of vert coord movement.
-
-      call mpas_log_write(' Vertical coordinate movement is: ' // &
-                          trim(config_vert_coord_movement))
-
-
-      select case (trim(config_vert_coord_movement))
-      case ('fixed')
-
-         vertCoordMovementWeights = 0.0_RKIND
-         vertCoordMovementWeights(1) = 1.0_RKIND
-
-      case ('uniform_stretching')
-
-         vertCoordMovementWeights = 1.0_RKIND
-
-      case ('tapered')
-
-         ! Set weight tapering:
-         !  1.0 shallower than config_vert_taper_weight_depth_1
-         !  linear in between
-         !  0.0 deeper than config_vert_taper_weight_depth_2
-         do k = 1, nVertLevels
-            vertCoordMovementWeights(k) = 1.0_RKIND + &
-                 (refZMid(k) + config_vert_taper_weight_depth_1) / &
-                 (config_vert_taper_weight_depth_2 - &
-                  config_vert_taper_weight_depth_1)
-            ! limit range to (0,1)
-            vertCoordMovementWeights(k) = max( 0.0_RKIND, &
-                      min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
-         end do
-
-      case ('impermeable_interfaces')
-
-         ! weights are never used, no init needed
-
-      case ('user_specified')
-
-         ! weights should be input? probably should check
-
-      case default
-
-         call mpas_log_write( &
-            'Incorrect choice of config_vert_coord_movement.', &
-             MPAS_LOG_CRIT)
-
-      end select
-
-      !-----------------------------------------------------------------
-      ! Check consistency and validity of options
-      !-----------------------------------------------------------------
-
-      ! SSH consistency
-      if (config_check_ssh_consistency) then
-
-         ! Check if abs(ssh)>20m.  If so, print warning.
-         consistentSSH = .true.
-         do iCell = 1,nCellsArray
-
-            ! Only check for open ocean when land ice is being used
-            checkSSH = .true.
-            if (landIceFlag) then
-               if (landIceMask(iCell) /= 0) checkSSH = .false.
-            endif
-
-            ! Check whether thickness is consistent with bottom depth
-            if (checkSSH) then
-               kmin = minLevelCell(iCell)
-               kmax = maxLevelCell(iCell)
-
-               thickDepth = sum(layerThickness(kmin:kmax,iCell))
-
-               if (abs(thickDepth - bottomDepth(iCell)) > 20.0_RKIND) then
-                  consistentSSH = .false.
-
-                  call mpas_log_write( &
-                     ' Warning: Sea surface height outside of acceptable range (20m)', &
-                     MPAS_LOG_ERR)
-                  call mpas_log_write( &
-                     ' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
-                     intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
-                     realArgs=(/ bottomDepth(iCell), thickDepth /) )
-               endif ! depth diff check
-            endif ! checkSSH
-         end do ! cell loop
-
-         if (.not. consistentSSH) call mpas_log_write( &
-            'Warning: SSH not consistent - ' // &
-            'initial layerThickness does not match bottomDepth.')
-
-      endif ! config_check_ssh_consistency
-
-      ! Z-level consistency
-      if (config_check_zlevel_consistency) then
-         do iCell = 1,nCellsArray
-            ! Check that bottomDepth and maxLevelCell match.  Some
-            ! older meshs do not have the bottomDepth variable.
-            kmax = maxLevelCell(iCell)
-            if (bottomDepth(iCell) > refBottomDepth(kmax) .or. &
-                bottomDepth(iCell) < refBottomDepthTopOfCell(kmax)) then
-               call mpas_log_write( &
-                 ' fatal error: bottomDepth and maxLevelCell do not match:',  &
-                 MPAS_LOG_ERR)
-               call mpas_log_write( &
-                 ' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r', &
-                 intArgs=(/iCell, kmax /), &
-                 realArgs=(/ bottomDepth(iCell) /) )
-            endif
-         enddo ! cell loop
-      endif ! check_zlevel_consistency
-
-      ! pressure gradient compatibility
-      if (config_vert_coord_movement /= 'impermeable_interfaces' .and. &
-          config_pressure_gradient_type == 'MontgomeryPotential') then
-         call mpas_log_write( 'Incompatible choice of ' // &
-            'impermeable vertical interfaces and Montgomery Potential',&
-            MPAS_LOG_CRIT)
-      end if
-
-      ! barotropic filter mode compatibility
-      if (config_filter_btr_mode .and. &
-          config_vert_coord_movement /= 'fixed')then
-         call mpas_log_write( &
-          'filter_btr_mode has only been tested with ' // &
-          'config_vert_coord_movement=fixed.', &
-          MPAS_LOG_CRIT)
-      endif
-
-   !--------------------------------------------------------------------
-
-   end subroutine meshVertCoordInit !}}}
+!   subroutine meshVertCoordInit(domain)!{{{
+!
+!      !-----------------------------------------------------------------
+!      ! Input/output variables
+!      !-----------------------------------------------------------------
+!
+!      type (domain_type), intent(inout) :: domain !< [inout] ocean state
+!
+!      !-----------------------------------------------------------------
+!      ! Local variables
+!      !-----------------------------------------------------------------
+!
+!      type (block_type), pointer :: block ! all ocn data in a block
+!
+!      type (mpas_pool_type), pointer :: &
+!         verticalMeshPool, &! vertical mesh data
+!         statePool,        &! ocean state (layer thickness)
+!         forcingPool        ! forcing data (land ice mask)
+!
+!      integer :: &
+!         iCell, k,         &! loop indices for cell, vertical loops
+!         kmin, kmax         ! min, max active levels in column
+!
+!      logical :: &
+!         consistentSSH,    &! flag if SSH consistent with depth
+!         landIceFlag,      &! flag if land ice mask exists
+!         checkSSH           ! flag for checking SSH in cell column
+!
+!      real (kind=RKIND) &
+!         thickDepth         ! depth based on sum of layer thicknesses
+!
+!      integer, dimension(:), pointer :: &
+!         landIceMask        ! land ice mask
+!
+!      real (kind=RKIND), dimension(:), pointer :: &
+!         refZMid,                  &! reference depth at mid-layer
+!         refLayerThickness          ! reference profile layer thickness
+!
+!      real (kind=RKIND), dimension(:,:), pointer :: &
+!         layerThickness     ! current layer thickness
+!
+!      ! End preamble
+!      !-------------
+!      ! Begin code
+!
+!      ! Extract pools from domain
+!      block => domain % blocklist
+!      call mpas_pool_get_subpool(block%structs, 'state', statePool)
+!      call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
+!                                                 verticalMeshPool)
+!      call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
+!
+!      ! Extract needed variables from pools
+!      call mpas_pool_get_array(statePool, 'layerThickness', &
+!                                           layerThickness, 1)
+!
+!      call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
+!      call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', &
+!                                                  refLayerThickness)
+!
+!      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+!      if (associated(landIceMask)) then
+!         landIceFlag = .true.  ! ice shelves
+!      else
+!         landIceFlag = .false. ! ice shelves
+!      endif
+!
+!      ! Initialize reference z coordinates based on refBottomDepth
+!      refBottomDepthTopOfCell(1) = 0.0_RKIND
+!      do k = 1, nVertLevels
+!         refBottomDepthTopOfCell(k+1) = refBottomDepth(k)
+!         refLayerThickness(k) = refBottomDepth(k) - &
+!                                refBottomDepthTopOfCell(k)
+!         refZMid(k) = - refBottomDepthTopOfCell(k) - &
+!                        refLayerThickness(k)/2.0_RKIND
+!      end do
+!
+!      ! Initialization of vertCoordMovementWeights. 
+!      ! This determines how SSH perturbations are distributed throughout
+!      ! the column. Check for invalid choice of vert coord movement.
+!
+!      call mpas_log_write(' Vertical coordinate movement is: ' // &
+!                          trim(config_vert_coord_movement))
+!
+!
+!      select case (trim(config_vert_coord_movement))
+!      case ('fixed')
+!
+!         vertCoordMovementWeights = 0.0_RKIND
+!         vertCoordMovementWeights(1) = 1.0_RKIND
+!
+!      case ('uniform_stretching')
+!
+!         vertCoordMovementWeights = 1.0_RKIND
+!
+!      case ('tapered')
+!
+!         ! Set weight tapering:
+!         !  1.0 shallower than config_vert_taper_weight_depth_1
+!         !  linear in between
+!         !  0.0 deeper than config_vert_taper_weight_depth_2
+!         do k = 1, nVertLevels
+!            vertCoordMovementWeights(k) = 1.0_RKIND + &
+!                 (refZMid(k) + config_vert_taper_weight_depth_1) / &
+!                 (config_vert_taper_weight_depth_2 - &
+!                  config_vert_taper_weight_depth_1)
+!            ! limit range to (0,1)
+!            vertCoordMovementWeights(k) = max( 0.0_RKIND, &
+!                      min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
+!         end do
+!
+!      case ('impermeable_interfaces')
+!
+!         ! weights are never used, no init needed
+!
+!      case ('user_specified')
+!
+!         ! weights should be input? probably should check
+!
+!      case default
+!
+!         call mpas_log_write( &
+!            'Incorrect choice of config_vert_coord_movement.', &
+!             MPAS_LOG_CRIT)
+!
+!      end select
+!
+!      !-----------------------------------------------------------------
+!      ! Check consistency and validity of options
+!      !-----------------------------------------------------------------
+!
+!      ! SSH consistency
+!      if (config_check_ssh_consistency) then
+!
+!         ! Check if abs(ssh)>20m.  If so, print warning.
+!         consistentSSH = .true.
+!         do iCell = 1,nCells
+!
+!            ! Only check for open ocean when land ice is being used
+!            checkSSH = .true.
+!            if (landIceFlag) then
+!               if (landIceMask(iCell) /= 0) checkSSH = .false.
+!            endif
+!
+!            ! Check whether thickness is consistent with bottom depth
+!            if (checkSSH) then
+!               kmin = minLevelCell(iCell)
+!               kmax = maxLevelCell(iCell)
+!
+!               thickDepth = sum(layerThickness(kmin:kmax,iCell))
+!
+!               if (abs(thickDepth - bottomDepth(iCell)) > 20.0_RKIND) then
+!                  consistentSSH = .false.
+!
+!                  call mpas_log_write( &
+!                     ' Warning: Sea surface height outside of acceptable range (20m)', &
+!                     MPAS_LOG_ERR)
+!                  call mpas_log_write( &
+!                     ' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
+!                     intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
+!                     realArgs=(/ bottomDepth(iCell), thickDepth /) )
+!               endif ! depth diff check
+!            endif ! checkSSH
+!         end do ! cell loop
+!
+!         if (.not. consistentSSH) call mpas_log_write( &
+!            'Warning: SSH not consistent - ' // &
+!            'initial layerThickness does not match bottomDepth.')
+!
+!      endif ! config_check_ssh_consistency
+!
+!      ! Z-level consistency
+!      if (config_check_zlevel_consistency) then
+!         do iCell = 1,nCells
+!            ! Check that bottomDepth and maxLevelCell match.  Some
+!            ! older meshs do not have the bottomDepth variable.
+!            kmax = maxLevelCell(iCell)
+!            if (bottomDepth(iCell) > refBottomDepth(kmax) .or. &
+!                bottomDepth(iCell) < refBottomDepthTopOfCell(kmax)) then
+!               call mpas_log_write( &
+!                 ' fatal error: bottomDepth and maxLevelCell do not match:',  &
+!                 MPAS_LOG_ERR)
+!               call mpas_log_write( &
+!                 ' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r', &
+!                 intArgs=(/iCell, kmax /), &
+!                 realArgs=(/ bottomDepth(iCell) /) )
+!            endif
+!         enddo ! cell loop
+!      endif ! check_zlevel_consistency
+!
+!      ! pressure gradient compatibility
+!      if (config_vert_coord_movement /= 'impermeable_interfaces' .and. &
+!          config_pressure_gradient_type == 'MontgomeryPotential') then
+!         call mpas_log_write( 'Incompatible choice of ' // &
+!            'impermeable vertical interfaces and Montgomery Potential',&
+!            MPAS_LOG_CRIT)
+!      end if
+!
+!      ! barotropic filter mode compatibility
+!      if (config_filter_btr_mode .and. &
+!          config_vert_coord_movement /= 'fixed')then
+!         call mpas_log_write( &
+!          'filter_btr_mode has only been tested with ' // &
+!          'config_vert_coord_movement=fixed.', &
+!          MPAS_LOG_CRIT)
+!      endif
+!
+!   !--------------------------------------------------------------------
+!
+!   end subroutine meshVertCoordInit !}}}
 
 !***********************************************************************
 !
@@ -1726,7 +1727,7 @@ contains
       ! Begin code
 
       ! Allocate space
-      allocate (edgeAreaFractionOfCell(maxEdges,nCellsArray), STAT=ierr)
+      allocate (edgeAreaFractionOfCell(maxEdges,nCells), STAT=ierr)
 #ifdef MPAS_OPENACC
       !$acc enter data create(edgeAreaFractionOfCell)
 #endif
@@ -1734,7 +1735,7 @@ contains
          'Error allocating edgeAreaFractionOfCell in li_mesh', &
           MPAS_LOG_CRIT)
 
-      do iCell = 1, nCellsArray
+      do iCell = 1, nCells
       do i = 1, nEdgesOnCell(iCell)
          iEdge = edgesOnCell(i, iCell)
          edgeAreaFractionOfCell(i, iCell) = 0.25_RKIND* &
@@ -1762,75 +1763,75 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine meshScaling() !{{{
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-
-      integer :: &
-         iEdge,       &! loop index/address for edges
-         cell1, cell2  ! cell addresses for neighbors across edge
-
-      real (kind=RKIND) :: &
-         cellWidth,   &! reference cell width for scaling
-         avgDensity    ! avg mesh density across edge
-
-      ! End preamble
-      !-------------
-      ! Begin code
-
-      if (config_hmix_scaleWithMesh) then
-         if (config_hmix_use_ref_cell_width) then
-            ! Mesh scaling is set by areaCell and and an input
-            ! reference widht config_hmix_ref_cell_width
-            ! See description of config_hmix_ref_cell_width in
-            ! Registry.xml for more detail.
-            do iEdge = 1, nEdgesArray
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               ! Effective cell width at edge iEdge, assuming
-               ! neighboring cells are circles for this calculation.
-               cellWidth = 2.0_RKIND* &
-                           sqrt((areaCell(cell1) + areaCell(cell2))/ &
-                                2.0_RKIND/pii)
-               meshScalingDel2(iEdge) =  cellWidth/ &
-                                         config_hmix_ref_cell_width
-               meshScalingDel4(iEdge) = (cellWidth/ &
-                                         config_hmix_ref_cell_width)**3
-            end do
-
-         else ! not using ref cell width
-            ! Mesh scaling is set by meshDensity. This is both confusing
-            ! and inconvenient, as the flags like config_mom_del2 need
-            ! to be reset for every resolution. It is kept for backwards
-            ! compatibility, but should become defunct.
-            ! del2 scales as dc**1, del4 scales as dc**3
-            do iEdge = 1, nEdgesArray
-               cell1 = cellsOnEdge(1,iEdge)
-               cell2 = cellsOnEdge(2,iEdge)
-               avgDensity = (meshDensity(cell1) + meshDensity(cell2))/ &
-                            2.0_RKIND
-               meshScalingDel2(iEdge) = 1.0_RKIND/ &
-                  (avgDensity/config_maxMeshDensity)**(1.0_RKIND/4.0_RKIND)
-               meshScalingDel4(iEdge) = 1.0_RKIND/ &
-                  (avgDensity/config_maxMeshDensity)**(3.0_RKIND/4.0_RKIND)
-            end do
-         end if
-
-      else ! no scaling with mesh
-
-         ! If config_hmix_scaleWithMesh is false, hmix coefficients
-         ! do not vary with cell size but remain constant across domain.
-         do iEdge = 1, nEdgesArray
-            meshScalingDel2(iEdge) = 1.0_RKIND
-            meshScalingDel4(iEdge) = 1.0_RKIND
-         end do
-      end if
-
-   !--------------------------------------------------------------------
-
-   end subroutine meshScaling !}}}
+!   subroutine meshScaling() !{{{
+!
+!      !-----------------------------------------------------------------
+!      ! local variables
+!      !-----------------------------------------------------------------
+!
+!      integer :: &
+!         iEdge,       &! loop index/address for edges
+!         cell1, cell2  ! cell addresses for neighbors across edge
+!
+!      real (kind=RKIND) :: &
+!         cellWidth,   &! reference cell width for scaling
+!         avgDensity    ! avg mesh density across edge
+!
+!      ! End preamble
+!      !-------------
+!      ! Begin code
+!
+!      if (config_hmix_scaleWithMesh) then
+!         if (config_hmix_use_ref_cell_width) then
+!            ! Mesh scaling is set by areaCell and and an input
+!            ! reference widht config_hmix_ref_cell_width
+!            ! See description of config_hmix_ref_cell_width in
+!            ! Registry.xml for more detail.
+!            do iEdge = 1, nEdges
+!               cell1 = cellsOnEdge(1,iEdge)
+!               cell2 = cellsOnEdge(2,iEdge)
+!               ! Effective cell width at edge iEdge, assuming
+!               ! neighboring cells are circles for this calculation.
+!               cellWidth = 2.0_RKIND* &
+!                           sqrt((areaCell(cell1) + areaCell(cell2))/ &
+!                                2.0_RKIND/pii)
+!               meshScalingDel2(iEdge) =  cellWidth/ &
+!                                         config_hmix_ref_cell_width
+!               meshScalingDel4(iEdge) = (cellWidth/ &
+!                                         config_hmix_ref_cell_width)**3
+!            end do
+!
+!         else ! not using ref cell width
+!            ! Mesh scaling is set by meshDensity. This is both confusing
+!            ! and inconvenient, as the flags like config_mom_del2 need
+!            ! to be reset for every resolution. It is kept for backwards
+!            ! compatibility, but should become defunct.
+!            ! del2 scales as dc**1, del4 scales as dc**3
+!            do iEdge = 1, nEdges
+!               cell1 = cellsOnEdge(1,iEdge)
+!               cell2 = cellsOnEdge(2,iEdge)
+!               avgDensity = (meshDensity(cell1) + meshDensity(cell2))/ &
+!                            2.0_RKIND
+!               meshScalingDel2(iEdge) = 1.0_RKIND/ &
+!                  (avgDensity/config_maxMeshDensity)**(1.0_RKIND/4.0_RKIND)
+!               meshScalingDel4(iEdge) = 1.0_RKIND/ &
+!                  (avgDensity/config_maxMeshDensity)**(3.0_RKIND/4.0_RKIND)
+!            end do
+!         end if
+!
+!      else ! no scaling with mesh
+!
+!         ! If config_hmix_scaleWithMesh is false, hmix coefficients
+!         ! do not vary with cell size but remain constant across domain.
+!         do iEdge = 1, nEdges
+!            meshScalingDel2(iEdge) = 1.0_RKIND
+!            meshScalingDel4(iEdge) = 1.0_RKIND
+!         end do
+!      end if
+!
+!   !--------------------------------------------------------------------
+!
+!   end subroutine meshScaling !}}}
 
 !***********************************************************************
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -1,0 +1,1840 @@
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! \file mpas_li_mesh.F
+!
+! Copyright (c) 2013,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  li_mesh
+!
+!>  \brief MALI mesh structure with GPU support
+!> \author Rob Aulwes and Phil Jones, modified for MALI
+!>         by Trevor Hillebrand and Matthew Hoffman
+!> \date   14 Jan 2020
+!> \details
+!> This module creates and maintains a primary land ice mesh structure
+!> and ensures all mesh variables are copied to an accelerator device
+!> if needed. Currently it consists of pointers to the existing MPAS mesh pool
+!> variables, but is intended to eventually replace the mesh pool later.
+!
+!-------------------------------------------------------------------------------
+
+module li_mesh
+
+   ! module dependencies
+   use mpas_dmpar
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_constants
+   use mpas_log
+
+!   use ocn_config
+
+   implicit none
+   private
+
+   !----------------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !----------------------------------------------------------------------------
+   !{{{
+
+   logical, public :: &
+      onSphere        ! this mesh is on the sphere
+
+   real (kind=RKIND), public :: &
+      sphereRadius    ! radius of sphere for spherical meshes
+
+   integer, public :: &! mesh, array sizes
+      nCells, &! total number of local (owned+halo) cells in primary
+      nEdges, &! total number of local edge midpoints
+      nVertices, &! total number of local cells in dual (cell vertices)
+      nCellsSolve, &! number of cells    owned by the local domain
+      nEdgesSolve, &! number of edges    owned by the local domain
+      nVerticesSolve, &! number of vertices owned by the local domain
+      maxEdges, &! largest number of edges any polygon has
+      maxEdges2, &! 2x the largest number of edges any polygon has
+      vertexDegree, &! number of cells or edges touching each vertex
+      nVertLevels, &! number of vertical levels
+!      nVertLevelsP1 ! number of vertical interfaces (levels plus one)
+
+   integer, public, dimension(:), allocatable :: &
+      nCellsHalo, &! number of owned+halo(n) cells in local domain
+      nEdgesHalo, &! number of owned+halo(n) edges in local domain
+      nVerticesHalo      ! number of owned+halo(n) vertices in local domain
+
+   integer, public, dimension(:), pointer :: &
+      nEdgesOnEdge, &! number of edges connected to each edge point
+      nEdgesOnCell, &! number of edges associated with each cell center
+!      minLevelCell, &! max ocean level at bottom of cell
+!      minLevelEdgeTop, &! max ocean level at top    of edge column
+!      minLevelEdgeBot, &! max ocean level at bottom of edge column
+!      minLevelVertexTop, &! max ocean level at top    of each vertex
+!      minLevelVertexBot, &! max ocean level at bottom of each vertex
+!      maxLevelCell, &! max ocean level at bottom of cell
+!      maxLevelEdgeTop, &! max ocean level at top    of edge column
+!      maxLevelEdgeBot, &! max ocean level at bottom of edge column
+!      maxLevelVertexTop, &! max ocean level at top    of each vertex
+!      maxLevelVertexBot, &! max ocean level at bottom of each vertex
+      indexToCellID, &! global ID of each local cell
+      indexToEdgeID, &! global ID of each local edge
+      indexToVertexID    ! global ID of each local vertex
+
+   integer, public, dimension(:, :), pointer :: &
+      edgesOnEdge, &! index of edges connected to each edge
+      cellsOnEdge, &! index of cells connected to each edge
+      verticesOnEdge, &! index of vertices connected to each edge
+      cellsOnCell, &! index of cells connected to each cell
+      edgesOnCell, &! index of edges connected to each cell
+      verticesOnCell, &! index of vertices connected to each cell
+      cellsOnVertex, &! index of cells connected to each vertex
+      edgesOnVertex, &! index of edges connected to each vertex
+      kiteIndexOnCell ! index of kite associated with each cell
+
+   real(kind=RKIND), public, dimension(:), pointer :: &
+      latCell, &! latitude  of cell centers
+      lonCell, &! longitude of cell centers
+      xCell, &! Cartesian x coord of cell center
+      yCell, &! Cartesian y coord of cell center
+      zCell, &! Cartesian z coord of cell center
+      latEdge, &! latitude  of edge
+      lonEdge, &! longitude of edge
+      xEdge, &! Cartesian x coord of edge
+      yEdge, &! Cartesian y coord of edge
+      zEdge, &! Cartesian z coord of edge
+      latVertex, &! latitude  of vertex
+      lonVertex, &! longitude of vertex
+      xVertex, &! Cartesian coord of vertex
+      yVertex, &! Cartesian y coord of vertex
+      zVertex, &! Cartesian z coord of vertex
+!      fEdge, &! Coriolus parameter at edge
+!      fVertex, &! Coriolus parameter at vertex
+!      fCell, &! Coriolus parameter at cell center
+      dcEdge, &! length of edge = dist between cells across edge
+      dvEdge, &! length of edge = dist between vertices along edge
+      areaCell, &! area of each cell
+      areaTriangle, &! area of each cell on dual grid
+!      bottomDepth, &! ocean bottom depth at each cell center
+!      refBottomDepth, &! ocean depth at bottom of cell for reference profile
+!      refBottomDepthTopOfCell, &! depth at top of cell for reference profile
+!      vertCoordMovementWeights, &! weights for distributing height perturb
+!      meshScalingDel2, &! mesh scaling factor for use in del2 diffusion
+!      meshScalingDel4, &! mesh scaling factor for use in del4 diffusion
+      meshDensity, &! density of mesh
+      angleEdge, &! angle the edge normal makes with local east
+!      distanceToCoast ! distance to nearest coast cell 
+
+   real(kind=RKIND), public, dimension(:), allocatable :: &
+      invAreaCell   ! inverse of area of each cell
+
+   ! Multiplicative masks and vectors for various conditions
+   real(kind=RKIND), public, dimension(:, :), allocatable :: &
+      edgeMask, &! mask to denote active edges    with depth
+      cellMask, &! mask to denote active cells    with depth
+      vertexMask, &! mask to denote active vertices with depth
+      boundaryEdge, &! mask for boundary edges    at each level
+      boundaryCell, &! mask for boundary cells    at each level
+      boundaryVertex, &! mask for boundary vertices at each level
+      edgeSignOnCell, &! sign of edge contributions to a cell
+      edgeSignOnVertex ! sign of edge contributions to a vertex
+
+   real(kind=RKIND), public, dimension(:, :), pointer :: &
+      weightsOnEdge, &! weights on each edge
+      kiteAreasOnVertex, &! real (vertexDegree nVertices)
+      edgeTangentVectors, &! tangent unit vector at edge
+      edgeNormalVectors, &! normal  unit vector at edge
+      localVerticalUnitVectors ! local unit vector iin vertical
+
+   real(kind=RKIND), public, dimension(:, :, :), pointer :: &
+      cellTangentPlane, &! two vectors defining tangent plane at cell center
+      coeffs_reconstruct  ! coeffs for reconstructing vectors at cell centers
+
+   ! Derived mesh values needed
+   real(kind=RKIND), public, dimension(:, :), allocatable :: &
+!      edgeAreaFractionOfCell
+
+   !}}}
+
+   !----------------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !----------------------------------------------------------------------------
+   !{{{
+
+   public :: &
+      li_meshCreate, &
+      li_meshUpdateFields, &
+      li_meshDestroy
+   !}}}
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+!
+!  li_meshCreate
+!
+!> \brief Creates the ocean mesh data structure on both host and device
+!> \author Rob Aulwes and Phil Jones
+!> \date   14 Jan 2020
+!> \details
+!> This module creates and maintains public ocean mesh data
+!> and ensures all mesh variables are copied to an accelerator device
+!> if needed.
+!
+!-----------------------------------------------------------------------
+
+   subroutine li_meshCreate(domain) !{{{
+
+      ! Input arguments
+
+      type(domain_type) :: &
+         domain                    !< [in] MPAS type to describe domain
+
+      ! Local variables
+
+      integer :: &
+         blockCount               ! counter for number of blocks
+
+      type(block_type), pointer :: &
+         block                    ! variables in current subblock
+
+      type(mpas_pool_type), pointer :: &
+         meshPool                 ! mesh variables in MPAS pool structure
+
+      real (kind=RKIND) :: &
+         maxDensityLocal, maxDensityGlobal ! temps for mesh density
+
+      ! scalar pointers for retrieval, but convert to actual scalars in struct
+      logical, pointer :: &
+         on_a_sphere
+
+      real (kind=RKIND), pointer :: &
+         sphere_radius
+
+      integer, pointer :: &! mesh dimensions
+         nCellsTmp, &!
+         nEdgesTmp, &!
+         nVerticesTmp, &!
+         maxEdgesTmp, &!
+         maxEdges2Tmp, &!
+         vertexDegreeTmp, &!
+         nVertLevelsTmp, &!
+         nVertLevelsP1Tmp !
+
+      ! temporary pointers for converting index arrays
+      integer, dimension(:), pointer :: &
+         nCellsArrayTmp, &
+         nEdgesArrayTmp, &
+         nVerticesArrayTmp
+
+      ! temporary pointers for converting masks
+      integer i, k, n          ! loop indices
+      integer, dimension(:, :), pointer :: &
+         edgeMaskTmp, &
+         vertexMaskTmp, &
+         cellMaskTmp, &
+         edgeSignOnCellTmp, &
+         edgeSignOnVertexTmp, &
+         boundaryEdgeTmp, &
+         boundaryVertexTmp, &
+         boundaryCellTmp
+
+      !***
+      !*** end of preamble, begin code
+      !***
+
+      ! We only support one block so test for condition here
+      blockCount = 0
+      block => domain%blocklist
+      do while (associated(block))
+         blockCount = blockCount + 1
+         if (blockCount > 1) then
+            call mpas_log_write( &
+               'li_meshCreate: more than one block no longer supported', &
+               MPAS_LOG_CRIT)
+         endif
+         block => block%next
+      end do
+
+      ! Reset to original block
+      block => domain%blocklist
+
+      ! retrieve the mpas mesh pool
+      call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
+
+      !-----------------------------------------------------------------
+      ! first set pointers/values for all mesh variables
+      ! many variables already initialized based on read of mesh file
+      !-----------------------------------------------------------------
+
+      ! set all mesh properties
+      call mpas_pool_get_config(meshPool, 'on_a_sphere', &
+                                           on_a_sphere)
+      call mpas_pool_get_config(meshPool, 'sphere_radius', &
+                                           sphere_radius)
+
+      ! set all mesh dimensions
+      call mpas_pool_get_dimension(meshPool, 'nCells', &
+                                   nCellsTmp)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', &
+                                   nEdgesTmp)
+      call mpas_pool_get_dimension(meshPool, 'nVertices', &
+                                   nVerticesTmp)
+      call mpas_pool_get_dimension(meshPool, 'maxEdges', &
+                                   maxEdgesTmp)
+      call mpas_pool_get_dimension(meshPool, 'maxEdges2', &
+                                   maxEdges2Tmp)
+      call mpas_pool_get_dimension(meshPool, 'vertexDegree', &
+                                   vertexDegreeTmp)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', &
+                                   nVertLevelsTmp)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', &
+                                   nVertLevelsP1Tmp)
+      call mpas_pool_get_dimension(meshPool, 'nCellsArray', &
+                                   nCellsArrayTmp)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesArray', &
+                                   nEdgesArrayTmp)
+      call mpas_pool_get_dimension(meshPool, 'nVerticesArray', &
+                                   nVerticesArrayTmp)
+
+      ! translate scalar pointers to scalars in new mesh structure
+      onSphere = on_a_sphere
+      sphereRadius = sphere_radius
+      maxEdges = maxEdgesTmp
+      maxEdges2 = maxEdges2Tmp
+      vertexDegree = vertexDegreeTmp
+      nVertLevels = nVertLevelsTmp
+      nVertLevelsP1 = nVertLevelsP1Tmp
+
+      ! convert previous index limits into new halo definitions
+      nCellsArray = nCellsTmp
+      nEdgesArray = nEdgesTmp
+      nVerticesArray = nVerticesTmp
+
+      n = size(nCellsArrayTmp)
+      allocate (nCellsHalo(n - 1))
+      nCellsSolve = nCellsArrayTmp(1)
+      do i = 2, n
+         nCellsHalo(i - 1) = nCellsArrayTmp(i)
+      end do
+
+      n = size(nEdgesArrayTmp)
+      allocate (nEdgesHalo(n - 1))
+      nEdgesSolve = nEdgesArrayTmp(1)
+      do i = 2, n
+         nEdgesHalo(i - 1) = nEdgesArrayTmp(i)
+      end do
+
+      n = size(nVerticesArrayTmp)
+      allocate (nVerticesHalo(n - 1))
+      nVerticesSolve = nVerticesArrayTmp(1)
+      do i = 2, n
+         nVerticesHalo(i - 1) = nVerticesArrayTmp(i)
+      end do
+
+      ! set pointers for a lot of connectivity info
+      call mpas_pool_get_array(meshPool, 'nEdgesOnEdge', &
+                               nEdgesOnEdge)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', &
+                               nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'minLevelCell', &
+                               minLevelCell)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
+                               minLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
+                               minLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
+                               minLevelVertexTop)
+      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
+                               minLevelVertexBot)
+      call mpas_pool_get_array(meshPool, 'maxLevelCell', &
+                               maxLevelCell)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
+                               maxLevelEdgeTop)
+      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', &
+                            maxLevelEdgeBot)
+      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
+                               maxLevelVertexTop)
+      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
+                               maxLevelVertexBot)
+      call mpas_pool_get_array(meshPool, 'indexToCellID', &
+                               indexToCellID)
+      call mpas_pool_get_array(meshPool, 'indexToEdgeID', &
+                               indexToEdgeID)
+      call mpas_pool_get_array(meshPool, 'indexToVertexID', &
+                               indexToVertexID)
+      call mpas_pool_get_array(meshPool, 'edgesOnEdge', &
+                               edgesOnEdge)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', &
+                               cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', &
+                               verticesOnEdge)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', &
+                               cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', &
+                               edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'verticesOnCell', &
+                               verticesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnVertex', &
+                               cellsOnVertex)
+      call mpas_pool_get_array(meshPool, 'edgesOnVertex', &
+                               edgesOnVertex)
+      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
+                               kiteIndexOnCell)
+
+      ! now set a number of physics and numerical properties of mesh
+      call mpas_pool_get_array(meshPool, 'latCell', &
+                               latCell)
+      call mpas_pool_get_array(meshPool, 'lonCell', &
+                               lonCell)
+      call mpas_pool_get_array(meshPool, 'xCell', &
+                               xCell)
+      call mpas_pool_get_array(meshPool, 'yCell', &
+                               yCell)
+      call mpas_pool_get_array(meshPool, 'zCell', &
+                               zCell)
+      call mpas_pool_get_array(meshPool, 'latEdge', &
+                               latEdge)
+      call mpas_pool_get_array(meshPool, 'lonEdge', &
+                               lonEdge)
+      call mpas_pool_get_array(meshPool, 'xEdge', &
+                               xEdge)
+      call mpas_pool_get_array(meshPool, 'yEdge', &
+                               yEdge)
+      call mpas_pool_get_array(meshPool, 'zEdge', &
+                               zEdge)
+      call mpas_pool_get_array(meshPool, 'latVertex', &
+                               latVertex)
+      call mpas_pool_get_array(meshPool, 'lonVertex', &
+                               lonVertex)
+      call mpas_pool_get_array(meshPool, 'xVertex', &
+                               xVertex)
+      call mpas_pool_get_array(meshPool, 'yVertex', &
+                               yVertex)
+      call mpas_pool_get_array(meshPool, 'zVertex', &
+                               zVertex)
+      call mpas_pool_get_array(meshPool, 'fEdge', &
+                               fEdge)
+      call mpas_pool_get_array(meshPool, 'fVertex', &
+                               fVertex)
+      call mpas_pool_get_array(meshPool, 'fCell', &
+                               fCell)
+      call mpas_pool_get_array(meshPool, 'dcEdge', &
+                               dcEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', &
+                               dvEdge)
+      call mpas_pool_get_array(meshPool, 'areaCell', &
+                               areaCell)
+      call mpas_pool_get_array(meshPool, 'areaTriangle', &
+                               areaTriangle)
+      call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
+                               weightsOnEdge)
+      call mpas_pool_get_array(meshPool, 'bottomDepth', &
+                               bottomDepth)
+      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
+                               refBottomDepth)
+      call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', &
+                               refBottomDepthTopOfCell)
+      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', &
+                               vertCoordMovementWeights)
+      call mpas_pool_get_array(meshPool, 'meshScalingDel2', &
+                               meshScalingDel2)
+      call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
+                               meshScalingDel4)
+      call mpas_pool_get_array(meshPool, 'meshDensity', &
+                               meshDensity)
+      call mpas_pool_get_array(meshPool, 'angleEdge', &
+                               angleEdge)
+      call mpas_pool_get_array(meshPool, 'distanceToCoast', &
+                               distanceToCoast)
+
+      call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
+                               weightsOnEdge)
+      call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', &
+                               kiteAreasOnVertex)
+      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', &
+                               edgeTangentVectors)
+      call mpas_pool_get_array(meshPool, 'edgeNormalVectors', &
+                               edgeNormalVectors)
+      call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors', &
+                               localVerticalUnitVectors)
+      call mpas_pool_get_array(meshPool, 'cellTangentPlane', &
+                               cellTangentPlane)
+      call mpas_pool_get_array(meshPool, 'coeffs_reconstruct', &
+                               coeffs_reconstruct)
+
+      ! For masks, we wish to convert to real multiplicative masks
+      ! so retrieve integer version pointers and allocate real masks
+      ! Once these are converted in Registry, we can eliminate this.
+      call mpas_pool_get_array(meshPool, 'edgeMask', &
+                               edgeMaskTmp)
+      call mpas_pool_get_array(meshPool, 'vertexMask', &
+                               vertexMaskTmp)
+      call mpas_pool_get_array(meshPool, 'cellMask', &
+                               cellMaskTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
+                               edgeSignOnCellTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
+                               edgeSignOnVertexTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
+                               boundaryEdgeTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
+                               boundaryVertexTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryCell', &
+                               boundaryCellTmp)
+
+      allocate ( &
+            edgeMask(nVertLevels, nEdgesArray+1), &
+            cellMask(nVertLevels, nCellsArray+1), &
+            vertexMask(nVertLevels, nVerticesArray+1), &
+            boundaryEdge(nVertLevels, nEdgesArray+1), &
+            boundaryCell(nVertLevels, nCellsArray+1), &
+            boundaryVertex(nVertLevels, nVerticesArray+1), &
+            edgeSignOnCell(maxEdges, nCellsArray+1), &
+            edgeSignOnVertex(maxEdges, nVerticesArray+1), &
+            invAreaCell(nCellsArray+1))
+
+      !-----------------------------------------------------------------
+      ! Now that all pointers are set and mesh variables allocated
+      ! we initialize other mesh quantities
+      !-----------------------------------------------------------------
+
+      ! Start by initializing vertical mesh, min/max cells and
+      ! sign/index fields
+      call li_meshVertCoordInit(domain)
+      call li_meshMinMaxLevel()
+      call li_meshSignIndexFields()
+
+      ! Compute max mesh density and mesh scaling
+      if (config_maxMeshDensity < 0.0_RKIND) then
+         maxDensityLocal = maxval(meshDensity)
+         call mpas_dmpar_max_real(domain%dminfo, maxDensityLocal, &
+                                                 maxDensityGlobal)
+         config_maxMeshDensity = maxDensityGlobal 
+      endif
+      call li_meshScaling()
+   
+      ! Routine calls above initialized the real mask arrays
+      ! so convert the meshPool integer pointers here
+      do n = 1, nCellsArray+1
+      do k = 1, nVertLevels
+         cellMaskTmp(k,n)     = nint(cellMask(k,n))
+         boundaryCellTmp(k,n) = nint(boundaryCell(k,n))
+      end do
+      end do
+
+      do n = 1, nCellsArray+1
+      do k = 1, maxEdges
+         edgeSignOnCellTmp(k, n) = nint(edgeSignOnCell(k,n))
+      end do
+      end do
+
+      do n = 1, nEdgesArray+1
+      do k = 1, nVertLevels
+         edgeMaskTmp(k, n) = nint(edgeMask(k,n))
+         boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
+      end do
+      end do
+
+      do n = 1, nVerticesArray+1
+      do k = 1, nVertLevels
+         vertexMaskTmp(k, n) = nint(vertexMask(k,n))
+         boundaryVertexTmp(k, n) = nint(boundaryVertex(k,n))
+      end do
+      end do
+
+      do n = 1, nVerticesArray+1
+      do k = 1, vertexDegree
+         edgeSignOnVertexTmp(k,n) = nint(edgeSignOnVertex(k,n))
+      end do
+      end do
+
+      ! Compute area weighting for some interpolation
+      call li_meshAreaWeights()
+      areaCell(nCellsArray+1) = -1.0e34_RKIND
+
+      ! Compute the inverse of areaCell
+      do n = 1, nCellsArray
+         invAreaCell(n) = 1.0_RKIND / areaCell(n)
+      end do
+      invAreaCell(nCellsArray+1) = 0.0_RKIND
+
+      !-----------------------------------------------------------------
+      ! Copy mesh data to accelerator if needed.
+      !-----------------------------------------------------------------
+
+         !$acc enter data copyin( &
+         !$acc                   onSphere,                 &
+         !$acc                   sphereRadius,             &
+         !$acc                   nCellsArray,                &
+         !$acc                   nEdgesArray,                &
+         !$acc                   nVerticesArray,             &
+         !$acc                   nCellsSolve,              &
+         !$acc                   nEdgesSolve,              &
+         !$acc                   nVerticesSolve,           &
+         !$acc                   maxEdges,                 &
+         !$acc                   maxEdges2,                &
+         !$acc                   vertexDegree,             &
+         !$acc                   nVertLevels,              &
+         !$acc                   nVertLevelsP1,            &
+         !$acc                   nEdgesHalo,               &
+         !$acc                   nCellsHalo,               &
+         !$acc                   nVerticesHalo,            &
+         !$acc                   nEdgesOnEdge,             &
+         !$acc                   nEdgesOnCell,             &
+         !$acc                   minLevelCell,             &
+         !$acc                   minLevelEdgeTop,          &
+         !$acc                   minLevelEdgeBot,          &
+         !$acc                   minLevelVertexTop,        &
+         !$acc                   minLevelVertexBot,        &
+         !$acc                   maxLevelCell,             &
+         !$acc                   maxLevelEdgeTop,          &
+         !$acc                   maxLevelEdgeBot,          &
+         !$acc                   maxLevelVertexTop,        &
+         !$acc                   maxLevelVertexBot,        &
+         !$acc                   indexToCellID,            &
+         !$acc                   indexToEdgeID,            &
+         !$acc                   indexToVertexID,          &
+         !$acc                   edgesOnEdge,              &
+         !$acc                   cellsOnEdge,              &
+         !$acc                   verticesOnEdge,           &
+         !$acc                   cellsOnCell,              &
+         !$acc                   edgesOnCell,              &
+         !$acc                   verticesOnCell,           &
+         !$acc                   cellsOnVertex,            &
+         !$acc                   edgesOnVertex,            &
+         !$acc                   kiteIndexOnCell,          &
+         !$acc                   latCell,                  &
+         !$acc                   lonCell,                  &
+         !$acc                   xCell,                    &
+         !$acc                   yCell,                    &
+         !$acc                   zCell,                    &
+         !$acc                   latEdge,                  &
+         !$acc                   lonEdge,                  &
+         !$acc                   xEdge,                    &
+         !$acc                   yEdge,                    &
+         !$acc                   zEdge,                    &
+         !$acc                   latVertex,                &
+         !$acc                   lonVertex,                &
+         !$acc                   xVertex,                  &
+         !$acc                   yVertex,                  &
+         !$acc                   zVertex,                  &
+         !$acc                   fEdge,                    &
+         !$acc                   fVertex,                  &
+         !$acc                   fCell,                    &
+         !$acc                   dcEdge,                   &
+         !$acc                   dvEdge,                   &
+         !$acc                   areaCell,                 &
+         !$acc                   invAreaCell,              &
+         !$acc                   areaTriangle,             &
+         !$acc                   bottomDepth,              &
+         !$acc                   refBottomDepth,           &
+         !$acc                   refBottomDepthTopOfCell,  &
+         !$acc                   vertCoordMovementWeights, &
+         !$acc                   meshScalingDel2,          &
+         !$acc                   meshScalingDel4,          &
+         !$acc                   meshDensity,              &
+         !$acc                   angleEdge,                &
+         !$acc                   distanceToCoast,          &
+         !$acc                   edgeMask,                 &
+         !$acc                   cellMask,                 &
+         !$acc                   vertexMask,               &
+         !$acc                   boundaryEdge,             &
+         !$acc                   boundaryCell,             &
+         !$acc                   boundaryVertex,           &
+         !$acc                   edgeSignOnCell,           &
+         !$acc                   edgeSignOnVertex,         &
+         !$acc                   weightsOnEdge,            &
+         !$acc                   kiteAreasOnVertex,        &
+         !$acc                   edgeTangentVectors,       &
+         !$acc                   edgeNormalVectors,        &
+         !$acc                   localVerticalUnitVectors, &
+         !$acc                   cellTangentPlane,         &
+         !$acc                   coeffs_reconstruct)
+
+!-------------------------------------------------------------------------------
+
+   end subroutine li_meshCreate !}}}
+
+!*******************************************************************************
+!
+!  li_meshDestroy
+!
+!> \brief Destroy mesh structure and removes from device
+!> \author Rob Aulwes and Phil Jones
+!> \date   14 Jan 2020
+!> \details
+!> This module removes the mesh variables from the device and invalidates
+!> all pointers in the mesh structure.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine li_meshDestroy(err) !{{{
+
+      ! Input variables
+
+      ! Since the ocnMesh is currently a public module variable, no inputs
+      ! here, but eventually may want to treat ocnMesh as a specific
+      ! instantiation instead and pass via args everywhere. If so, need an
+      ! input mesh here
+
+      ! Output variables
+
+      integer, intent(out) :: &
+         err                   ! returned error flag
+
+      ! Local variables
+
+      !***
+      !*** end of preamble, begin code
+      !***
+
+      err = 0
+
+      ! First remove data from the device. Must remove components first,
+      ! then remove the mesh type itself.
+
+      !$acc exit data delete(onSphere,          &
+      !$acc                  sphereRadius,      &
+      !$acc                  nCellsArray,         &
+      !$acc                  nEdgesArray,         &
+      !$acc                  nVerticesArray,      &
+      !$acc                  nCellsSolve,       &
+      !$acc                  nEdgesSolve,       &
+      !$acc                  nVerticesSolve,    &
+      !$acc                  maxEdges,          &
+      !$acc                  maxEdges2,         &
+      !$acc                  vertexDegree,      &
+      !$acc                  nVertLevels,       &
+      !$acc                  nVertLevelsP1,     &
+      !$acc                  nEdgesHalo,        &
+      !$acc                  nCellsHalo,        &
+      !$acc                  nVerticesHalo,     &
+      !$acc                  nEdgesOnEdge,      &
+      !$acc                  nEdgesOnCell,      &
+      !$acc                  minLevelCell,      &
+      !$acc                  minLevelEdgeTop,   &
+      !$acc                  minLevelEdgeBot,   &
+      !$acc                  minLevelVertexTop, &
+      !$acc                  minLevelVertexBot, &
+      !$acc                  maxLevelCell,      &
+      !$acc                  maxLevelEdgeTop,   &
+      !$acc                  maxLevelEdgeBot,   &
+      !$acc                  maxLevelVertexTop, &
+      !$acc                  maxLevelVertexBot, &
+      !$acc                  indexToCellID,     &
+      !$acc                  indexToEdgeID,     &
+      !$acc                  indexToVertexID,   &
+      !$acc                  edgesOnEdge,       &
+      !$acc                  cellsOnEdge,       &
+      !$acc                  verticesOnEdge,    &
+      !$acc                  cellsOnCell,       &
+      !$acc                  edgesOnCell,       &
+      !$acc                  verticesOnCell,    &
+      !$acc                  cellsOnVertex,     &
+      !$acc                  edgesOnVertex,     &
+      !$acc                  kiteIndexOnCell,   &
+      !$acc                  latCell,           &
+      !$acc                  lonCell,           &
+      !$acc                  xCell,             &
+      !$acc                  yCell,             &
+      !$acc                  zCell,             &
+      !$acc                  latEdge,           &
+      !$acc                  lonEdge,           &
+      !$acc                  xEdge,             &
+      !$acc                  yEdge,             &
+      !$acc                  zEdge,             &
+      !$acc                  latVertex,         &
+      !$acc                  lonVertex,         &
+      !$acc                  xVertex,           &
+      !$acc                  yVertex,           &
+      !$acc                  zVertex,           &
+      !$acc                  fEdge,             &
+      !$acc                  fVertex,           &
+      !$acc                  fCell,             &
+      !$acc                  dcEdge,            &
+      !$acc                  dvEdge,            &
+      !$acc                  areaCell,          &
+      !$acc                  invAreaCell,       &
+      !$acc                  areaTriangle,      &
+      !$acc                  bottomDepth,       &
+      !$acc                  refBottomDepth,    &
+      !$acc                  refBottomDepthTopOfCell, &
+      !$acc                  vertCoordMovementWeights, &
+      !$acc                  meshScalingDel2,   &
+      !$acc                  meshScalingDel4,   &
+      !$acc                  meshDensity,       &
+      !$acc                  angleEdge,         &
+      !$acc                  distanceToCoast,   &
+      !$acc                  edgeMask,          &
+      !$acc                  cellMask,          &
+      !$acc                  vertexMask,        &
+      !$acc                  boundaryEdge,      &
+      !$acc                  boundaryCell,      &
+      !$acc                  boundaryVertex,    &
+      !$acc                  edgeSignOnCell,    &
+      !$acc                  edgeSignOnVertex,  &
+      !$acc                  weightsOnEdge,     &
+      !$acc                  kiteAreasOnVertex, &
+      !$acc                  edgeTangentVectors,&
+      !$acc                  edgeNormalVectors, &
+      !$acc                  localVerticalUnitVectors, &
+      !$acc                  cellTangentPlane,  &
+      !$acc                  coeffs_reconstruct)
+
+      ! Reset all scalars to zero
+      onSphere  = .false.
+      sphereRadius = 0.0_RKIND
+      nCellsArray = 0
+      nEdgesArray = 0
+      nVerticesArray = 0
+      nCellsSolve = 0
+      nEdgesSolve = 0
+      nVerticesSolve = 0
+      maxEdges = 0
+      maxEdges2 = 0
+      vertexDegree = 0
+      nVertLevels = 0
+      nVertLevelsP1 = 0
+
+      ! Now nullify all pointers to invalidate fields
+      ! If this becomes the only mesh structure and mesh pool is eliminated,
+      !  then we will want to deallocate here instead of nullify.
+
+      nullify (nEdgesOnEdge, &
+               nEdgesOnCell, &
+               minLevelCell, &
+               minLevelEdgeTop, &
+               minLevelEdgeBot, &
+               minLevelVertexTop, &
+               minLevelVertexBot, &
+               maxLevelCell, &
+               maxLevelEdgeTop, &
+               maxLevelEdgeBot, &
+               maxLevelVertexTop, &
+               maxLevelVertexBot, &
+               indexToCellID, &
+               indexToEdgeID, &
+               indexToVertexID, &
+               edgesOnEdge, &
+               cellsOnEdge, &
+               verticesOnEdge, &
+               cellsOnCell, &
+               edgesOnCell, &
+               verticesOnCell, &
+               cellsOnVertex, &
+               edgesOnVertex, &
+               kiteIndexOnCell, &
+               latCell, &
+               lonCell, &
+               xCell, &
+               yCell, &
+               zCell, &
+               latEdge, &
+               lonEdge, &
+               xEdge, &
+               yEdge, &
+               zEdge, &
+               latVertex, &
+               lonVertex, &
+               xVertex, &
+               yVertex, &
+               zVertex, &
+               fEdge, &
+               fVertex, &
+               fCell, &
+               dcEdge, &
+               dvEdge, &
+               areaCell, &
+               areaTriangle, &
+               bottomDepth, &
+               refBottomDepth, &
+               refBottomDepthTopOfCell, &
+               vertCoordMovementWeights, &
+               meshScalingDel2, &
+               meshScalingDel4, &
+               meshDensity, &
+               angleEdge, &
+               distanceToCoast, &
+               weightsOnEdge, &
+               kiteAreasOnVertex, &
+               edgeTangentVectors, &
+               edgeNormalVectors, &
+               localVerticalUnitVectors, &
+               cellTangentPlane, &
+               coeffs_reconstruct)
+
+#ifdef MPAS_OPENACC
+      !$acc exit data delete(edgeAreaFractionOfCell)
+#endif
+      deallocate (nEdgesHalo, &
+                  nCellsHalo, &
+                  nVerticesHalo, &
+                  edgeMask, &
+                  cellMask, &
+                  vertexMask, &
+                  boundaryEdge, &
+                  boundaryCell, &
+                  boundaryVertex, &
+                  edgeSignOnCell, &
+                  edgeSignOnVertex, &
+                  edgeAreaFractionOfCell, &
+                  invAreaCell)
+
+!-------------------------------------------------------------------------------
+
+   end subroutine li_meshDestroy !}}}
+
+!*******************************************************************************
+!
+!  li_meshUpdateFields
+!
+!> \brief Updates fields on an accelerator device
+!> \author Rob Aulwes and Phil Jones
+!> \date   14 Jan 2020
+!> \details
+!> Many mesh fields are computed or input later in the initialization
+!> phase after the meshCreate call. This routine updates these fields
+!> on the device. The routine is not needed if the original mesh pool is
+!> eliminated and this mesh becomes the only mesh structure and can be
+!> updated directly.
+!
+!-------------------------------------------------------------------------------
+
+   subroutine li_meshUpdateFields(domain) !{{{
+
+      ! Input arguments
+
+      type(domain_type) :: &
+         domain                    !< [in] MPAS type to describe domain
+
+      ! Local variables
+
+      type(block_type), pointer :: &
+         block                    ! variables in current subblock
+
+      type(mpas_pool_type), pointer :: &
+         meshPool                 ! mesh variables in MPAS pool structure
+
+      ! temporary pointers for converting masks
+      integer k, n          ! loop indices
+      integer, dimension(:, :), pointer :: &
+         edgeMaskTmp, &
+         vertexMaskTmp, &
+         cellMaskTmp, &
+         edgeSignOnCellTmp, &
+         edgeSignOnVertexTmp, &
+         boundaryEdgeTmp, &
+         boundaryVertexTmp, &
+         boundaryCellTmp
+
+      !***
+      !*** end of preamble, begin code
+      !***
+
+      ! already check during create that there should only be one block
+      block => domain%blocklist
+
+      ! retrieve the mpas mesh pool
+      call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
+
+      ! Mesh dimensions should not have changed so no updates
+
+      ! Because these fields are pointers into meshPool, they do not need
+      ! to be updated - they capture the updates automatically.
+      !call mpas_pool_get_array(meshPool, 'nEdgesOnEdge',      &
+      !                                    nEdgesOnEdge)
+      !call mpas_pool_get_array(meshPool, 'nEdgesOnCell',      &
+      !                                    nEdgesOnCell)
+      !call mpas_pool_get_array(meshPool, 'maxLevelCell',      &
+      !                                    maxLevelCell)
+      !call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop',   &
+      !                                    maxLevelEdgeTop)
+      !call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot',   &
+      !                                    maxLevelEdgeBot)
+      !call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
+      !                                    maxLevelVertexTop)
+      !call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
+      !                                    maxLevelVertexBot)
+      !call mpas_pool_get_array(meshPool, 'indexToCellID',     &
+      !                                    indexToCellID)
+      !call mpas_pool_get_array(meshPool, 'indexToEdgeID',     &
+      !                                    indexToEdgeID)
+      !call mpas_pool_get_array(meshPool, 'indexToVertexID',   &
+      !                                    indexToVertexID)
+      !call mpas_pool_get_array(meshPool, 'edgesOnEdge',       &
+      !                                    edgesOnEdge)
+      !call mpas_pool_get_array(meshPool, 'cellsOnEdge',       &
+      !                                    cellsOnEdge)
+      !call mpas_pool_get_array(meshPool, 'verticesOnEdge',    &
+      !                                    verticesOnEdge)
+      !call mpas_pool_get_array(meshPool, 'cellsOnCell',       &
+      !                                    cellsOnCell)
+      !call mpas_pool_get_array(meshPool, 'edgesOnCell',       &
+      !                                    edgesOnCell)
+      !call mpas_pool_get_array(meshPool, 'verticesOnCell',    &
+      !                                    verticesOnCell)
+      !call mpas_pool_get_array(meshPool, 'cellsOnVertex',     &
+      !                                    cellsOnVertex)
+      !call mpas_pool_get_array(meshPool, 'edgesOnVertex',     &
+      !                                    edgesOnVertex)
+      !call mpas_pool_get_array(meshPool, 'kiteIndexOnCell',   &
+      !                                    kiteIndexOnCell)
+
+      ! these are also pointers that do not require updating
+      ! now set a number of physics and numerical properties of mesh
+      !call mpas_pool_get_array(meshPool, 'latCell',           &
+      !                                    latCell)
+      !call mpas_pool_get_array(meshPool, 'lonCell',           &
+      !                                    lonCell)
+      !call mpas_pool_get_array(meshPool, 'xCell',             &
+      !                                    xCell)
+      !call mpas_pool_get_array(meshPool, 'yCell',             &
+      !                                    yCell)
+      !call mpas_pool_get_array(meshPool, 'zCell',             &
+      !                                    zCell)
+      !call mpas_pool_get_array(meshPool, 'latEdge',           &
+      !                                    latEdge)
+      !call mpas_pool_get_array(meshPool, 'lonEdge',           &
+      !                                    lonEdge)
+      !call mpas_pool_get_array(meshPool, 'xEdge',             &
+      !                                    xEdge)
+      !call mpas_pool_get_array(meshPool, 'yEdge',             &
+      !                                    yEdge)
+      !call mpas_pool_get_array(meshPool, 'zEdge',             &
+      !                                    zEdge)
+      !call mpas_pool_get_array(meshPool, 'latVertex',         &
+      !                                    latVertex)
+      !call mpas_pool_get_array(meshPool, 'lonVertex',         &
+      !                                    lonVertex)
+      !call mpas_pool_get_array(meshPool, 'xVertex',           &
+      !                                    xVertex)
+      !call mpas_pool_get_array(meshPool, 'yVertex',           &
+      !                                    yVertex)
+      !call mpas_pool_get_array(meshPool, 'zVertex',           &
+      !                                    zVertex)
+      !call mpas_pool_get_array(meshPool, 'fEdge',             &
+      !                                    fEdge)
+      !call mpas_pool_get_array(meshPool, 'fVertex',           &
+      !                                    fVertex)
+      !call mpas_pool_get_array(meshPool, 'fCell',             &
+      !                                    fCell)
+      !call mpas_pool_get_array(meshPool, 'dcEdge',            &
+      !                                    dcEdge)
+      !call mpas_pool_get_array(meshPool, 'dvEdge',            &
+      !                                    dvEdge)
+      !call mpas_pool_get_array(meshPool, 'areaCell',          &
+      !                                    areaCell)
+      !call mpas_pool_get_array(meshPool, 'areaTriangle',      &
+      !                                    areaTriangle)
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge',     &
+      !                                    weightsOnEdge)
+      !call mpas_pool_get_array(meshPool, 'bottomDepth',       &
+      !                                    bottomDepth)
+      !call mpas_pool_get_array(meshPool, 'refBottomDepth',    &
+      !                                    refBottomDepth)
+      !call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell',   &
+      !                                    refBottomDepthTopOfCell)
+      !call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights',  &
+      !                                    vertCoordMovementWeights)
+      !call mpas_pool_get_array(meshPool, 'meshScalingDel2',   &
+      !                                    meshScalingDel2)
+      !call mpas_pool_get_array(meshPool, 'meshScalingDel4',   &
+      !                                    meshScalingDel4)
+      !call mpas_pool_get_array(meshPool, 'meshDensity',       &
+      !                                    meshDensity)
+      !call mpas_pool_get_array(meshPool, 'angleEdge',         &
+      !                                    angleEdge)
+      !call mpas_pool_get_array(meshPool, 'distanceToCoast',   &
+      !                                    distanceToCoast)
+      !
+      !call mpas_pool_get_array(meshPool, 'weightsOnEdge',             &
+      !                                    weightsOnEdge)
+      !call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex',         &
+      !                                    kiteAreasOnVertex)
+      !call mpas_pool_get_array(meshPool, 'edgeTangentVectors',        &
+      !                                    edgeTangentVectors)
+      !call mpas_pool_get_array(meshPool, 'edgeNormalVectors',         &
+      !                                    edgeNormalVectors)
+      !call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors',  &
+      !                                    localVerticalUnitVectors)
+      !call mpas_pool_get_array(meshPool, 'cellTangentPlane',          &
+      !                                    cellTangentPlane)
+      !call mpas_pool_get_array(meshPool, 'coeffs_reconstruct',        &
+      !                                    coeffs_reconstruct)
+
+      ! For masks, we converted to real masks, so need to recompute for
+      ! updated values. Probably only the edgeSign masks need updating, but
+      ! do them all to be sure.
+      call mpas_pool_get_array(meshPool, 'edgeMask', &
+                               edgeMaskTmp)
+      call mpas_pool_get_array(meshPool, 'vertexMask', &
+                               vertexMaskTmp)
+      call mpas_pool_get_array(meshPool, 'cellMask', &
+                               cellMaskTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
+                               edgeSignOnCellTmp)
+      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
+                               edgeSignOnVertexTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryEdge', &
+                               boundaryEdgeTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryVertex', &
+                               boundaryVertexTmp)
+      call mpas_pool_get_array(meshPool, 'boundaryCell', &
+                               boundaryCellTmp)
+
+      do n = 1, nCellsArray+1
+      do k = 1, nVertLevels
+         cellMask(k, n) = real(cellMaskTmp(k, n), RKIND)
+         boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
+      end do
+      end do
+
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+      ! pointer needs to be udpated
+      do n = 1, nCellsArray+1
+      do k = 1, maxEdges
+         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
+      end do
+      end do
+
+      do n = 1, nEdgesArray+1
+      do k = 1, nVertLevels
+         edgeMask(k, n) = real(edgeMaskTmp(k, n), RKIND)
+         boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
+      end do
+      end do
+
+      do n = 1, nVerticesArray+1
+      do k = 1, nVertLevels
+         vertexMask(k, n) = real(vertexMaskTmp(k, n), RKIND)
+         boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
+      end do
+      end do
+
+      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
+      ! pointer needs to be udpated
+      do n = 1, nVerticesArray+1
+      do k = 1, vertexDegree
+         edgeSignOnVertexTmp(k, n) = &
+            int(edgeSignOnVertex(k, n))
+      end do
+      end do
+
+      ! Go ahead and update all fields on device to be safe.
+      ! NOTE: if we end up computing some fields on the device during
+      !       init, the update must go the opposite direction (update host)
+
+      !$acc update device(onSphere,                 &
+      !$acc               sphereRadius,             &
+      !$acc               nCellsArray,                &
+      !$acc               nEdgesArray,                &
+      !$acc               nVerticesArray,             &
+      !$acc               nCellsSolve,              &
+      !$acc               nEdgesSolve,              &
+      !$acc               nVerticesSolve,           &
+      !$acc               maxEdges,                 &
+      !$acc               maxEdges2,                &
+      !$acc               vertexDegree,             &
+      !$acc               nVertLevels,              &
+      !$acc               nVertLevelsP1,            &
+      !$acc               nEdgesHalo,               &
+      !$acc               nCellsHalo,               &
+      !$acc               nVerticesHalo,            &
+      !$acc               nEdgesOnEdge,             &
+      !$acc               nEdgesOnCell,             &
+      !$acc               minLevelCell,             &
+      !$acc               minLevelEdgeTop,          &
+      !$acc               minLevelEdgeBot,          &
+      !$acc               minLevelVertexTop,        &
+      !$acc               minLevelVertexBot,        &
+      !$acc               maxLevelCell,             &
+      !$acc               maxLevelEdgeTop,          &
+      !$acc               maxLevelEdgeBot,          &
+      !$acc               maxLevelVertexTop,        &
+      !$acc               maxLevelVertexBot,        &
+      !$acc               indexToCellID,            &
+      !$acc               indexToEdgeID,            &
+      !$acc               indexToVertexID,          &
+      !$acc               edgesOnEdge,              &
+      !$acc               cellsOnEdge,              &
+      !$acc               verticesOnEdge,           &
+      !$acc               cellsOnCell,              &
+      !$acc               edgesOnCell,              &
+      !$acc               verticesOnCell,           &
+      !$acc               cellsOnVertex,            &
+      !$acc               edgesOnVertex,            &
+      !$acc               kiteIndexOnCell,          &
+      !$acc               latCell,                  &
+      !$acc               lonCell,                  &
+      !$acc               xCell,                    &
+      !$acc               yCell,                    &
+      !$acc               zCell,                    &
+      !$acc               latEdge,                  &
+      !$acc               lonEdge,                  &
+      !$acc               xEdge,                    &
+      !$acc               yEdge,                    &
+      !$acc               zEdge,                    &
+      !$acc               latVertex,                &
+      !$acc               lonVertex,                &
+      !$acc               xVertex,                  &
+      !$acc               yVertex,                  &
+      !$acc               zVertex,                  &
+      !$acc               fEdge,                    &
+      !$acc               fVertex,                  &
+      !$acc               fCell,                    &
+      !$acc               dcEdge,                   &
+      !$acc               dvEdge,                   &
+      !$acc               areaCell,                 &
+      !$acc               invAreaCell,              &
+      !$acc               areaTriangle,             &
+      !$acc               bottomDepth,              &
+      !$acc               refBottomDepth,           &
+      !$acc               refBottomDepthTopOfCell,  &
+      !$acc               vertCoordMovementWeights, &
+      !$acc               meshScalingDel2,          &
+      !$acc               meshScalingDel4,          &
+      !$acc               meshDensity,              &
+      !$acc               angleEdge,                &
+      !$acc               distanceToCoast,          &
+      !$acc               edgeMask,                 &
+      !$acc               cellMask,                 &
+      !$acc               vertexMask,               &
+      !$acc               boundaryEdge,             &
+      !$acc               boundaryCell,             &
+      !$acc               boundaryVertex,           &
+      !$acc               edgeSignOnCell,           &
+      !$acc               edgeSignOnVertex,         &
+      !$acc               weightsOnEdge,            &
+      !$acc               kiteAreasOnVertex,        &
+      !$acc               edgeTangentVectors,       &
+      !$acc               edgeNormalVectors,        &
+      !$acc               localVerticalUnitVectors, &
+      !$acc               cellTangentPlane,         &
+      !$acc               coeffs_reconstruct)
+
+!-------------------------------------------------------------------------------
+
+   end subroutine li_meshUpdateFields !}}}
+
+!***********************************************************************
+!
+!  routine ocn_MeshMinMaxLevel
+!
+!> \brief  initialize max level and boundary mask variables
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This routine initializes max level and boundary mask variables
+!
+!-----------------------------------------------------------------------
+
+   subroutine meshMinMaxLevel()!{{{
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, iEdge, iVertex, &! loop indices for cells,edges,vertices
+         i, k                    ! loop indices for neighbors, vertical
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! minLevelEdgeTop is the minimum (shallowest) of surrounding cells
+      ! if the water column is dry, set minLevelCell outside of bounds
+      ! to prevent dry cells from determining minimum
+      do iCell = 1, nCellsArray+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell)=nVertLevels+1 
+      end do
+      do iEdge = 1, nEdgesArray
+         minLevelEdgeTop(iEdge) = &
+            min( minLevelCell(cellsOnEdge(1,iEdge)), &
+                 minLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+      minLevelEdgeTop(nEdgesArray+1) = 0
+
+      ! minLevelEdgeBot is the maximum (deepest) of surrounding cells
+      ! prevent dry cells from determining maximum
+      do iCell = 1, nCellsArray+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
+      end do
+      do iEdge = 1, nEdgesArray
+         minLevelEdgeBot(iEdge) = &
+            max( minLevelCell(cellsOnEdge(1,iEdge)), &
+                 minLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+      minLevelEdgeBot(nEdgesArray+1) = 0
+
+      ! minLevelVertexBot is the maximum (deepest) of surrounding cells
+      do iVertex = 1,nVerticesArray
+         minLevelVertexBot(iVertex) = &
+              minLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            minLevelVertexBot(iVertex) = &
+               max( minLevelVertexBot(iVertex), &
+                    minLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+      minLevelVertexBot(nVerticesArray+1) = 0
+
+      ! minLevelVertexTop is the minimum (shallowest) of surrounding cells
+      ! if the water column is dry, set minLevelCell outside of bounds
+      ! to prevent dry cells from determining minimum
+      do iCell = 1, nCellsArray+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
+      end do
+      do iVertex = 1,nVerticesArray
+         minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            minLevelVertexTop(iVertex) = &
+               min( minLevelVertexTop(iVertex), &
+                    minLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+      minLevelVertexTop(nVerticesArray+1) = 0
+
+      ! if the water column is dry, set minLevelCell = 1
+      do iCell = 1, nCellsArray+1
+         if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1
+      end do
+      
+      ! maxLevelEdgeTop is the minimum (shallowest) of surrounding cells
+      do iEdge = 1, nEdgesArray
+         maxLevelEdgeTop(iEdge) = &
+            min( maxLevelCell(cellsOnEdge(1,iEdge)), &
+                 maxLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+      maxLevelEdgeTop(nEdgesArray+1) = 0
+
+      ! maxLevelEdgeBot is the maximum (deepest) of surrounding cells
+      do iEdge = 1, nEdgesArray
+         maxLevelEdgeBot(iEdge) = &
+            max( maxLevelCell(cellsOnEdge(1,iEdge)), &
+                 maxLevelCell(cellsOnEdge(2,iEdge)) )
+      end do
+      maxLevelEdgeBot(nEdgesArray+1) = 0
+
+      ! maxLevelVertexBot is the maximum (deepest) of surrounding cells
+      do iVertex = 1,nVerticesArray
+         maxLevelVertexBot(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            maxLevelVertexBot(iVertex) = &
+               max( maxLevelVertexBot(iVertex), &
+                    maxLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+      maxLevelVertexBot(nVerticesArray+1) = 0
+
+      ! maxLevelVertexTop is the minimum (shallowest) of surrounding cells
+      do iVertex = 1,nVerticesArray
+         maxLevelVertexTop(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
+         do i = 2, vertexDegree
+            maxLevelVertexTop(iVertex) = &
+               min( maxLevelVertexTop(iVertex), &
+                    maxLevelCell(cellsOnVertex(i,iVertex)))
+         end do
+      end do
+      maxLevelVertexTop(nVerticesArray+1) = 0
+
+      ! set boundary edge
+      boundaryEdge(:,1:nEdgesArray+1)=1.0_RKIND
+      edgeMask(:,1:nEdgesArray+1)=0.0_RKIND
+
+      do iEdge = 1, nEdgesArray
+      do k= minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
+         boundaryEdge(k,iEdge)=0.0_RKIND
+         edgeMask(k,iEdge)=1.0_RKIND
+      end do
+      end do
+
+      ! Find cells and vertices that have an edge on the boundary
+      boundaryCell(:,1:nCellsArray+1) = 0.0_RKIND
+      cellMask(:,1:nCellsArray+1) = 0.0_RKIND
+      boundaryVertex(:,1:nVerticesArray+1) = 0.0_RKIND
+      vertexMask(:,1:nVerticesArray+1) = 0.0_RKIND
+
+      do iEdge = 1, nEdgesArray
+      do k = 1, nVertLevels
+         if (boundaryEdge(k,iEdge) == 1) then
+            boundaryCell(k,cellsOnEdge(1,iEdge)) = 1.0_RKIND
+            boundaryCell(k,cellsOnEdge(2,iEdge)) = 1.0_RKIND
+            boundaryVertex(k,verticesOnEdge(1,iEdge)) = 1.0_RKIND
+            boundaryVertex(k,verticesOnEdge(2,iEdge)) = 1.0_RKIND
+         endif
+      end do
+      end do
+
+      do iCell = 1, nCellsArray
+      do k = 1, nVertLevels
+         if ( minLevelCell(iCell) <= k .and. &
+              maxLevelCell(iCell) >= k ) then
+            cellMask(k, iCell) = 1.0_RKIND
+         end if
+      end do
+      end do
+
+      do iVertex = 1, nVerticesArray
+      do k = 1, nVertLevels
+         if ( minLevelVertexTop(iVertex) <= k .and. &
+              maxLevelVertexBot(iVertex) >= k ) then
+            vertexMask(k, iVertex) = 1.0_RKIND
+         end if
+      end do
+      end do
+
+      ! Note: We do not update halos on maxLevel* variables.  We want
+      ! the outside edge of a halo to be zero on each processor.
+
+   !--------------------------------------------------------------------
+
+   end subroutine meshMinMaxLevel !}}}
+
+!***********************************************************************
+!
+!  routine li_meshSignIndexFields
+!
+!> \brief   set up sign and index fields
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This routine initializes edgeSignOnCell, edgeSignOnVertex, and
+!>  kiteIndexOnCell.
+!
+!-----------------------------------------------------------------------
+
+   subroutine meshSignIndexFields()!{{{
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+      integer :: iCell, iEdge, iVertex, i, j
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Initialize to zero
+      edgeSignOnCell   = 0.0_RKIND
+      edgeSignOnVertex = 0.0_RKIND
+      kiteIndexOnCell  = 0
+
+      do iCell = 1, nCellsArray
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            iVertex = verticesOnCell(i, iCell)
+
+            ! Vector points from cell 1 to cell 2
+            if (iCell == cellsOnEdge(1, iEdge)) then
+               edgeSignOnCell(i, iCell) = -1.0_RKIND
+            else
+               edgeSignOnCell(i, iCell) =  1.0_RKIND
+            end if
+
+            do j = 1, vertexDegree
+               if (cellsOnVertex(j,iVertex) == iCell) then
+                  kiteIndexOnCell(i,iCell) = j
+               end if
+            end do
+         end do
+      end do
+
+      do iVertex = 1, nVerticesArray
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+
+            ! Vector points from vertex 1 to vertex 2
+            if (iVertex == verticesOnEdge(1,iEdge)) then
+               edgeSignOnVertex(i,iVertex) = -1.0_RKIND
+            else
+               edgeSignOnVertex(i,iVertex) =  1.0_RKIND
+            end if
+         end do
+      end do
+
+   !--------------------------------------------------------------------
+
+   end subroutine meshSignIndexFields !}}}
+
+!***********************************************************************
+!
+!  routine li_meshVertCoordInit
+!
+!> \brief  initialize vertical coordinate variables
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This routine initializes vertical coordinate variables, including
+!>  zlevel-type variables and adjusted initial conditions for partial
+!>  bottom cells.
+!
+!-----------------------------------------------------------------------
+
+   subroutine meshVertCoordInit(domain)!{{{
+
+      !-----------------------------------------------------------------
+      ! Input/output variables
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain !< [inout] ocean state
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      type (block_type), pointer :: block ! all ocn data in a block
+
+      type (mpas_pool_type), pointer :: &
+         verticalMeshPool, &! vertical mesh data
+         statePool,        &! ocean state (layer thickness)
+         forcingPool        ! forcing data (land ice mask)
+
+      integer :: &
+         iCell, k,         &! loop indices for cell, vertical loops
+         kmin, kmax         ! min, max active levels in column
+
+      logical :: &
+         consistentSSH,    &! flag if SSH consistent with depth
+         landIceFlag,      &! flag if land ice mask exists
+         checkSSH           ! flag for checking SSH in cell column
+
+      real (kind=RKIND) &
+         thickDepth         ! depth based on sum of layer thicknesses
+
+      integer, dimension(:), pointer :: &
+         landIceMask        ! land ice mask
+
+      real (kind=RKIND), dimension(:), pointer :: &
+         refZMid,                  &! reference depth at mid-layer
+         refLayerThickness          ! reference profile layer thickness
+
+      real (kind=RKIND), dimension(:,:), pointer :: &
+         layerThickness     ! current layer thickness
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Extract pools from domain
+      block => domain % blocklist
+      call mpas_pool_get_subpool(block%structs, 'state', statePool)
+      call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
+                                                 verticalMeshPool)
+      call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
+
+      ! Extract needed variables from pools
+      call mpas_pool_get_array(statePool, 'layerThickness', &
+                                           layerThickness, 1)
+
+      call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
+      call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', &
+                                                  refLayerThickness)
+
+      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
+      if (associated(landIceMask)) then
+         landIceFlag = .true.  ! ice shelves
+      else
+         landIceFlag = .false. ! ice shelves
+      endif
+
+      ! Initialize reference z coordinates based on refBottomDepth
+      refBottomDepthTopOfCell(1) = 0.0_RKIND
+      do k = 1, nVertLevels
+         refBottomDepthTopOfCell(k+1) = refBottomDepth(k)
+         refLayerThickness(k) = refBottomDepth(k) - &
+                                refBottomDepthTopOfCell(k)
+         refZMid(k) = - refBottomDepthTopOfCell(k) - &
+                        refLayerThickness(k)/2.0_RKIND
+      end do
+
+      ! Initialization of vertCoordMovementWeights. 
+      ! This determines how SSH perturbations are distributed throughout
+      ! the column. Check for invalid choice of vert coord movement.
+
+      call mpas_log_write(' Vertical coordinate movement is: ' // &
+                          trim(config_vert_coord_movement))
+
+
+      select case (trim(config_vert_coord_movement))
+      case ('fixed')
+
+         vertCoordMovementWeights = 0.0_RKIND
+         vertCoordMovementWeights(1) = 1.0_RKIND
+
+      case ('uniform_stretching')
+
+         vertCoordMovementWeights = 1.0_RKIND
+
+      case ('tapered')
+
+         ! Set weight tapering:
+         !  1.0 shallower than config_vert_taper_weight_depth_1
+         !  linear in between
+         !  0.0 deeper than config_vert_taper_weight_depth_2
+         do k = 1, nVertLevels
+            vertCoordMovementWeights(k) = 1.0_RKIND + &
+                 (refZMid(k) + config_vert_taper_weight_depth_1) / &
+                 (config_vert_taper_weight_depth_2 - &
+                  config_vert_taper_weight_depth_1)
+            ! limit range to (0,1)
+            vertCoordMovementWeights(k) = max( 0.0_RKIND, &
+                      min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
+         end do
+
+      case ('impermeable_interfaces')
+
+         ! weights are never used, no init needed
+
+      case ('user_specified')
+
+         ! weights should be input? probably should check
+
+      case default
+
+         call mpas_log_write( &
+            'Incorrect choice of config_vert_coord_movement.', &
+             MPAS_LOG_CRIT)
+
+      end select
+
+      !-----------------------------------------------------------------
+      ! Check consistency and validity of options
+      !-----------------------------------------------------------------
+
+      ! SSH consistency
+      if (config_check_ssh_consistency) then
+
+         ! Check if abs(ssh)>20m.  If so, print warning.
+         consistentSSH = .true.
+         do iCell = 1,nCellsArray
+
+            ! Only check for open ocean when land ice is being used
+            checkSSH = .true.
+            if (landIceFlag) then
+               if (landIceMask(iCell) /= 0) checkSSH = .false.
+            endif
+
+            ! Check whether thickness is consistent with bottom depth
+            if (checkSSH) then
+               kmin = minLevelCell(iCell)
+               kmax = maxLevelCell(iCell)
+
+               thickDepth = sum(layerThickness(kmin:kmax,iCell))
+
+               if (abs(thickDepth - bottomDepth(iCell)) > 20.0_RKIND) then
+                  consistentSSH = .false.
+
+                  call mpas_log_write( &
+                     ' Warning: Sea surface height outside of acceptable range (20m)', &
+                     MPAS_LOG_ERR)
+                  call mpas_log_write( &
+                     ' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
+                     intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
+                     realArgs=(/ bottomDepth(iCell), thickDepth /) )
+               endif ! depth diff check
+            endif ! checkSSH
+         end do ! cell loop
+
+         if (.not. consistentSSH) call mpas_log_write( &
+            'Warning: SSH not consistent - ' // &
+            'initial layerThickness does not match bottomDepth.')
+
+      endif ! config_check_ssh_consistency
+
+      ! Z-level consistency
+      if (config_check_zlevel_consistency) then
+         do iCell = 1,nCellsArray
+            ! Check that bottomDepth and maxLevelCell match.  Some
+            ! older meshs do not have the bottomDepth variable.
+            kmax = maxLevelCell(iCell)
+            if (bottomDepth(iCell) > refBottomDepth(kmax) .or. &
+                bottomDepth(iCell) < refBottomDepthTopOfCell(kmax)) then
+               call mpas_log_write( &
+                 ' fatal error: bottomDepth and maxLevelCell do not match:',  &
+                 MPAS_LOG_ERR)
+               call mpas_log_write( &
+                 ' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r', &
+                 intArgs=(/iCell, kmax /), &
+                 realArgs=(/ bottomDepth(iCell) /) )
+            endif
+         enddo ! cell loop
+      endif ! check_zlevel_consistency
+
+      ! pressure gradient compatibility
+      if (config_vert_coord_movement /= 'impermeable_interfaces' .and. &
+          config_pressure_gradient_type == 'MontgomeryPotential') then
+         call mpas_log_write( 'Incompatible choice of ' // &
+            'impermeable vertical interfaces and Montgomery Potential',&
+            MPAS_LOG_CRIT)
+      end if
+
+      ! barotropic filter mode compatibility
+      if (config_filter_btr_mode .and. &
+          config_vert_coord_movement /= 'fixed')then
+         call mpas_log_write( &
+          'filter_btr_mode has only been tested with ' // &
+          'config_vert_coord_movement=fixed.', &
+          MPAS_LOG_CRIT)
+      endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine meshVertCoordInit !}}}
+
+!***********************************************************************
+!
+!  routine li_meshAreaWeights
+!
+!> \brief  set up area weighting
+!> \author Mark Petersen
+!> \date   June 2020
+!> \details
+!>  This routine initializes edgeAreaFractionOfCell which is defined as
+!>  the fractional area of cell iCell encompassed by the triangle with
+!>  edge iEdge connected to the cell center of cell iCell. On a perfect
+!>  planar hex mesh this is always 1/6. This weighting is used to
+!>  interpolate scalars from edges to cell centers.
+!>  Use 2*edgeAreaFractionOfCell to interpolate normal vectors at
+!>  edges to vector norms at cell centers.
+!
+!-----------------------------------------------------------------------
+
+   subroutine meshAreaWeights()!{{{
+
+      !-----------------------------------------------------------------
+      ! Local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iCell, iEdge, &! cell, edge addresses
+         i,            &! edge on cell index
+         ierr           ! internal error flag
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      ! Allocate space
+      allocate (edgeAreaFractionOfCell(maxEdges,nCellsArray), STAT=ierr)
+#ifdef MPAS_OPENACC
+      !$acc enter data create(edgeAreaFractionOfCell)
+#endif
+      if (ierr /= 0) call mpas_log_write( &
+         'Error allocating edgeAreaFractionOfCell in li_mesh', &
+          MPAS_LOG_CRIT)
+
+      do iCell = 1, nCellsArray
+      do i = 1, nEdgesOnCell(iCell)
+         iEdge = edgesOnCell(i, iCell)
+         edgeAreaFractionOfCell(i, iCell) = 0.25_RKIND* &
+               dcEdge(iEdge)*dvEdge(iEdge)/areaCell(iCell)
+      end do
+      end do
+#ifdef MPAS_OPENACC
+      !$acc update device(edgeAreaFractionOfCell)
+#endif
+
+   !--------------------------------------------------------------------
+
+   end subroutine meshAreaWeights !}}}
+
+!***********************************************************************
+!
+!  routine li_meshScaling
+!
+!> \brief  Computes mesh scaling variables for mixing
+!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
+!> \date   September 2011
+!> \details
+!>  This routine initializes meshScalingDel2 and meshScalingDel4
+!>  that are used to scale coefficients with mesh size.
+!
+!-----------------------------------------------------------------------
+
+   subroutine meshScaling() !{{{
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer :: &
+         iEdge,       &! loop index/address for edges
+         cell1, cell2  ! cell addresses for neighbors across edge
+
+      real (kind=RKIND) :: &
+         cellWidth,   &! reference cell width for scaling
+         avgDensity    ! avg mesh density across edge
+
+      ! End preamble
+      !-------------
+      ! Begin code
+
+      if (config_hmix_scaleWithMesh) then
+         if (config_hmix_use_ref_cell_width) then
+            ! Mesh scaling is set by areaCell and and an input
+            ! reference widht config_hmix_ref_cell_width
+            ! See description of config_hmix_ref_cell_width in
+            ! Registry.xml for more detail.
+            do iEdge = 1, nEdgesArray
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               ! Effective cell width at edge iEdge, assuming
+               ! neighboring cells are circles for this calculation.
+               cellWidth = 2.0_RKIND* &
+                           sqrt((areaCell(cell1) + areaCell(cell2))/ &
+                                2.0_RKIND/pii)
+               meshScalingDel2(iEdge) =  cellWidth/ &
+                                         config_hmix_ref_cell_width
+               meshScalingDel4(iEdge) = (cellWidth/ &
+                                         config_hmix_ref_cell_width)**3
+            end do
+
+         else ! not using ref cell width
+            ! Mesh scaling is set by meshDensity. This is both confusing
+            ! and inconvenient, as the flags like config_mom_del2 need
+            ! to be reset for every resolution. It is kept for backwards
+            ! compatibility, but should become defunct.
+            ! del2 scales as dc**1, del4 scales as dc**3
+            do iEdge = 1, nEdgesArray
+               cell1 = cellsOnEdge(1,iEdge)
+               cell2 = cellsOnEdge(2,iEdge)
+               avgDensity = (meshDensity(cell1) + meshDensity(cell2))/ &
+                            2.0_RKIND
+               meshScalingDel2(iEdge) = 1.0_RKIND/ &
+                  (avgDensity/config_maxMeshDensity)**(1.0_RKIND/4.0_RKIND)
+               meshScalingDel4(iEdge) = 1.0_RKIND/ &
+                  (avgDensity/config_maxMeshDensity)**(3.0_RKIND/4.0_RKIND)
+            end do
+         end if
+
+      else ! no scaling with mesh
+
+         ! If config_hmix_scaleWithMesh is false, hmix coefficients
+         ! do not vary with cell size but remain constant across domain.
+         do iEdge = 1, nEdgesArray
+            meshScalingDel2(iEdge) = 1.0_RKIND
+            meshScalingDel4(iEdge) = 1.0_RKIND
+         end do
+      end if
+
+   !--------------------------------------------------------------------
+
+   end subroutine meshScaling !}}}
+
+!***********************************************************************
+
+end module li_mesh
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+! vim: foldmethod=marker

--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -136,7 +136,7 @@ module li_mesh
       invAreaCell   ! inverse of area of each cell
 
    ! Multiplicative masks and vectors for various conditions
-   integer, public, dimension(:, :), allocatable :: &
+   integer, public, dimension(:), allocatable :: &
       boundaryEdge, &! mask for boundary edges    at each level
       boundaryCell, &! mask for boundary cells    at each level
       boundaryVertex ! mask for boundary vertices at each level
@@ -472,9 +472,9 @@ contains
                                edgeSignOnVertex)
 
       allocate ( &
-            boundaryEdge(nVertLevels, nEdges+1), &
-            boundaryCell(nVertLevels, nCells+1), &
-            boundaryVertex(nVertLevels, nVertices+1), &
+            boundaryEdge(nEdges+1), &
+            boundaryCell(nCells+1), &
+            boundaryVertex(nVertices+1), &
             invAreaCell(nCells+1))
 
       !-----------------------------------------------------------------
@@ -1287,7 +1287,7 @@ contains
       !maxLevelVertexTop(nVertices+1) = 0
 
       ! set boundary edge
-      boundaryEdge(:,1:nEdges+1)=1.0_RKIND
+      boundaryEdge(1:nEdges+1)=0.0_RKIND
       !edgeMask(1:nEdges+1)=0
 
       ! TODO: Replace this loop over levels with MALI levels
@@ -1298,16 +1298,16 @@ contains
       !end do
 
       ! Find cells and vertices that have an edge on the boundary
-      boundaryCell(:,1:nCells+1) = 0.0_RKIND
-      boundaryVertex(:,1:nVertices+1) = 0.0_RKIND
+      boundaryCell(1:nCells+1) = 0.0_RKIND
+      boundaryVertex(1:nVertices+1) = 0.0_RKIND
 
       do iEdge = 1, nEdges
       do k = 1, nVertLevels
-         if (boundaryEdge(k,iEdge) == 1) then
-            boundaryCell(k,cellsOnEdge(1,iEdge)) = 1.0_RKIND
-            boundaryCell(k,cellsOnEdge(2,iEdge)) = 1.0_RKIND
-            boundaryVertex(k,verticesOnEdge(1,iEdge)) = 1.0_RKIND
-            boundaryVertex(k,verticesOnEdge(2,iEdge)) = 1.0_RKIND
+         if (boundaryEdge(iEdge) == 1) then
+            boundaryCell(cellsOnEdge(1,iEdge)) = 1.0_RKIND
+            boundaryCell(cellsOnEdge(2,iEdge)) = 1.0_RKIND
+            boundaryVertex(verticesOnEdge(1,iEdge)) = 1.0_RKIND
+            boundaryVertex(verticesOnEdge(2,iEdge)) = 1.0_RKIND
          endif
       end do
       end do

--- a/components/mpas-albany-landice/src/shared/mpas_li_setup.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_setup.F
@@ -121,7 +121,7 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_tracer_advection', config_tracer_advection)
       if (( (trim(config_thermal_solver) == 'temperature') .or. &
             (trim(config_thermal_solver) == 'enthalpy') ) .and. &
-            (trim(config_tracer_advection) /= 'fo') )then
+            ( (trim(config_tracer_advection) /= 'fo') .and. (trim(config_tracer_advection) /= 'fct') ) )then
          call mpas_log_write("Setting config_tracer_advection='fo' because a thermal solver has been selected. " // &
             "(config_tracer_advection was set to: " // trim(config_tracer_advection) // ")", MPAS_LOG_WARN)
          config_tracer_advection = 'fo'


### PR DESCRIPTION
This merge adds a flux-correct transport (FCT) scheme to MALI for thickness and tracer advection, ported over with MALI-relevant modification from MPAS-Ocean's routines, which are based on Skamarock and Gassmann (2011) (https://doi.org/10.1175/MWR-D-10-05056.1). This uses a blend of 3rd and 4th order fluxes to achieve monotonicity. The FCT routine is only used for tracers in MPAS-Ocean, whereas here it is modified for use with both thickness and tracers. The user can specify 2nd, 3rd, or 4th order advection with the `config_horiz_tracer_adv_order` option, but only `config_horiz_tracer_adv_order = 3` with 0 < `config_advection_coef_3rd_order` < 1 is truly FCT. The `config_advection_coef_3rd_order` option specifies the blend between 3rd and 4th order fluxes used in the flux correction. `config_advection_coef_3rd_order = 1.0` is purely 3rd order, while `config_advection_coef_3rd_order = 0.0` is purely 4th order. The default value of 0.25 is taken from the MPAS-Ocean default and may not be appropriate for all situations. Note that all higher-order advection must reduce to 1st order at the boundaries.

This also adds a new variable `passiveTracer2d`, that can be used to verify advection schemes.

Currently supported combinations of thickness and tracer advection with fct include:
1. `config_thickness_advection = 'fo'`; `config_tracer_advection = 'fct'`
2. `config_thickness_advection = 'fct'`; `config_tracer_advection = 'fct'`
3. `config_thickness_advection = 'fct'`; `config_tracer_advection = 'none'`
FCT tracer advection with no thickness advection and FCT thickness advection with FO tracer advection could be added, but we do not currently anticipate using them. Therefore, we have left them out of this PR as they would add unnecessary complexity to the code.

When used with forward Euler time integration, FCT requires a severely reduced time step relative to first order advection. Testing shows that CFL fraction on the order of 0.1 is likely sufficiently small, but this is probably case-dependent. Once Runge-Kutta time integration is operational, it is recommended to use that instead of forward Euler.

At the time of merging, there is a very slight conservation error (<0.1% in the grounded slab test shown below) for tracers when using FCT for both thickness and tracer advection, while mass is fully conserved. Tracers are conserved when using FO thickness advection with FCT tracer advection. The convergence order has not yet been verified, but testing is under way using a new mesh convergence COMPASS test: https://github.com/MPAS-Dev/compass/pull/690. 