### PR TITLE
Calculate ismip6 retreat rate on initial solve

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2083,7 +2083,7 @@ module li_calving
          ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
          if ( trim(stream_cursor % name) == 'ismip6-gis' .and. (stream_cursor % valid) ) then
             streamFound = .true.
-            if (timestepNumber == 1) then
+            if (timestepNumber == 0) then
                ! On the first timestep of a cold start OR restart initialize all needed fields by forcing a read of
                ! the previous forcing data on the first timestep.  This could be potentially be an unnecessary read on the
                ! initial time of a restart run, but that is a small cost for simplifying logic and making the initial time of both

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -2083,7 +2083,7 @@ module li_calving
          ! Input stream with forcings must be called 'ismip6-gis', or this will throw an error.
          if ( trim(stream_cursor % name) == 'ismip6-gis' .and. (stream_cursor % valid) ) then
             streamFound = .true.
-            if (timestepNumber == 0) then
+            if ( (timestepNumber == 0) .or. (config_do_restart .and. (timestepNumber == 1)) ) then
                ! On the first timestep of a cold start OR restart initialize all needed fields by forcing a read of
                ! the previous forcing data on the first timestep.  This could be potentially be an unnecessary read on the
                ! initial time of a restart run, but that is a small cost for simplifying logic and making the initial time of both


### PR DESCRIPTION
Now that calving is being called during the initial solve instead of the first time step, we need to calculate the initial ismip6 retreat rate on time step 0 instead of time step 1. This fixes an invalid memory reference segmentation fault that was causing all runs using `config_calving = ismip6_retreat` to die during the first solve.

This closes https://github.com/MALI-Dev/E3SM/issues/71.