### PR TITLE
Add global stats for subglacial hydrology model

### DIFF
--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -100,6 +100,43 @@
                 <var name="basalSpeedMax" type="real" dimensions="Time" units="m yr^{-1}"
                         description="maximum basal speed in the domain"
                 />
+                <var name="totalSubglacialWaterVolume" type="real" dimensions="Time" units="m^3"
+                        description="total subglacial water volume"
+                />
+                <var name="totalLakeVolume" type="real" dimensions="Time" units="m^3"
+                        description="total volume of lakes"
+                />
+                <var name="totalLakeArea" type="real" dimensions="Time" units="m^2"
+                        description="total area of lakes"
+                />
+                <var name="totalBasalMeltInput" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total basal meltwater contributing to the subglacial hydrologic system"
+                />
+                <var name="totalExternalWaterInput" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total external meltwater contributing to the subglacial hydrologic system"
+                />
+                <var name="totalChannelMelt" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total melt rate in the subglacial hydrologic system "
+                />
+                <var name="totalGLMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total distributed meltwater flux across the grounding line"
+                />
+                <var name="totalTerrestrialMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total distrubuted meltwater flux across terrestrial margins"
+                />
+                <var name="totalChannelGLMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total channelized meltwater flux across the grounding line"
+                />
+                <var name="totalChannelTerrestrialMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total channelized meltwater flux across terrestrial margins"
+                />
+                <var name="totalFlotationFraction" type="real" dimensions="Time" units="none"
+                        description="total flotation fraction to calculate avgFlotationFraction"
+                />
+                <var name="avgFlotationFraction" type="real" dimensions="Time" units="none"
+                        description="area-weighted average of the flotation fraction"
+                />
+    
  	</var_struct>
 	<streams>
 		<stream name="globalStatsOutput" type="output"

--- a/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_global_stats.xml
@@ -100,14 +100,15 @@
                 <var name="basalSpeedMax" type="real" dimensions="Time" units="m yr^{-1}"
                         description="maximum basal speed in the domain"
                 />
+                <!-- stats related to subglacial hydrology -->
                 <var name="totalSubglacialWaterVolume" type="real" dimensions="Time" units="m^3"
                         description="total subglacial water volume"
                 />
-                <var name="totalLakeVolume" type="real" dimensions="Time" units="m^3"
-                        description="total volume of lakes"
+                <var name="totalSubglacialLakeVolume" type="real" dimensions="Time" units="m^3"
+                        description="total volume of subglacial lakes, defined as water volume exceeding bed bump height"
                 />
-                <var name="totalLakeArea" type="real" dimensions="Time" units="m^2"
-                        description="total area of lakes"
+                <var name="totalSubglacialLakeArea" type="real" dimensions="Time" units="m^2"
+                        description="total area of subglacial lakes"
                 />
                 <var name="totalBasalMeltInput" type="real" dimensions="Time" units="kg s^{-1}"
                         description="total basal meltwater contributing to the subglacial hydrologic system"
@@ -118,25 +119,22 @@
                 <var name="totalChannelMelt" type="real" dimensions="Time" units="kg s^{-1}"
                         description="total melt rate in the subglacial hydrologic system "
                 />
-                <var name="totalGLMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
-                        description="total distributed meltwater flux across the grounding line"
+                <var name="totalDistWaterFluxMarineMargin" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total distributed subglacial water flux across marine boundaries (grounding lines or grounded marine margins)"
                 />
-                <var name="totalTerrestrialMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
-                        description="total distrubuted meltwater flux across terrestrial margins"
+                <var name="totalDistWaterFluxTerrestrialMargin" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total distributed subglacial water flux across terrestrial margins"
                 />
-                <var name="totalChannelGLMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
-                        description="total channelized meltwater flux across the grounding line"
+                <var name="totalChnlWaterFluxMarineMargin" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total channelized subglacial water flux across marine boundaries (grounding lines or grounded marine margins)"
                 />
-                <var name="totalChannelTerrestrialMeltFlux" type="real" dimensions="Time" units="kg s^{-1}"
-                        description="total channelized meltwater flux across terrestrial margins"
-                />
-                <var name="totalFlotationFraction" type="real" dimensions="Time" units="none"
-                        description="total flotation fraction to calculate avgFlotationFraction"
+                <var name="totalChnlWaterFluxTerrestrialMargin" type="real" dimensions="Time" units="kg s^{-1}"
+                        description="total channelized subglacial water flux across terrestrial margins"
                 />
                 <var name="avgFlotationFraction" type="real" dimensions="Time" units="none"
-                        description="area-weighted average of the flotation fraction"
+                        description="area-weighted average of the flotation fraction under grounded ice"
                 />
-    
+
  	</var_struct>
 	<streams>
 		<stream name="globalStatsOutput" type="output"

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -163,11 +163,13 @@ contains
       type (mpas_pool_type), pointer :: globalStatsAM
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: hydroPool      
 
       ! arrays, vars needed from other pools for calculations here
       real (kind=RKIND), pointer ::  deltat
       real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:), pointer ::  dvEdge
+      real (kind=RKIND), dimension(:), pointer ::  dcEdge
       real (kind=RKIND), dimension(:), pointer ::  thickness
       real (kind=RKIND), dimension(:), pointer ::  bedTopography
       real (kind=RKIND), dimension(:), pointer ::  sfcMassBalApplied
@@ -181,7 +183,17 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
       real (kind=RKIND), dimension(:), pointer ::  groundedToFloatingThickness
+      real (kind=RKIND), dimension(:), pointer ::  waterThickness
+      real (kind=RKIND), dimension(:), pointer ::  basalMeltInput
+      real (kind=RKIND), dimension(:), pointer ::  externalWaterInput
+      real (kind=RKIND), dimension(:), pointer ::  channelMelt
+      real (kind=RKIND), dimension(:), pointer ::  waterFlux
+      real (kind=RKIND), dimension(:), pointer ::  channelDischarge
+      real (kind=RKIND), dimension(:), pointer ::  waterPressure
+
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, pointer :: nCellsSolve
       integer, pointer :: nEdgesSolve
 
@@ -189,9 +201,10 @@ contains
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoi ! config_ice_density
       real (kind=RKIND), pointer :: rhow ! config_ocean_density
+      real (kind=RKIND), pointer :: bedBumpMax ! config_SGH_bed_roughness_max
 
       ! Local counters
-      integer :: k, iCell, iEdge
+      integer :: k, iCell, iEdge, nCellsGrounded
 
       ! scalars to be calculated here from global reductions
       real (kind=RKIND), pointer ::  totalIceArea, totalIceVolume
@@ -211,6 +224,18 @@ contains
       real (kind=RKIND), pointer ::  groundingLineMigrationFlux
       real (kind=RKIND), pointer ::  surfaceSpeedMax
       real (kind=RKIND), pointer ::  basalSpeedMax
+      real (kind=RKIND), pointer ::  totalSubglacialWaterVolume
+      real (kind=RKIND), pointer ::  totalBasalMeltInput
+      real (kind=RKIND), pointer ::  totalExternalWaterInput
+      real (kind=RKIND), pointer ::  totalChannelMelt
+      real (kind=RKIND), pointer ::  totalLakeVolume
+      real (kind=RKIND), pointer ::  totalLakeArea
+      real (kind=RKIND), pointer ::  totalGLMeltFlux
+      real (kind=RKIND), pointer ::  totalTerrestrialMeltFlux
+      real (kind=RKIND), pointer ::  totalChannelGLMeltFlux
+      real (kind=RKIND), pointer ::  totalChannelTerrestrialMeltFlux
+      real (kind=RKIND), pointer ::  totalFlotationFraction
+      real (kind=RKIND), pointer ::  avgFlotationFraction
 
       ! scalar reductions over all blocks on this processor
       real (kind=RKIND) ::  blockSumIceArea, blockSumIceVolume
@@ -227,11 +252,22 @@ contains
       real (kind=RKIND) ::  blockMaxBasalSpeed
       real (kind=RKIND) ::  blockGLflux
       real (kind=RKIND) ::  blockGLMigrationFlux
+      real (kind=RKIND) ::  blockSumSubglacialWaterVolume
+      real (kind=RKIND) ::  blockSumBasalMeltInput
+      real (kind=RKIND) ::  blockSumExternalWaterInput
+      real (kind=RKIND) ::  blockSumChannelMelt
+      real (kind=RKIND) ::  blockSumLakeVolume
+      real (kind=RKIND) ::  blockSumLakeArea
+      real (kind=RKIND) ::  blockSumGLMeltFlux
+      real (kind=RKIND) ::  blockSumTerrestrialMeltFlux
+      real (kind=RKIND) ::  blockSumChannelGLMeltFlux
+      real (kind=RKIND) ::  blockSumChannelTerrestrialMeltFlux
+      real (kind=RKIND) ::  blockSumFlotationFraction
 
       ! Local variables for calculations
 
       ! variables for processing stats
-      integer, parameter :: kMaxVariables = 24 ! Increase if number of stats increase
+      integer, parameter :: kMaxVariables = 35 ! Increase if number of stats increase 
       integer :: nVars
       real (kind=RKIND), dimension(kMaxVariables) :: reductions, sums, mins, maxes
 
@@ -257,6 +293,17 @@ contains
       blockSumFaceMeltingFlux = 0.0_RKIND
       blockGLflux = 0.0_RKIND
       blockGLMigrationFlux = 0.0_RKIND
+      blockSumSubglacialWaterVolume = 0.0_RKIND
+      blockSumBasalMeltInput = 0.0_RKIND
+      blockSumExternalWaterInput = 0.0_RKIND
+      blockSumChannelMelt = 0.0_RKIND
+      blockSumLakeVolume = 0.0_RKIND
+      blockSumLakeArea = 0.0_RKIND
+      blockSumGLMeltFlux = 0.0_RKIND
+      blockSumTerrestrialMeltFlux = 0.0_RKIND
+      blockSumChannelGLMeltFlux = 0.0_RKIND
+      blockSumChannelTerrestrialMeltFlux = 0.0_RKIND
+      blockSumFlotationFraction = 0.0_RKIND
 
       ! initialize max to 0, min to large number
       blockThickMin = 100000.0_RKIND
@@ -268,6 +315,7 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhow)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', bedBumpMax)
 
       ! loop over blocks
       block => domain % blocklist
@@ -278,6 +326,7 @@ contains
          call mpas_pool_get_subpool(block % structs, 'globalStatsAM', globalStatsAMPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
 
          ! get values and arrays from standard pools
          call mpas_pool_get_dimension(block % dimensions, 'nCellsSolve', nCellsSolve)
@@ -285,6 +334,7 @@ contains
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
          call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+         call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
@@ -299,11 +349,21 @@ contains
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
          call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
+         call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
+         call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
+         call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
+         call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+         call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+         call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+         call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
+         call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+         call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+
 
          ! loop over cells
          do iCell = 1,nCellsSolve
 
-            ! sums of ice area and volume over cells (m^2 and m^3)
+            ! sums of ice area and volume over cells (m^2 and m^3)i
             blockSumIceArea = blockSumIceArea + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell)
             blockSumIceVolume = blockSumIceVolume + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
@@ -314,11 +374,13 @@ contains
 
             blockSumGroundedIceArea = blockSumGroundedIceArea + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
                  * areaCell(iCell)
+           
             blockSumGroundedIceVolume = blockSumGroundedIceVolume + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
             blockSumFloatingIceArea = blockSumFloatingIceArea + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell)
+           
             blockSumFloatingIceVolume = blockSumFloatingIceVolume + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
@@ -335,6 +397,7 @@ contains
             blockSumGroundedSfcMassBal = blockSumGroundedSfcMassBal + areaCell(iCell) * groundedSfcMassBalApplied(iCell) * scyr
             blockSumFloatingSfcMassBal = blockSumFloatingSfcMassBal + &
                (sfcMassBalApplied(iCell) - groundedSfcMassBalApplied(iCell)) * areaCell(iCell) * scyr
+      
             ! BMB (kg yr-1)
             blockSumBasalMassBal = blockSumBasalMassBal + areaCell(iCell) * basalMassBalApplied(iCell) * scyr
             blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr
@@ -362,13 +425,57 @@ contains
             blockGLMigrationFlux = blockGLMigrationFlux + groundedToFloatingThickness(iCell) * areaCell(iCell) &
                * rhoi / (deltat / scyr)  ! convert from m to kg/yr
 
+            !! Subglacial Hydrology Calculations
+
+            ! Subglacial Water Volume
+            blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
+
+            ! Basal melt input
+            blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
+
+            ! External water input
+            blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
+
+            ! Lake Volume
+            if (waterThickness(iCell) > bedBumpMax) then
+                blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+            endif
+           
+            ! Lake Area
+            if (waterThickness(iCell) > bedBumpMax) then
+                blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
+            endif
+
+            ! Area-weighted flotation fraction for grounded ice
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
+            endif
+           
+
          end do ! end loop over cells
 
          ! Loop over edges
          do iEdge = 1, nEdgesSolve
+
             ! Flux across GL, units = kg/yr
             blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
                       * scyr * rhoi ! convert from m^2/s to kg/yr
+
+            ! Channel Melt
+            blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
+
+            ! Meltwater Flux across the grounding line
+            blockSumGLMeltFlux = blockSumGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+
+            ! Meltwater Flux across terrestrial margins
+            blockSumTerrestrialMeltFlux = blockSumTerrestrialMeltFlux + abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+
+            ! Meltwater Discharge in channels across grounding line
+            blockSumChannelGLMeltFlux = blockSumChannelGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+
+            ! Meltwater discharge in channels across terrestrial margin
+            blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+
          end do ! end loop over edges
 
          block => block % next
@@ -409,7 +516,6 @@ contains
       sums(7) = blockSumSfcMassBal
       sums(8) = blockSumGroundedSfcMassBal
       sums(9) = blockSumFloatingSfcMassBal
-
       sums(10) = blockSumBasalMassBal
       sums(11) = blockSumGroundedBasalMassBal
       sums(12) = blockSumFloatingBasalMassBal
@@ -418,7 +524,18 @@ contains
       sums(15) = blockSumVAF
       sums(16) = blockGLflux
       sums(17) = blockGLMigrationflux
-      nVars = 17
+      sums(18) = blockSumSubglacialWaterVolume
+      sums(19) = blockSumBasalMeltInput
+      sums(20) = blockSumExternalWaterInput
+      sums(21) = blockSumChannelMelt
+      sums(22) = blockSumLakeVolume
+      sums(23) = blockSumLakeArea
+      sums(24) = blockSumGLMeltFlux
+      sums(25) = blockSumTerrestrialMeltFlux
+      sums(26) = blockSumChannelGLMeltFlux
+      sums(27) = blockSumChannelTerrestrialMeltFlux
+      sums(28) = blockSumFlotationFraction
+      nVars = 28
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -447,6 +564,18 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
+         call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
 
          totalIceArea = reductions(1)
          totalIceVolume = reductions(2)
@@ -465,6 +594,18 @@ contains
          volumeAboveFloatation = reductions(15)
          groundingLineFlux = reductions(16)
          groundingLineMigrationFlux = reductions(17)
+         totalSubglacialWaterVolume = reductions(18)
+         totalBasalMeltInput = reductions(19)
+         totalExternalWaterInput = reductions(20)
+         totalChannelMelt = reductions(21)
+         totalLakevolume = reductions(22)
+         totalLakeArea = reductions(23)
+         totalGLMeltFlux = reductions(24)
+         totalTerrestrialMeltFlux = reductions(25)
+         totalChannelGLMeltFlux = reductions(26)
+         totalChannelTerrestrialMeltFlux = reductions(27)
+         totalFlotationFraction = reductions(28)
+
 
          if (totalIceArea > 0.0_RKIND) then
             iceThicknessMean = totalIceVolume / totalIceArea
@@ -473,15 +614,23 @@ contains
             iceThicknessMean = 0.0_RKIND
             avgNetAccumulation = 0.0_RKIND
          endif
+
          if (groundedIceArea > 0.0_RKIND) then
             avgGroundedBasalMelt = -1.0_RKIND * totalGroundedBasalMassBal / groundedIceArea / rhoi
          else
             avgGroundedBasalMelt = 0.0_RKIND
          endif
+
          if (floatingIceArea > 0.0_RKIND) then
             avgSubshelfMelt = -1.0_RKIND * totalFloatingBasalMassBal / floatingIceArea / rhoi
          else
             avgSubshelfMelt = 0.0_RKIND
+         endif
+
+         if (groundedIceArea > 0.0_RKIND) then
+            avgFlotationFraction = totalFlotationFraction / groundedIceArea
+         else
+            avgFlotationFraction = 0.0_RKIND
          endif
 
          block => block % next

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -454,7 +454,7 @@ contains
 
                ! Area-weighted flotation fraction for grounded ice
                if (li_mask_is_grounded_ice(cellMask(iCell))) then
-                   blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
+                   blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhoi / gravity / thickness(iCell) ) * areaCell(iCell)
                endif
             endif
 

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -163,7 +163,7 @@ contains
       type (mpas_pool_type), pointer :: globalStatsAM
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: velocityPool
-      type (mpas_pool_type), pointer :: hydroPool      
+      type (mpas_pool_type), pointer :: hydroPool
 
       ! arrays, vars needed from other pools for calculations here
       real (kind=RKIND), pointer ::  deltat
@@ -183,7 +183,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
       real (kind=RKIND), dimension(:), pointer ::  groundedToFloatingThickness
-      
+
       real (kind=RKIND), dimension(:), pointer ::  waterThickness
       real (kind=RKIND), dimension(:), pointer ::  basalMeltInput
       real (kind=RKIND), dimension(:), pointer ::  externalWaterInput
@@ -230,13 +230,12 @@ contains
       real (kind=RKIND), pointer ::  totalBasalMeltInput
       real (kind=RKIND), pointer ::  totalExternalWaterInput
       real (kind=RKIND), pointer ::  totalChannelMelt
-      real (kind=RKIND), pointer ::  totalLakeVolume
-      real (kind=RKIND), pointer ::  totalLakeArea
-      real (kind=RKIND), pointer ::  totalGLMeltFlux
-      real (kind=RKIND), pointer ::  totalTerrestrialMeltFlux
-      real (kind=RKIND), pointer ::  totalChannelGLMeltFlux
-      real (kind=RKIND), pointer ::  totalChannelTerrestrialMeltFlux
-      real (kind=RKIND), pointer ::  totalFlotationFraction
+      real (kind=RKIND), pointer ::  totalSubglacialLakeVolume
+      real (kind=RKIND), pointer ::  totalSubglacialLakeArea
+      real (kind=RKIND), pointer ::  totalDistWaterFluxMarineMargin
+      real (kind=RKIND), pointer ::  totalDistWaterFluxTerrestrialMargin
+      real (kind=RKIND), pointer ::  totalChnlWaterFluxMarineMargin
+      real (kind=RKIND), pointer ::  totalChnlWaterFluxTerrestrialMargin
       real (kind=RKIND), pointer ::  avgFlotationFraction
 
       ! scalar reductions over all blocks on this processor
@@ -267,9 +266,10 @@ contains
       real (kind=RKIND) ::  blockSumFlotationFraction
 
       ! Local variables for calculations
+      real (kind=RKIND) ::  totalFlotationFraction
 
       ! variables for processing stats
-      integer, parameter :: kMaxVariables = 35 ! Increase if number of stats increase 
+      integer, parameter :: kMaxVariables = 35 ! Increase if number of stats increase
       integer :: nVars
       real (kind=RKIND), dimension(kMaxVariables) :: reductions, sums, mins, maxes
 
@@ -367,7 +367,7 @@ contains
          ! loop over cells
          do iCell = 1,nCellsSolve
 
-            ! sums of ice area and volume over cells (m^2 and m^3)i
+            ! sums of ice area and volume over cells (m^2 and m^3)
             blockSumIceArea = blockSumIceArea + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell)
             blockSumIceVolume = blockSumIceVolume + real(li_mask_is_ice_int(cellMask(iCell)),RKIND) &
@@ -378,13 +378,13 @@ contains
 
             blockSumGroundedIceArea = blockSumGroundedIceArea + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
                  * areaCell(iCell)
-           
+
             blockSumGroundedIceVolume = blockSumGroundedIceVolume + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
             blockSumFloatingIceArea = blockSumFloatingIceArea + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell)
-           
+
             blockSumFloatingIceVolume = blockSumFloatingIceVolume + real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND) &
                 * areaCell(iCell) * thickness(iCell)
 
@@ -401,7 +401,7 @@ contains
             blockSumGroundedSfcMassBal = blockSumGroundedSfcMassBal + areaCell(iCell) * groundedSfcMassBalApplied(iCell) * scyr
             blockSumFloatingSfcMassBal = blockSumFloatingSfcMassBal + &
                (sfcMassBalApplied(iCell) - groundedSfcMassBalApplied(iCell)) * areaCell(iCell) * scyr
-      
+
             ! BMB (kg yr-1)
             blockSumBasalMassBal = blockSumBasalMassBal + areaCell(iCell) * basalMassBalApplied(iCell) * scyr
             blockSumGroundedBasalMassBal = blockSumGroundedBasalMassBal + areaCell(iCell) * groundedBasalMassBalApplied(iCell) * scyr
@@ -446,7 +446,7 @@ contains
                if (waterThickness(iCell) > bedBumpMax) then
                   blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
                endif
-                 
+
                ! Lake Area
                if (waterThickness(iCell) > bedBumpMax) then
                    blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
@@ -581,13 +581,12 @@ contains
             call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
             call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
             call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
-            call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialLakeVolume', totalSubglacialLakeVolume)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialLakeArea', totalSubglacialLakeArea)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalDistWaterFluxMarineMargin',totalDistWaterFluxMarineMargin)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalDistWaterFluxTerrestrialMargin', totalDistWaterFluxTerrestrialMargin)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChnlWaterFluxMarineMargin',totalChnlWaterFluxMarineMargin)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChnlWaterFluxTerrestrialMargin', totalChnlWaterFluxTerrestrialMargin)
             call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
          endif
 
@@ -613,12 +612,12 @@ contains
             totalBasalMeltInput = reductions(19)
             totalExternalWaterInput = reductions(20)
             totalChannelMelt = reductions(21)
-            totalLakevolume = reductions(22)
-            totalLakeArea = reductions(23)
-            totalGLMeltFlux = reductions(24)
-            totalTerrestrialMeltFlux = reductions(25)
-            totalChannelGLMeltFlux = reductions(26)
-            totalChannelTerrestrialMeltFlux = reductions(27)
+            totalSubglacialLakeVolume = reductions(22)
+            totalSubglacialLakeArea = reductions(23)
+            totalDistWaterFluxMarineMargin = reductions(24)
+            totalDistWaterFluxTerrestrialMargin = reductions(25)
+            totalChnlWaterFluxMarineMargin = reductions(26)
+            totalChnlWaterFluxTerrestrialMargin = reductions(27)
             totalFlotationFraction = reductions(28)
          endif
 

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -183,6 +183,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
       real (kind=RKIND), dimension(:), pointer ::  groundedToFloatingThickness
+      
       real (kind=RKIND), dimension(:), pointer ::  waterThickness
       real (kind=RKIND), dimension(:), pointer ::  basalMeltInput
       real (kind=RKIND), dimension(:), pointer ::  externalWaterInput
@@ -202,6 +203,7 @@ contains
       real (kind=RKIND), pointer :: rhoi ! config_ice_density
       real (kind=RKIND), pointer :: rhow ! config_ocean_density
       real (kind=RKIND), pointer :: bedBumpMax ! config_SGH_bed_roughness_max
+      logical, pointer :: config_SGH
 
       ! Local counters
       integer :: k, iCell, iEdge, nCellsGrounded
@@ -316,6 +318,7 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhow)
       call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', bedBumpMax)
+      call mpas_pool_get_config(liConfigs, 'config_SGH', config_SGH)
 
       ! loop over blocks
       block => domain % blocklist
@@ -349,16 +352,17 @@ contains
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
          call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
-         call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
-         call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
-         call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
-         call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
-         call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
-         call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
-         call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
-         call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
-         call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
-
+         if (config_SGH) then
+            call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
+            call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
+            call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
+            call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+            call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+            call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+            call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
+            call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+            call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+         endif
 
          ! loop over cells
          do iCell = 1,nCellsSolve
@@ -426,58 +430,61 @@ contains
                * rhoi / (deltat / scyr)  ! convert from m to kg/yr
 
             !! Subglacial Hydrology Calculations
+            if (config_SGH) then
 
-            ! Subglacial Water Volume
-            blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
+               ! Subglacial Water Volume
+               blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
 
-            ! Basal melt input
-            blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
+               ! Basal melt input
+               blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
 
-            ! External water input
-            blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
+               ! External water input
+               blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
 
-            ! Lake Volume
-            if (waterThickness(iCell) > bedBumpMax) then
-                blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+               ! Lake Volume
+               if (waterThickness(iCell) > bedBumpMax) then
+                  blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+               endif
+                 
+               ! Lake Area
+               if (waterThickness(iCell) > bedBumpMax) then
+                   blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
+               endif
+
+               ! Area-weighted flotation fraction for grounded ice
+               if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                   blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
+               endif
             endif
-           
-            ! Lake Area
-            if (waterThickness(iCell) > bedBumpMax) then
-                blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
-            endif
 
-            ! Area-weighted flotation fraction for grounded ice
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then
-                blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
-            endif
-           
 
          end do ! end loop over cells
 
-         ! Loop over edges
-         do iEdge = 1, nEdgesSolve
+         if (config_SGH) then
+            ! Loop over edges
+            do iEdge = 1, nEdgesSolve
 
-            ! Flux across GL, units = kg/yr
-            blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
-                      * scyr * rhoi ! convert from m^2/s to kg/yr
+               ! Flux across GL, units = kg/yr
+               blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
+                         * scyr * rhoi ! convert from m^2/s to kg/yr
 
-            ! Channel Melt
-            blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
+               ! Channel Melt
+               blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
 
-            ! Meltwater Flux across the grounding line
-            blockSumGLMeltFlux = blockSumGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+               ! Meltwater Flux across the grounding line
+               blockSumGLMeltFlux = blockSumGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
 
-            ! Meltwater Flux across terrestrial margins
-            blockSumTerrestrialMeltFlux = blockSumTerrestrialMeltFlux + abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+               ! Meltwater Flux across terrestrial margins
+               blockSumTerrestrialMeltFlux = blockSumTerrestrialMeltFlux + abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
 
-            ! Meltwater Discharge in channels across grounding line
-            blockSumChannelGLMeltFlux = blockSumChannelGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+               ! Meltwater Discharge in channels across grounding line
+               blockSumChannelGLMeltFlux = blockSumChannelGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
 
-            ! Meltwater discharge in channels across terrestrial margin
-            blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+               ! Meltwater discharge in channels across terrestrial margin
+               blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
 
-         end do ! end loop over edges
-
+            end do ! end loop over edges
+         endif
          block => block % next
       end do    ! end loop over blocks
 
@@ -522,20 +529,24 @@ contains
       sums(13) = blockSumCalvingFlux
       sums(14) = blockSumFaceMeltingFlux
       sums(15) = blockSumVAF
-      sums(16) = blockGLflux
-      sums(17) = blockGLMigrationflux
-      sums(18) = blockSumSubglacialWaterVolume
-      sums(19) = blockSumBasalMeltInput
-      sums(20) = blockSumExternalWaterInput
-      sums(21) = blockSumChannelMelt
-      sums(22) = blockSumLakeVolume
-      sums(23) = blockSumLakeArea
-      sums(24) = blockSumGLMeltFlux
-      sums(25) = blockSumTerrestrialMeltFlux
-      sums(26) = blockSumChannelGLMeltFlux
-      sums(27) = blockSumChannelTerrestrialMeltFlux
-      sums(28) = blockSumFlotationFraction
-      nVars = 28
+      if (config_SGH) then
+         sums(16) = blockGLflux
+         sums(17) = blockGLMigrationflux
+         sums(18) = blockSumSubglacialWaterVolume
+         sums(19) = blockSumBasalMeltInput
+         sums(20) = blockSumExternalWaterInput
+         sums(21) = blockSumChannelMelt
+         sums(22) = blockSumLakeVolume
+         sums(23) = blockSumLakeArea
+         sums(24) = blockSumGLMeltFlux
+         sums(25) = blockSumTerrestrialMeltFlux
+         sums(26) = blockSumChannelGLMeltFlux
+         sums(27) = blockSumChannelTerrestrialMeltFlux
+         sums(28) = blockSumFlotationFraction
+         nVars = 28
+      else
+        nVars = 15
+      endif
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -562,20 +573,22 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'avgSubshelfMelt', avgSubshelfMelt)
          call mpas_pool_get_array(globalStatsAMPool, 'totalCalvingFlux', totalCalvingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
-         call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
+         if (config_SGH) then
+            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
+            call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
+         endif
 
          totalIceArea = reductions(1)
          totalIceVolume = reductions(2)
@@ -592,20 +605,21 @@ contains
          totalCalvingFlux = reductions(13)
          totalFaceMeltingFlux = reductions(14)
          volumeAboveFloatation = reductions(15)
-         groundingLineFlux = reductions(16)
-         groundingLineMigrationFlux = reductions(17)
-         totalSubglacialWaterVolume = reductions(18)
-         totalBasalMeltInput = reductions(19)
-         totalExternalWaterInput = reductions(20)
-         totalChannelMelt = reductions(21)
-         totalLakevolume = reductions(22)
-         totalLakeArea = reductions(23)
-         totalGLMeltFlux = reductions(24)
-         totalTerrestrialMeltFlux = reductions(25)
-         totalChannelGLMeltFlux = reductions(26)
-         totalChannelTerrestrialMeltFlux = reductions(27)
-         totalFlotationFraction = reductions(28)
-
+         if (config_SGH) then
+            groundingLineFlux = reductions(16)
+            groundingLineMigrationFlux = reductions(17)
+            totalSubglacialWaterVolume = reductions(18)
+            totalBasalMeltInput = reductions(19)
+            totalExternalWaterInput = reductions(20)
+            totalChannelMelt = reductions(21)
+            totalLakevolume = reductions(22)
+            totalLakeArea = reductions(23)
+            totalGLMeltFlux = reductions(24)
+            totalTerrestrialMeltFlux = reductions(25)
+            totalChannelGLMeltFlux = reductions(26)
+            totalChannelTerrestrialMeltFlux = reductions(27)
+            totalFlotationFraction = reductions(28)
+         endif
 
          if (totalIceArea > 0.0_RKIND) then
             iceThicknessMean = totalIceVolume / totalIceArea
@@ -626,11 +640,12 @@ contains
          else
             avgSubshelfMelt = 0.0_RKIND
          endif
-
-         if (groundedIceArea > 0.0_RKIND) then
-            avgFlotationFraction = totalFlotationFraction / groundedIceArea
-         else
-            avgFlotationFraction = 0.0_RKIND
+         if (config_SGH) then
+            if (groundedIceArea > 0.0_RKIND) then
+                avgFlotationFraction = totalFlotationFraction / groundedIceArea
+            else
+                avgFlotationFraction = 0.0_RKIND
+            endif
          endif
 
          block => block % next

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -436,7 +436,8 @@ contains
                blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
 
                ! Basal melt input
-               blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
+               blockSumBasalMeltInput = blockSumBasalMeltInput + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * &
+                                        basalMeltInput(iCell) * areaCell(iCell)
 
                ! External water input
                blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
@@ -647,6 +648,8 @@ contains
                 avgFlotationFraction = 0.0_RKIND
             endif
          endif
+
+
 
          block => block % next
       end do


### PR DESCRIPTION
This PR request includes updates to the global stats to include new analysis members for subglacial hydrology. 

The new analysis members are:
* totalSubglacialWaterVolume
* totalSubglacialLakeVolume
* totalSubglacialLakeArea
* totalBasalMeltInput
* totalExternalWaterInput
* totalChannelMelt
* totalDistWaterFluxMarineMargin
* totalDistWaterFluxTerrestrialMargin
* totalChnlWaterFluxMarineMargin
* totalChnlWaterFluxTerrestrialMargin
* avgFlotationFraction
