### PR TITLE
Update config_start_time and config_stop_time

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -124,8 +124,8 @@
 <!-- time_management -->
 <config_do_restart>.false.</config_do_restart>
 <config_restart_timestamp_name>'rpointer.glc'</config_restart_timestamp_name>
-<config_start_time>'0000-01-01_00:00:00'</config_start_time>
-<config_stop_time>'0000-01-01_00:00:00'</config_stop_time>
+<config_start_time>'0001-01-01_00:00:00'</config_start_time>
+<config_stop_time>'0001-01-01_00:00:00'</config_stop_time>
 <config_run_duration>'none'</config_run_duration>
 <config_calendar_type CALENDAR="NO_LEAP">'noleap'</config_calendar_type>
 <config_calendar_type>'gregorian'</config_calendar_type>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -533,11 +533,11 @@
 		description="Path to the filename for restart timestamps to be read and written from."
 		possible_values="Path to a file."
 		/>
-		<nml_option name="config_start_time" type="character" default_value="0000-01-01_00:00:00" units="unitless"
+		<nml_option name="config_start_time" type="character" default_value="0001-01-01_00:00:00" units="unitless"
 		            description="Timestamp describing the initial time of the simulation.  If it is set to 'file', the initial time is read from the filename specified by config_restart_timestamp_name (defaults to 'restart_timestamp')."
 		            possible_values="'YYYY-MM-DD_HH:MM:SS' (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
 		/>
-		<nml_option name="config_stop_time" type="character" default_value="0000-01-01_00:00:00" units="unitless"
+		<nml_option name="config_stop_time" type="character" default_value="0001-01-01_00:00:00" units="unitless"
 		            description="Timestamp describing the final time of the simulation. If it is set to 'none' the final time is determined from config_start_time and config_run_duration.  If config_run_duration is also specified, it takes precedence over config_stop_time.  Set config_stop_time to be equal to config_start_time (and config_run_duration to 'none') to perform a diagnostic solve only."
 		            possible_values="'YYYY-MM-DD_HH:MM:SS' or 'none' (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
 		/>


### PR DESCRIPTION
Change config_start_time and config_stop_time from `0000-01-01_00:00:00` to `0001-01-01_00:00:00` to avoid unpredictable I/O behavior.