### PR TITLE
Implement Runge-Kutta time integration

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1183,6 +1183,9 @@ is the value of that variable from the *previous* time level!
                 <var name="dynamicThickening" type="real" dimensions="nCells Time" units="m a^{-1}"
                      description="diagnostic field of dynamic thickening rate (calculated as negative of flux divergence)"
                 />
+                <var name="rkTend" type="real" dimensions="maxTracersAdvect nCells Time" units="varies"
+                     description="accumulated tendencies for RK time integration"
+                />
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on cells.  cellMask only needs to be a restart field if config_allow_additional_advance = false (to keep the mask of initial ice extent)"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -489,8 +489,8 @@
 		            possible_values="'forward_euler' or 'runge_kutta'"
 		/>
                 <nml_option name="config_rk_order" type="integer" default_value="2" units="unitless"
-                            description="Order of Runge-Kutta time integration to use. A value of 1 is equivalent to forward euler."
-                            possible_values="1, 2, 3, 4"
+                            description="Order of Runge-Kutta time integration to use. A value of 1 is equivalent to forward euler. Values of 2 and 3 indicate strong-stability preserving RK2 and RK3. There is currently no support for classical RK2 or RK4 methods."
+                            possible_values="1, 2, 3"
                 />
 		<nml_option name="config_adaptive_timestep" type="logical" default_value=".false." units="unitless"
 			description="Determines if the time step should be adjusted based on the CFL condition or should be steady in time. If true, the config_dt_* options are ignored."
@@ -1186,12 +1186,6 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="dynamicThickening" type="real" dimensions="nCells Time" units="m a^{-1}"
                      description="diagnostic field of dynamic thickening rate (calculated as negative of flux divergence)"
-                />
-                <var name="rkTend" type="real" dimensions="maxTracersAdvect nVertLevels nCells Time" units="none"
-                     description="tendencies for RK time integration at current RK stage"
-                />
-                <var name="rkTendAccum" type="real" dimensions="maxTracersAdvect nVertLevels nCells Time" units="none"
-                     description="accumulated tendencies for RK time integration"
                 />
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"
                      description="bitmask indicating various properties about the ice sheet on cells.  cellMask only needs to be a restart field if config_allow_additional_advance = false (to keep the mask of initial ice extent)"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -485,7 +485,7 @@
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS', but limited by CFL condition."
 		/>
 		<nml_option name="config_time_integration" type="character" default_value="forward_euler" units="unitless"
-		            description="Time integration method (currently, only forward Euler is supported)."
+		            description="Time integration method."
 		            possible_values="'forward_euler' or 'runge_kutta'"
 		/>
                 <nml_option name="config_rk_order" type="integer" default_value="2" units="unitless"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1183,7 +1183,7 @@ is the value of that variable from the *previous* time level!
                 <var name="dynamicThickening" type="real" dimensions="nCells Time" units="m a^{-1}"
                      description="diagnostic field of dynamic thickening rate (calculated as negative of flux divergence)"
                 />
-                <var name="rkTend" type="real" dimensions="maxTracersAdvect nCells Time" units="varies"
+                <var name="rkTend" type="real" dimensions="maxTracersAdvect nVertLevels nCells Time" units="none"
                      description="accumulated tendencies for RK time integration"
                 />
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -486,8 +486,12 @@
 		/>
 		<nml_option name="config_time_integration" type="character" default_value="forward_euler" units="unitless"
 		            description="Time integration method (currently, only forward Euler is supported)."
-		            possible_values="'forward_euler'"
+		            possible_values="'forward_euler' or 'runge_kutta'"
 		/>
+                <nml_option name="config_rk_order" type="integer" default_value="2" units="unitless"
+                            description="Order of Runge-Kutta time integration to use. A value of 1 is equivalent to forward euler."
+                            possible_values="1, 2, 3, 4"
+                />
 		<nml_option name="config_adaptive_timestep" type="logical" default_value=".false." units="unitless"
 			description="Determines if the time step should be adjusted based on the CFL condition or should be steady in time. If true, the config_dt_* options are ignored."
 			possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1188,6 +1188,9 @@ is the value of that variable from the *previous* time level!
                      description="diagnostic field of dynamic thickening rate (calculated as negative of flux divergence)"
                 />
                 <var name="rkTend" type="real" dimensions="maxTracersAdvect nVertLevels nCells Time" units="none"
+                     description="tendencies for RK time integration at current RK stage"
+                />
+                <var name="rkTendAccum" type="real" dimensions="maxTracersAdvect nVertLevels nCells Time" units="none"
                      description="accumulated tendencies for RK time integration"
                 />
                 <var name="cellMask" type="integer" dimensions="nCells Time" units="none"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -492,6 +492,10 @@
                             description="Order of Runge-Kutta time integration to use. A value of 1 is equivalent to forward euler. Values of 2 and 3 indicate strong-stability preserving RK2 and RK3. There is currently no support for classical RK2 or RK4 methods."
                             possible_values="1, 2, 3"
                 />
+		<nml_option name="config_rk3_stages" type="integer" default_value="3" units="stages"
+                        description="Number of stages for strong stability preserving RK3 time integration. If set to 3, this involves 3 velocity solves and a maximum CFL fraction of 1. If set to 4, this involves 4 velocity solves, but the maximum CFL fraction is 2."
+                        possible_values="3 or 4"
+		/>
 		<nml_option name="config_adaptive_timestep" type="logical" default_value=".false." units="unitless"
 			description="Determines if the time step should be adjusted based on the CFL condition or should be steady in time. If true, the config_dt_* options are ignored."
 			possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -489,8 +489,8 @@
 		            possible_values="'forward_euler' or 'runge_kutta'"
 		/>
                 <nml_option name="config_rk_order" type="integer" default_value="2" units="unitless"
-                            description="Order of Runge-Kutta time integration to use. A value of 1 is equivalent to forward euler. Values of 2 and 3 indicate strong-stability preserving RK2 and RK3. There is currently no support for classical RK2 or RK4 methods."
-                            possible_values="1, 2, 3"
+                            description="Order of Runge-Kutta time integration to use. A value of 1 would be equivalent to forward euler, but will cause an error to avoid unnecessary redundancy. Values of 2 and 3 indicate strong-stability preserving RK2 and RK3. There is currently no support for classical RK2 or RK4 methods."
+                            possible_values="2 or 3"
                 />
 		<nml_option name="config_rk3_stages" type="integer" default_value="3" units="stages"
                         description="Number of stages for strong stability preserving RK3 time integration. If set to 3, this involves 3 velocity solves and a maximum CFL fraction of 1. If set to 4, this involves 4 velocity solves, but the maximum CFL fraction is 2."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -292,6 +292,10 @@
                         description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity.  If you choose to set config_adaptive_timestep_calvingCFL_fraction much larger than 1.0 (which is not recommended), setting this option to true usually results in more accurate calving behavior. "
                         possible_values=".true. or .false."
                 />
+                <nml_option name="config_update_velocity_before_calving" type="logical" default_value=".true." units="unitless"
+                            description="If true, add an additional velocity solve between advection and calving. If false, use velocity field from beginning of time step to calculate calving rate. For certain calving laws, like damage threshold calving, it is not necessary to update the velocity before calving, while for von Mises stress and eigencalving, it is more accurate to have an updated velocity state before solving for calvingThickness."
+                            possible_values=".true. or .false."
+                />
 	</nml_record>
 
 	<nml_record name="thermal_solver" in_defaults="true">

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -292,7 +292,7 @@
                         description="If true, then distribute unablatedVolumeDynCell among dynamic neighbors when converting ablation velocity to ablation thickness. This should only be used as a clean-up measure, while limiting the timestep based on ablation velocity should be used as the primary method of getting accurate ablation thickness from ablation velocity.  If you choose to set config_adaptive_timestep_calvingCFL_fraction much larger than 1.0 (which is not recommended), setting this option to true usually results in more accurate calving behavior. "
                         possible_values=".true. or .false."
                 />
-                <nml_option name="config_update_velocity_before_calving" type="logical" default_value=".true." units="unitless"
+                <nml_option name="config_update_velocity_before_calving" type="logical" default_value=".false." units="unitless"
                             description="If true, add an additional velocity solve between advection and calving. If false, use velocity field from beginning of time step to calculate calving rate. For certain calving laws, like damage threshold calving, it is not necessary to update the velocity before calving, while for von Mises stress and eigencalving, it is more accurate to have an updated velocity state before solving for calvingThickness."
                             possible_values=".true. or .false."
                 />

--- a/components/mpas-albany-landice/src/landice.cmake
+++ b/components/mpas-albany-landice/src/landice.cmake
@@ -57,7 +57,7 @@ list(APPEND RAW_SOURCES
   core_landice/mode_forward/mpas_li_core.F
   core_landice/mode_forward/mpas_li_core_interface.F
   core_landice/mode_forward/mpas_li_time_integration.F
-  core_landice/mode_forward/mpas_li_time_integration_fe.F
+  core_landice/mode_forward/mpas_li_time_integration_fe_rk.F
   core_landice/mode_forward/mpas_li_diagnostic_vars.F
   core_landice/mode_forward/mpas_li_advection.F
   core_landice/mode_forward/mpas_li_calving.F

--- a/components/mpas-albany-landice/src/mode_forward/Makefile
+++ b/components/mpas-albany-landice/src/mode_forward/Makefile
@@ -4,7 +4,7 @@
 OBJS =  mpas_li_core.o \
     mpas_li_core_interface.o \
     mpas_li_time_integration.o \
-    mpas_li_time_integration_fe.o \
+    mpas_li_time_integration_fe_rk.o \
     mpas_li_diagnostic_vars.o \
     mpas_li_advection.o \
     mpas_li_advection_fct_shared.o \
@@ -35,9 +35,9 @@ mpas_li_core.o: mpas_li_time_integration.o \
                      mpas_li_statistics.o \
                      mpas_li_calving.o
 
-mpas_li_time_integration.o: mpas_li_time_integration_fe.o
+mpas_li_time_integration.o: mpas_li_time_integration_fe_rk.o
 
-mpas_li_time_integration_fe.o: mpas_li_advection.o \
+mpas_li_time_integration_fe_rk.o: mpas_li_advection.o \
 	                       mpas_li_calving.o \
                                mpas_li_thermal.o \
 			       mpas_li_iceshelf_melt.o \

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -524,6 +524,7 @@ module li_advection
              endif
 
              ! Update tendencies for RK integration
+             ! How do we deal with these? should they be divided by updated layerThickness now?
              iTracer = 0
              if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
                 iTracer = iTracer + 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -630,10 +630,6 @@ module li_advection
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
 
-         ! Calculate volume converted from grounded to floating
-         ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
-         call li_grounded_to_floating(cellMaskTemporaryField % array, cellMask, thickness, groundedToFloatingThickness, nCells)
-
          ! Calculate flux across grounding line
          ! Do this after new thickness & mask have been calculated, including SMB/BMB
          fluxAcrossGroundingLine(:) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -81,6 +81,7 @@ module li_advection
         geometryPool,           &
         thermalPool,            &
         scratchPool,            &
+        rkTend,                 &
         err,                    &
         advectTracersIn)
 
@@ -109,6 +110,9 @@ module li_advection
       !
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
+
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
+           rkTend                 !< Input/output: accumulated tendencies for RK time integration
 
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information
@@ -207,12 +211,14 @@ module li_advection
       real (kind=RKIND), dimension(:), pointer :: dvEdge
 
       character (len=StrKIND), pointer :: &
-           config_thickness_advection   ! method for advecting thickness and tracers
+           config_thickness_advection, &   ! method for advecting thickness and tracers
+           config_thermal_solver
 
       logical, pointer :: &
            config_print_thickness_advection_info, &  !TODO - change to config_print_advection_info?
            config_print_thermal_info, &
-           config_thermal_calculate_bmb
+           config_thermal_calculate_bmb, &
+           config_calculate_damage
 
       real (kind=RKIND), pointer :: &
            config_ice_density,    & ! rhoi
@@ -225,7 +231,7 @@ module li_advection
 
       logical :: advectTracers     ! if true, then advect tracers as well as thickness
 
-      integer :: iCell1, iCell2, theGroundedCell
+      integer :: iCell1, iCell2, theGroundedCell, iTracer
       integer, parameter :: horizAdvOrder = 4
       integer, parameter :: vertAdvOrder = 1
 
@@ -315,6 +321,8 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_num_halos', config_num_halos)
+      call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(liConfigs, 'config_calculate_damage', config_calculate_damage)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -514,11 +522,27 @@ module li_advection
                 call mpas_log_write(trim(config_tracer_advection) // &
                                     ' tracer advection is not currently supported with fct thickness advection.', MPAS_LOG_ERR)
              endif
+
+             ! Update tendencies for RK integration
+             iTracer = 0
+             if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
+                iTracer = iTracer + 1
+                rkTend(1,:,:) = rkTend(1,:,:) + tend(iTracer,:,:)
+             endif
+             if (config_calculate_damage) then
+                iTracer = iTracer + 1
+                rkTend(2,:,:) = rkTend(2,:,:) + tend(iTracer,:,:)
+             endif
+             iTracer = iTracer + 1
+             rkTend(3,:,:) = rkTend(3,:,:) + tend(iTracer,:,:)  ! passiveTracer2d
+             iTracer = iTracer + 1
+             rkTend(4,:,:) = rkTend(4,:,:) + tend(iTracer,:,:)  ! layerThickness
+
          else
-            err_tmp = 1
-            call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &
-                                ", config_tracer_advection = " // trim(config_tracer_advection) // &
-                                " is not a supported combination.", MPAS_LOG_ERR)
+             err_tmp = 1
+             call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &
+                                 ", config_tracer_advection = " // trim(config_tracer_advection) // &
+                                 " is not a supported combination.", MPAS_LOG_ERR)
          endif
 
          if (config_print_thickness_advection_info) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -81,9 +81,6 @@ module li_advection
         geometryPool,           &
         thermalPool,            &
         scratchPool,            &
-        rkTendAccum,            &
-        tend,                 &
-        rkWeight,               &
         err,                    &
         advectTracersIn)
 
@@ -99,8 +96,6 @@ module li_advection
       real (kind=RKIND), intent(in) :: &
            dt                     !< Input: time step (s)
 
-      real (kind=RKIND), intent(in) :: rkWeight
-
       type (mpas_pool_type), intent(in) :: &
            meshPool               !< Input: mesh information
 
@@ -114,9 +109,6 @@ module li_advection
       !
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-           rkTendAccum            !< Input/output: accumulated tendencies for RK time integration
 
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information
@@ -137,7 +129,6 @@ module li_advection
       !
       !-----------------------------------------------------------------
 
-      real (kind=RKIND), dimension(:,:,:), intent(out) :: tend
       integer, intent(out) :: &
            err                    !< Output: error flag
 
@@ -216,14 +207,12 @@ module li_advection
       real (kind=RKIND), dimension(:), pointer :: dvEdge
 
       character (len=StrKIND), pointer :: &
-           config_thickness_advection, &   ! method for advecting thickness and tracers
-           config_thermal_solver
+           config_thickness_advection   ! method for advecting thickness and tracers
 
       logical, pointer :: &
            config_print_thickness_advection_info, &  !TODO - change to config_print_advection_info?
            config_print_thermal_info, &
-           config_thermal_calculate_bmb, &
-           config_calculate_damage
+           config_thermal_calculate_bmb
 
       real (kind=RKIND), pointer :: &
            config_ice_density,    & ! rhoi
@@ -236,7 +225,7 @@ module li_advection
 
       logical :: advectTracers     ! if true, then advect tracers as well as thickness
 
-      integer :: iCell1, iCell2, theGroundedCell, iTracer
+      integer :: iCell1, iCell2, theGroundedCell
       integer, parameter :: horizAdvOrder = 4
       integer, parameter :: vertAdvOrder = 1
 
@@ -326,8 +315,6 @@ module li_advection
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', config_ocean_density)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_num_halos', config_num_halos)
-      call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
-      call mpas_pool_get_config(liConfigs, 'config_calculate_damage', config_calculate_damage)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -527,26 +514,11 @@ module li_advection
                 call mpas_log_write(trim(config_tracer_advection) // &
                                     ' tracer advection is not currently supported with fct thickness advection.', MPAS_LOG_ERR)
              endif
-
-             ! Update tendencies for RK integration
-             iTracer = 0
-             if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
-                iTracer = iTracer + 1
-                rkTendAccum(1,:,:) = rkTendAccum(1,:,:) + tend(iTracer,:,:) * rkWeight
-             endif
-             if (config_calculate_damage) then
-                iTracer = iTracer + 1
-                rkTendAccum(2,:,:) = rkTendAccum(2,:,:) + tend(iTracer,:,:) * rkWeight
-             endif
-             iTracer = iTracer + 1
-             rkTendAccum(3,:,:) = rkTendAccum(3,:,:) + tend(iTracer,:,:) * rkWeight ! passiveTracer2d
-             iTracer = iTracer + 1
-             rkTendAccum(4,:,:) = rkTendAccum(4,:,:) + tend(iTracer,:,:) * rkWeight  ! layerThickness
          else
-             err_tmp = 1
-             call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &
-                                 ", config_tracer_advection = " // trim(config_tracer_advection) // &
-                                 " is not a supported combination.", MPAS_LOG_ERR)
+            err_tmp = 1
+            call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &
+                                ", config_tracer_advection = " // trim(config_tracer_advection) // &
+                                " is not a supported combination.", MPAS_LOG_ERR)
          endif
 
          if (config_print_thickness_advection_info) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -46,7 +46,8 @@ module li_advection
    !--------------------------------------------------------------------
    public :: li_advection_thickness_tracers, &
              li_layer_normal_velocity, &
-             li_update_geometry
+             li_update_geometry, &
+             li_grounded_to_floating
 
    !--------------------------------------------------------------------
    !
@@ -631,7 +632,7 @@ module li_advection
 
          ! Calculate volume converted from grounded to floating
          ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
-         call grounded_to_floating(cellMaskTemporaryField % array, cellMask, thickness, groundedToFloatingThickness, nCells)
+         call li_grounded_to_floating(cellMaskTemporaryField % array, cellMask, thickness, groundedToFloatingThickness, nCells)
 
          ! Calculate flux across grounding line
          ! Do this after new thickness & mask have been calculated, including SMB/BMB
@@ -2107,7 +2108,7 @@ module li_advection
 
     end subroutine vertical_remap
 
-    subroutine grounded_to_floating(cellMaskOrig, cellMaskNew, thicknessNew, groundedToFloatingThickness, nCells)
+    subroutine li_grounded_to_floating(cellMaskOrig, cellMaskNew, thicknessNew, groundedToFloatingThickness, nCells)
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -2151,7 +2152,7 @@ module li_advection
         endif
       enddo
 
-    end subroutine grounded_to_floating
+    end subroutine li_grounded_to_floating
 
 !***********************************************************************
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -81,7 +81,8 @@ module li_advection
         geometryPool,           &
         thermalPool,            &
         scratchPool,            &
-        rkTend,                 &
+        rkTendAccum,            &
+        tend,                 &
         rkWeight,               &
         err,                    &
         advectTracersIn)
@@ -115,7 +116,7 @@ module li_advection
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
-           rkTend                 !< Input/output: accumulated tendencies for RK time integration
+           rkTendAccum            !< Input/output: accumulated tendencies for RK time integration
 
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information
@@ -136,6 +137,7 @@ module li_advection
       !
       !-----------------------------------------------------------------
 
+      real (kind=RKIND), dimension(:,:,:), intent(out) :: tend
       integer, intent(out) :: &
            err                    !< Output: error flag
 
@@ -530,17 +532,16 @@ module li_advection
              iTracer = 0
              if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
                 iTracer = iTracer + 1
-                rkTend(1,:,:) = rkTend(1,:,:) + tend(iTracer,:,:) * rkWeight
+                rkTendAccum(1,:,:) = rkTendAccum(1,:,:) + tend(iTracer,:,:) * rkWeight
              endif
              if (config_calculate_damage) then
                 iTracer = iTracer + 1
-                rkTend(2,:,:) = rkTend(2,:,:) + tend(iTracer,:,:) * rkWeight
+                rkTendAccum(2,:,:) = rkTendAccum(2,:,:) + tend(iTracer,:,:) * rkWeight
              endif
              iTracer = iTracer + 1
-             rkTend(3,:,:) = rkTend(3,:,:) + tend(iTracer,:,:) * rkWeight ! passiveTracer2d
+             rkTendAccum(3,:,:) = rkTendAccum(3,:,:) + tend(iTracer,:,:) * rkWeight ! passiveTracer2d
              iTracer = iTracer + 1
-             rkTend(4,:,:) = rkTend(4,:,:) + tend(iTracer,:,:)  ! layerThickness
-
+             rkTendAccum(4,:,:) = rkTendAccum(4,:,:) + tend(iTracer,:,:) * rkWeight  ! layerThickness
          else
              err_tmp = 1
              call mpas_log_write("config_thickness_advection = " // trim(config_thickness_advection) // &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -82,6 +82,7 @@ module li_advection
         thermalPool,            &
         scratchPool,            &
         rkTend,                 &
+        rkWeight,               &
         err,                    &
         advectTracersIn)
 
@@ -96,6 +97,8 @@ module li_advection
 
       real (kind=RKIND), intent(in) :: &
            dt                     !< Input: time step (s)
+
+      real (kind=RKIND), intent(in) :: rkWeight
 
       type (mpas_pool_type), intent(in) :: &
            meshPool               !< Input: mesh information
@@ -528,14 +531,14 @@ module li_advection
              iTracer = 0
              if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
                 iTracer = iTracer + 1
-                rkTend(1,:,:) = rkTend(1,:,:) + tend(iTracer,:,:)
+                rkTend(1,:,:) = rkTend(1,:,:) + tend(iTracer,:,:) * rkWeight
              endif
              if (config_calculate_damage) then
                 iTracer = iTracer + 1
-                rkTend(2,:,:) = rkTend(2,:,:) + tend(iTracer,:,:)
+                rkTend(2,:,:) = rkTend(2,:,:) + tend(iTracer,:,:) * rkWeight
              endif
              iTracer = iTracer + 1
-             rkTend(3,:,:) = rkTend(3,:,:) + tend(iTracer,:,:)  ! passiveTracer2d
+             rkTend(3,:,:) = rkTend(3,:,:) + tend(iTracer,:,:) * rkWeight ! passiveTracer2d
              iTracer = iTracer + 1
              rkTend(4,:,:) = rkTend(4,:,:) + tend(iTracer,:,:)  ! layerThickness
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -527,7 +527,6 @@ module li_advection
              endif
 
              ! Update tendencies for RK integration
-             ! How do we deal with these? should they be divided by updated layerThickness now?
              iTracer = 0
              if ( (trim(config_thermal_solver) == 'enthalpy') .or. (trim(config_thermal_solver) == 'temperature') ) then
                 iTracer = iTracer + 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3314,7 +3314,7 @@ module li_calving
 
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_damage(domain, rkTend, rkWeight, err)
+   subroutine li_calculate_damage(domain, rkTendAccum, rkTend, rkWeight, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -3330,7 +3330,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-      real (kind=RKIND), dimension(:,:), intent(out) :: rkTend
+      real (kind=RKIND), dimension(:,:), intent(out) :: rkTend, rkTendAccum
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -3460,7 +3460,8 @@ module li_calving
          ddamagedt(:) = damageSource(:) * damage(:)
          ! Update damage tendency for RK time integration
          do k = 1, nVertLevels
-            rkTend(k,:) = rkTend(k,:) + ddamagedt(:) * layerThickness(k,:) * rkWeight
+            rkTend(k,:) = ddamagedt(:) * layerThickness(k,:)
+            rkTendAccum(k,:) = rkTendAccum(k,:) + rkTend(k,:) * rkWeight
          enddo
 
          damage(:) = damage(:) + ddamagedt(:) * deltat

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3683,14 +3683,18 @@ module li_calving
          endif
          ! put the damageMax value back to preserve the damage value (no heal)
 
-         where (damage < 0.0_RKIND)
-             damage = 0.0_RKIND
-         end where
-
-         where (damage > 1.0_RKIND)
-             damage = 1.0_RKIND
-         end where
-
+         ! limit damage to [damageNye, 1.0]
+         do iCell = 1, nCells
+            if (damage(iCell) < 0.0_RKIND) then
+                damage(iCell) = 0.0_RKIND
+            end if
+            if (damage(iCell) < damageNye(iCell)) then
+                damage(iCell) = damageNye(iCell)
+            end if
+            if (damage(iCell) > 1.0_RKIND) then
+                damage(iCell) = 1.0_RKIND
+            end if
+         end do
 
          do iCell = 1, nCells
             if (li_mask_is_grounded_ice(cellMask(iCell)) .or. .not. li_mask_is_ice(cellMask(iCell))) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3314,12 +3314,12 @@ module li_calving
 
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_damage(domain, rkTend, err)
+   subroutine li_calculate_damage(domain, rkTend, rkWeight, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-
+      real (kind=RKIND), intent(in) :: rkWeight
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -3460,7 +3460,7 @@ module li_calving
          ddamagedt(:) = damageSource(:) * damage(:)
          ! Update damage tendency for RK time integration
          do k = 1, nVertLevels
-            rkTend(k,:) = rkTend(k,:) + ddamagedt(:) * layerThickness(k,:)
+            rkTend(k,:) = rkTend(k,:) + ddamagedt(:) * layerThickness(k,:) * rkWeight
          enddo
 
          damage(:) = damage(:) + ddamagedt(:) * deltat

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3348,6 +3348,7 @@ module li_calving
       real(kind=RKIND), pointer :: config_flowLawExponent
       logical, pointer :: config_print_calving_info
 
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: eMax
       real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin
@@ -3402,6 +3403,7 @@ module li_calving
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)
@@ -3458,7 +3460,7 @@ module li_calving
          ddamagedt(:) = damageSource(:) * damage(:)
          ! Update damage tendency for RK time integration
          do k = 1, nVertLevels
-            rkTend(k,:) = rkTend(k,:) + ddamagedt(:)
+            rkTend(k,:) = rkTend(k,:) + ddamagedt(:) * layerThickness(k,:)
          enddo
 
          damage(:) = damage(:) + ddamagedt(:) * deltat

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3314,7 +3314,7 @@ module li_calving
 
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_damage(domain, err)
+   subroutine li_calculate_damage(domain, rkTend, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -3330,7 +3330,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-
+      real (kind=RKIND), dimension(:,:), intent(out) :: rkTend
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -3368,8 +3368,8 @@ module li_calving
       real (kind=RKIND), pointer :: deltat !< time step (s)
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, pointer :: nCells
-      integer :: iCell, jCell, iNeighbor, n_damage_downstream
+      integer, pointer :: nCells, nVertLevels
+      integer :: iCell, jCell, iNeighbor, n_damage_downstream, k
       real(kind=RKIND) :: damage_downstream
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       real(kind=RKIND), dimension(6) :: localMinInfo, localMaxInfo, globalMinInfo, globalMaxInfo
@@ -3396,6 +3396,7 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
@@ -3455,6 +3456,10 @@ module li_calving
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
          ddamagedt(:) = damageSource(:) * damage(:)
+         ! Update damage tendency for RK time integration
+         do k = 1, nVertLevels
+            rkTend(k,:) = rkTend(k,:) + ddamagedt(:)
+         enddo
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3314,12 +3314,12 @@ module li_calving
 
 !-----------------------------------------------------------------------
 
-   subroutine li_calculate_damage(domain, rkTendAccum, rkTend, rkWeight, err)
+   subroutine li_calculate_damage(domain, err)
 
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-      real (kind=RKIND), intent(in) :: rkWeight
+
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -3330,7 +3330,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-      real (kind=RKIND), dimension(:,:), intent(out) :: rkTend, rkTendAccum
+
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -3348,7 +3348,6 @@ module li_calving
       real(kind=RKIND), pointer :: config_flowLawExponent
       logical, pointer :: config_print_calving_info
 
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: eMax
       real (kind=RKIND), dimension(:), pointer :: tauMax, tauMin
@@ -3369,8 +3368,8 @@ module li_calving
       real (kind=RKIND), pointer :: deltat !< time step (s)
       integer, dimension(:), pointer :: nEdgesOnCell ! number of cells that border each cell
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
-      integer, pointer :: nCells, nVertLevels
-      integer :: iCell, jCell, iNeighbor, n_damage_downstream, k
+      integer, pointer :: nCells
+      integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       real(kind=RKIND), dimension(6) :: localMinInfo, localMaxInfo, globalMinInfo, globalMaxInfo
@@ -3397,13 +3396,11 @@ module li_calving
 
          ! get fields
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-         call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
          call mpas_pool_get_array(meshPool, 'deltat', deltat)
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
          call mpas_pool_get_array(geometryPool, 'damage', damage)
          call mpas_pool_get_array(geometryPool, 'ddamagedt', ddamagedt)
          call mpas_pool_get_array(geometryPool, 's0', s0)
@@ -3458,11 +3455,6 @@ module li_calving
          !    damageSource(:) * (1+exp(-uReconstructX(1,:)*seconds/1000.0)))
 
          ddamagedt(:) = damageSource(:) * damage(:)
-         ! Update damage tendency for RK time integration
-         do k = 1, nVertLevels
-            rkTend(k,:) = ddamagedt(:) * layerThickness(k,:)
-            rkTendAccum(k,:) = rkTendAccum(k,:) + rkTend(k,:) * rkWeight
-         enddo
 
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
@@ -3684,18 +3676,14 @@ module li_calving
          endif
          ! put the damageMax value back to preserve the damage value (no heal)
 
-         ! limit damage to [damageNye, 1.0]
-         do iCell = 1, nCells
-            if (damage(iCell) < 0.0_RKIND) then
-                damage(iCell) = 0.0_RKIND
-            end if
-            if (damage(iCell) < damageNye(iCell)) then
-                damage(iCell) = damageNye(iCell)
-            end if
-            if (damage(iCell) > 1.0_RKIND) then
-                damage(iCell) = 1.0_RKIND
-            end if
-         end do
+         where (damage < 0.0_RKIND)
+             damage = 0.0_RKIND
+         end where
+
+         where (damage > 1.0_RKIND)
+             damage = 1.0_RKIND
+         end where
+
 
          do iCell = 1, nCells
             if (li_mask_is_grounded_ice(cellMask(iCell)) .or. .not. li_mask_is_ice(cellMask(iCell))) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -74,7 +74,7 @@ module li_calving
 !> (3) Calve ice based on an ice thickness threshold
 !-----------------------------------------------------------------------
 
-   subroutine li_calve_ice(domain, err)
+   subroutine li_calve_ice(domain, err, solveVeloAfterCalving)
 
       use li_advection
 
@@ -92,7 +92,7 @@ module li_calving
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-
+      logical, intent(out), optional :: solveVeloAfterCalving
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -111,13 +111,14 @@ module li_calving
       logical, pointer :: config_apply_calving_mask
       real(kind=RKIND), pointer :: config_calving_timescale
 
-      integer, pointer :: nCells
+      integer, pointer :: nCells, nCellsSolve
       integer, pointer :: config_number_of_blocks
 
       real (kind=RKIND), pointer :: deltat  !< time step (s)
 
       integer, dimension(:), pointer :: &
-           indexToCellID       ! list of global cell IDs
+           indexToCellID, &       ! list of global cell IDs
+           cellMask
 
       real (kind=RKIND) ::  &
            calvingFraction ! fraction of ice that calves in each column; depends on calving_timescale
@@ -136,13 +137,21 @@ module li_calving
 
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
 
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+
       type (field1dReal), pointer :: originalThicknessField
 
       real (kind=RKIND), dimension(:), pointer :: originalThickness
 
+      type (field1dInteger), pointer :: cellMaskTemporaryField
+
       integer :: iCell
 
+      real (kind=RKIND), parameter :: smallNumber = 1.0e-6_RKIND
+
       integer :: err_tmp
+
+      real (kind=RKIND), dimension(1) :: calvingSumLocal, calvingSumGlobal
 
       err = 0
       err_tmp = 0
@@ -154,6 +163,15 @@ module li_calving
       call mpas_pool_get_config(liConfigs, 'config_print_calving_info', config_print_calving_info)
       call mpas_pool_get_config(liConfigs, 'config_data_calving', config_data_calving)
       call mpas_pool_get_config(liConfigs, 'config_number_of_blocks', config_number_of_blocks)
+
+      if (present(solveVeloAfterCalving)) then
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+         call mpas_pool_get_field(geometryPool, 'cellMaskTemporary', cellMaskTemporaryField)
+         call mpas_allocate_scratch_field(cellMaskTemporaryField, .true.)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         ! Store cellMask prior to calving
+         cellMaskTemporaryField % array(:) = cellMask(:)
+      endif
 
       ! Zero calvingThickness here instead of or in addition to in individual subroutines.
       ! This is necessary when using damage threshold calving with other calving
@@ -206,7 +224,7 @@ module li_calving
       ! However, the eigencalving method requires multiple applications of the calvingThickness
       ! to the thickness.  So the simplest method to apply data calving is to store the old
       ! thickness and then set it back when we are done.
-      if (config_data_calving) then
+      if ( config_data_calving .or. present(solveVeloAfterCalving) ) then
          call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
          call mpas_pool_get_field(scratchPool, 'workCell2',  originalThicknessField)
          call mpas_allocate_scratch_field(originalThicknessField, single_block_in = .false.)
@@ -337,8 +355,22 @@ module li_calving
 
          block => block % next
       end do
+      if (present(solveVeloAfterCalving)) then
+         call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
+         calvingSumLocal(1) = sum(calvingThickness(1:nCellsSolve) * areaCell(1:nCellsSolve) * &
+                               real(li_mask_is_dynamic_ice_int(cellMaskTemporaryField % array(1:nCellsSolve)), RKIND))
+         call mpas_dmpar_sum_real_array(domain % dminfo, 1, calvingSumLocal(1), calvingSumGlobal(1))
+         if (calvingSumGlobal(1) > smallNumber) then
+            solveVeloAfterCalving = .true.
+         else
+            solveVeloAfterCalving = .false.
+         endif
+         call mpas_deallocate_scratch_field(cellMaskTemporaryField, .true.)
+      endif
 
-      if (config_data_calving) then
+      if ( config_data_calving .or. present(solveVeloAfterCalving) ) then
          call mpas_deallocate_scratch_field(originalThicknessField, single_block_in=.false.)
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -167,9 +167,8 @@ module li_time_integration
       select case (config_time_integration)
       case ('forward_euler')
          call li_time_integrator_forwardeuler(domain, err_tmp)
-      case ('rk4')
-         call mpas_log_write(trim(config_time_integration) // ' is not currently supported.', MPAS_LOG_ERR)
-         err_tmp = 1
+      case ('runge_kutta')
+         call li_time_integrator_forwardeuler(domain, err_tmp)
       case default
          call mpas_log_write(trim(config_time_integration) // ' is not a valid land ice time integration option.', MPAS_LOG_ERR)
          err_tmp = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -26,7 +26,7 @@ module li_time_integration
    use mpas_timekeeping
    use mpas_log
 
-   use li_time_integration_fe
+   use li_time_integration_fe_rk
    use li_setup
    use li_constants
 
@@ -166,9 +166,9 @@ module li_time_integration
       !call mpas_log_write('Using ' // trim(config_time_integration) // ' time integration.')
       select case (config_time_integration)
       case ('forward_euler')
-         call li_time_integrator_forwardeuler(domain, err_tmp)
+         call li_time_integrator_forwardeuler_rungekutta(domain, err_tmp)
       case ('runge_kutta')
-         call li_time_integrator_forwardeuler(domain, err_tmp)
+         call li_time_integrator_forwardeuler_rungekutta(domain, err_tmp)
       case default
          call mpas_log_write(trim(config_time_integration) // ' is not a valid land ice time integration option.', MPAS_LOG_ERR)
          err_tmp = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -146,6 +146,8 @@ module li_time_integration_fe
       call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
+      call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       allocate(temperatureProv(nVertLevels, nCells+1))
       allocate(enthalpyProv(nVertLevels, nCells+1))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -119,10 +119,13 @@ module li_time_integration_fe
                                                     waterFrac
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
-      real (kind=RKIND), dimension(:), allocatable :: damageProv, passiveTracer2dProv
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessProv, &
                                                         temperatureProv, &
-                                                        enthalpyProv
+                                                        enthalpyProv, &
+                                                        passiveTracer3d, &
+                                                        passiveTracer3dProv, &
+                                                        damage3d, &
+                                                        damage3dProv
       integer, pointer :: nVertLevels
       integer, pointer :: nCells
       real (kind=RKIND), pointer :: deltat
@@ -147,14 +150,18 @@ module li_time_integration_fe
       allocate(temperatureProv(nVertLevels, nCells+1))
       allocate(enthalpyProv(nVertLevels, nCells+1))
       allocate(layerThicknessProv(nVertLevels, nCells+1))
-      allocate(damageProv(nCells+1))
-      allocate(passiveTracer2dProv(nCells+1))
+      allocate(damage3dProv(nVertLevels, nCells+1))
+      allocate(damage3d(nVertLevels, nCells+1))
+      allocate(passiveTracer3dProv(nVertLevels, nCells+1))
+      allocate(passiveTracer3d(nVertLevels, nCells+1))
 
       temperatureProv(:,:) = 0.0_RKIND
       enthalpyProv(:,:) = 0.0_RKIND
       layerThicknessProv(:,:) = 0.0_RKIND
-      damageProv(:) = 0.0_RKIND
-      passiveTracer2dProv(:) = 0.0_RKIND
+      damage3dProv(:,:) = 0.0_RKIND
+      damage3d(:,:) = 0.0_RKIND
+      passiveTracer3dProv(:,:) = 0.0_RKIND
+      passiveTracer3d(:,:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -215,8 +222,10 @@ module li_time_integration_fe
       temperatureProv(:,:) = temperature(:,:)
       enthalpyProv(:,:) =  enthalpy(:,:)
       layerThicknessProv(:,:) = layerThickness(:,:)
-      damageProv(:) = damage(:)
-      passiveTracer2dProv(:) = passiveTracer2d(:)
+      do k = 1, nVertLevels
+         damage3dProv(k,:) = damage(:)
+         passiveTracer3dProv(k,:) = passiveTracer2d(:)
+      enddo
       rkTend(:,:,:) = 0.0_RKIND
 ! *** Start RK loop ***
       do rkStep = 1, 2
@@ -246,8 +255,19 @@ module li_time_integration_fe
          ! before final velocity solve
          if (rkStep .eq. 2) then ! or whichever is last rk step
             ! y_{n+1} = y_n + (k1 + k2) / 2
+
+            ! Need layerThickness first in order to update other tracers
+            if (trim(config_thickness_advection) == 'fct') then
+               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:) / 2.0_RKIND
+               thickness = sum(layerThickness, 1)
+            endif
+
             if (trim(config_thermal_solver) == 'enthalpy') then
-               enthalpy(:,:) = enthalpyProv(:,:) + deltat * rkTend(1,:,:) / 2.0_RKIND
+               where (layerThickness(:,:) > 0.0_RKIND)
+                  enthalpy(:,:) = ( enthalpyProv(:,:) * layerThicknessProv(:,:) + &
+                                    deltat * rkTend(1,:,:) / 2.0_RKIND ) / layerThickness(:,:)
+               ! elsewhere, what? 
+               end where
                ! given the enthalpy, compute the temperature and water fraction
                do iCell = 1, nCells
 
@@ -259,26 +279,40 @@ module li_time_integration_fe
                        waterFrac(:,iCell))
 
                enddo
+
             elseif (trim(config_thermal_solver) == 'temperature') then
-               temperature(:,:) = temperatureProv(:,:) + deltat * rkTend(1,:,:) / 2.0_RKIND
+               where (layerThickness(:,:) > 0.0_RKIND)
+                  temperature(:,:) = ( temperatureProv(:,:) * layerThicknessProv(:,:) + &
+                                       deltat * rkTend(1,:,:) / 2.0_RKIND ) / layerThickness(:,:)
+               ! elsewhere, what?
+               end where
             endif
 
             if (config_calculate_damage) then
                do iCell = 1, nCells
-                  damage(iCell) = damageProv(iCell) + deltat * sum(rkTend(2,:,iCell) &
-                              * layerThicknessFractions) / 2.0_RKIND
+                  do k = 1, nVertLevels
+                     if (layerThickness(k,iCell) > 0.0_RKIND) then 
+                        damage3d(k,iCell) = ( damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                                            deltat * rkTend(2,k,iCell) / 2.0_RKIND ) / layerThickness(k,iCell)
+                     else
+                        damage3d(k,iCell) = 0.0_RKIND
+                     endif
+                  enddo
+                  damage(iCell) = sum(damage3d(:, iCell) * layerThicknessFractions)
                enddo
             endif
 
             do iCell = 1, nCells
-               passiveTracer2d(iCell) = passiveTracer2dProv(iCell) + deltat * & 
-                                        sum(rkTend(3,:,iCell) * layerThicknessFractions) / 2.0_RKIND
+               do k = 1, nVertLevels
+                  if (layerThickness(k,iCell) > 0.0_RKIND) then
+                     passiveTracer3d(k,iCell) = ( passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                                                  deltat * rkTend(3,k,iCell) / 2.0_RKIND ) / layerThickness(k,iCell)
+                  else
+                     passiveTracer3d(k,iCell) = 0.0_RKIND
+                  endif
+               enddo
+               passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
             enddo
-
-            if (trim(config_thickness_advection) == 'fct') then
-               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:) / 2.0_RKIND
-               thickness = sum(layerThickness, 1)
-            endif
 
             ! === Ensure damage is within bounds after full time integration ===
             if (config_finalize_damage_after_advection) then
@@ -344,6 +378,13 @@ module li_time_integration_fe
           call mpas_log_write("An error has occurred in li_time_integrator_forwardeuler.", MPAS_LOG_ERR)
       endif
 
+      deallocate(temperatureProv)
+      deallocate(enthalpyProv)
+      deallocate(layerThicknessProv)
+      deallocate(damage3dProv)
+      deallocate(damage3d)
+      deallocate(passiveTracer3dProv)
+      deallocate(passiveTracer3d)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -30,11 +30,12 @@ module li_time_integration_fe
 
    use li_advection
    use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_finalize_damage_after_advection
-   use li_thermal, only: li_thermal_solver
+   use li_thermal, only: li_thermal_solver, li_enthalpy_to_temperature_kelvin
    use li_iceshelf_melt
    use li_diagnostic_vars
    use li_setup
    use li_constants
+   use li_mesh
 
    implicit none
    private
@@ -103,17 +104,57 @@ module li_time_integration_fe
       !-----------------------------------------------------------------
       type (block_type), pointer :: block
       integer :: err_tmp
-
+      type (mpas_pool_type), pointer :: geometryPool, thermalPool, meshPool
+      
       logical, pointer :: config_restore_calving_front
       logical, pointer :: config_calculate_damage
       logical, pointer :: config_finalize_damage_after_advection
+      character (len=StrKIND), pointer :: config_thickness_advection
+      character (len=StrKIND), pointer :: config_thermal_solver
+      integer :: rkStep, iCell, iTracer, k
+      real (kind=RKIND), dimension(:,:,:), pointer :: rkTend
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
+                                                    temperature, &
+                                                    enthalpy, &
+                                                    waterFrac
+      real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
+      real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
+      real (kind=RKIND), dimension(:), allocatable :: damageProv, passiveTracer2dProv
+      real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessProv, &
+                                                        temperatureProv, &
+                                                        enthalpyProv
+      integer, pointer :: nVertLevels
+      integer, pointer :: nCells
+      real (kind=RKIND), pointer :: deltat
 
       err = 0
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
-      call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection',config_finalize_damage_after_advection)
+      call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection', config_finalize_damage_after_advection)
+      call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
+      call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'thermal', thermalPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
+      call mpas_pool_get_array(meshPool, 'deltat', deltat)
+      call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
+
+      allocate(temperatureProv(nVertLevels, nCells+1))
+      allocate(enthalpyProv(nVertLevels, nCells+1))
+      allocate(layerThicknessProv(nVertLevels, nCells+1))
+      allocate(damageProv(nCells+1))
+      allocate(passiveTracer2dProv(nCells+1))
+
+      temperatureProv(:,:) = 0.0_RKIND
+      enthalpyProv(:,:) = 0.0_RKIND
+      layerThicknessProv(:,:) = 0.0_RKIND
+      damageProv(:) = 0.0_RKIND
+      passiveTracer2dProv(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -135,6 +176,8 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("face melting for grounded ice")
 
+! *** TODO: Should basal melt rate calculation and column physics go inside RK loop? ***
+
 ! === Basal melting for floating ice ===========
       call mpas_timer_start("basal melting for floating ice")
       call li_basal_melt_floating_ice(domain, err_tmp)
@@ -147,37 +190,112 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("vertical therm")
 
-! === calculate damage ===========
-      if (config_calculate_damage) then
-          call mpas_timer_start("damage")
-          call li_calculate_damage(domain, err_tmp)
-          err = ior(err, err_tmp)
-          call mpas_timer_stop("damage")
-      endif
-
-! === Compute new state for prognostic variables ==================================
-      call mpas_timer_start("advect thickness and tracers")
-      call advection_solver(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("advect thickness and tracers")
-
-! === finalize damage after advection ===========
-      if (config_finalize_damage_after_advection) then
-          call mpas_timer_start("finalize damage")
-          call li_finalize_damage_after_advection(domain, err_tmp)
-          err = ior(err, err_tmp)
-          call mpas_timer_stop("finalize damage")
-      endif
-
 ! === Update subglacial hydrology  ===========
 ! It's not clear where the best place to call this should be.
 ! Seems sensible to put it after thermal evolution is complete to get updated basal melting source term.
 ! Also seems (might be?) better to put it after geometry evolution.
 ! We want it before the velocity solve since the hydro model can control  the velo basal b.c.
+! This was moved to be before geometry evolution to simplify RK time integration.
       call mpas_timer_start("subglacial hydro")
       call li_SGH_solve(domain, err_tmp)
       err = ior(err, err_tmp)
       call mpas_timer_stop("subglacial hydro")
+
+! *** TODO: Should basal melt rate calculation and column physics go inside RK loop? ***
+      call mpas_pool_get_array(geometryPool, 'rkTend', rkTend)
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
+      call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
+      call mpas_pool_get_array(geometryPool, 'damage', damage)
+
+      call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+      call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
+      call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
+      ! Save relevant fields before RK loop, to be used in update at the end
+      temperatureProv(:,:) = temperature(:,:)
+      enthalpyProv(:,:) =  enthalpy(:,:)
+      layerThicknessProv(:,:) = layerThickness(:,:)
+      damageProv(:) = damage(:)
+      passiveTracer2dProv(:) = passiveTracer2d(:)
+      rkTend(:,:,:) = 0.0_RKIND
+! *** Start RK loop ***
+      do rkStep = 1, 2
+         ! === calculate damage ===========
+         if (config_calculate_damage) then
+             call mpas_timer_start("damage")
+             call li_calculate_damage(domain, rkTend(2,:,:), err_tmp)
+             err = ior(err, err_tmp)
+             call mpas_timer_stop("damage")
+         endif
+
+         ! === Compute new state for prognostic variables ===
+         call mpas_timer_start("advect thickness and tracers")
+         call advection_solver(domain, rkTend, err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_timer_stop("advect thickness and tracers")
+
+         ! === finalize damage after advection ===========
+         if (config_finalize_damage_after_advection) then
+             call mpas_timer_start("finalize damage")
+             call li_finalize_damage_after_advection(domain, err_tmp)
+             err = ior(err, err_tmp)
+             call mpas_timer_stop("finalize damage")
+         endif
+
+         ! Update thickness, damage, temperature or enthalpy, passiveTracer2d 
+         ! before final velocity solve
+         if (rkStep .eq. 2) then ! or whichever is last rk step
+            ! y_{n+1} = y_n + (k1 + k2) / 2
+            if (trim(config_thermal_solver) == 'enthalpy') then
+               enthalpy(:,:) = enthalpyProv(:,:) + deltat * rkTend(1,:,:) / 2.0_RKIND
+               ! given the enthalpy, compute the temperature and water fraction
+               do iCell = 1, nCells
+
+                  call li_enthalpy_to_temperature_kelvin(&
+                       layerCenterSigma,                           &
+                       thickness(iCell),                           &
+                       enthalpy(:,iCell),     &
+                       temperature(:,iCell),  &
+                       waterFrac(:,iCell))
+
+               enddo
+            elseif (trim(config_thermal_solver) == 'temperature') then
+               temperature(:,:) = temperatureProv(:,:) + deltat * rkTend(1,:,:) / 2.0_RKIND
+            endif
+
+            if (config_calculate_damage) then
+               do iCell = 1, nCells
+                  damage(iCell) = damageProv(iCell) + deltat * sum(rkTend(2,:,iCell) &
+                              * layerThicknessFractions) / 2.0_RKIND
+               enddo
+            endif
+
+            do iCell = 1, nCells
+               passiveTracer2d(iCell) = passiveTracer2dProv(iCell) + deltat * & 
+                                        sum(rkTend(3,:,iCell) * layerThicknessFractions) / 2.0_RKIND
+            enddo
+
+            if (trim(config_thickness_advection) == 'fct') then
+               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:) / 2.0_RKIND
+               thickness = sum(layerThickness, 1)
+            endif
+
+            ! === Ensure damage is within bounds after full time integration ===
+            if (config_finalize_damage_after_advection) then
+                call mpas_timer_start("finalize damage")
+                call li_finalize_damage_after_advection(domain, err_tmp)
+                err = ior(err, err_tmp)
+                call mpas_timer_stop("finalize damage")
+            endif
+         endif
+         
+         ! Update velocity for each RK step
+         ! === Solve Velocity =====================
+         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+         err = ior(err, err_tmp)
+
+! *** end RK loop ***
+      enddo
 
 ! === Calve ice ========================
       call mpas_timer_start("calve_ice")
@@ -207,10 +325,11 @@ module li_time_integration_fe
       call li_bedtopo_solve(domain, err=err_tmp)
       err = ior(err, err_tmp)
 
+! TODO: Determine whether we need to update velocities again
 ! === Solve Velocity =====================
-      ! During time-stepping, we always solveVelo
-      call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
-      err = ior(err, err_tmp)
+!      ! During time-stepping, we always solveVelo
+!      call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+!      err = ior(err, err_tmp)
 
 ! === Calculate diagnostic variables for new state =====================
 
@@ -591,7 +710,7 @@ module li_time_integration_fe
 !>        in calculate tendencies are now in prepare_advection.
 !-----------------------------------------------------------------------
 
-   subroutine advection_solver(domain, err)
+   subroutine advection_solver(domain, rkTend, err)
 
       use mpas_timekeeping
       use li_mask
@@ -604,7 +723,7 @@ module li_time_integration_fe
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: rkTend
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -216,7 +216,7 @@ module li_time_integration_fe
       err = ior(err, err_tmp)
       call mpas_timer_stop("subglacial hydro")
 
-! *** TODO: Should basal melt rate calculation and column physics go inside RK loop? ***
+! *** TODO: Should basal melt rate calculation, column physics, and hydrology go inside RK loop? ***
       call mpas_pool_get_array(geometryPool, 'rkTend', rkTend)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
@@ -240,6 +240,7 @@ module li_time_integration_fe
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
+         config_rk_order = 1
          rkWeights(:) = 1.0_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
@@ -297,10 +298,10 @@ module li_time_integration_fe
              call mpas_timer_stop("finalize damage")
          endif
 
-         ! Update thickness, damage, temperature or enthalpy, passiveTracer2d 
-         ! before final velocity solve
-         if (rkStep .eq. config_rk_order) then ! or whichever is last rk step
-            ! y_{n+1} = y_n + (k1 + k2) / 2
+         ! If using Runge-Kutta time integration, update thickness, damage,
+         ! temperature or enthalpy, passiveTracer2d before final velocity solve.
+         ! If using forward Euler, these have already been updated above. 
+         if ( (rkStep .eq. config_rk_order) .and. (config_rk_order > 1) ) then
 
             ! Need layerThickness first in order to update other tracers
             if (trim(config_thickness_advection) == 'fct') then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -245,6 +245,8 @@ module li_time_integration_fe
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
+         call mpas_dmpar_field_halo_exch(domain, 'rkTend')
+
          ! === finalize damage after advection ===========
          if (config_finalize_damage_after_advection) then
              call mpas_timer_start("finalize damage")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -111,6 +111,8 @@ module li_time_integration_fe
       logical, pointer :: config_finalize_damage_after_advection
       character (len=StrKIND), pointer :: config_thickness_advection
       character (len=StrKIND), pointer :: config_thermal_solver
+      character (len=StrKIND), pointer :: config_time_integration
+      integer, pointer :: config_rk_order
       integer :: rkStep, iCell, iTracer, k
       real (kind=RKIND), dimension(:,:,:), pointer :: rkTend
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
@@ -129,6 +131,8 @@ module li_time_integration_fe
       integer, pointer :: nVertLevels
       integer, pointer :: nCells
       real (kind=RKIND), pointer :: deltat
+      real (kind=RKIND) :: deltatFull
+      real (kind=RKIND), dimension(4) :: rkWeights, rkSubstepWeights
 
       err = 0
       err_tmp = 0
@@ -138,6 +142,8 @@ module li_time_integration_fe
       call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection', config_finalize_damage_after_advection)
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(liConfigs, 'config_rk_order', config_rk_order)
+      call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'thermal', thermalPool)
@@ -229,19 +235,55 @@ module li_time_integration_fe
          passiveTracer3dProv(k,:) = passiveTracer2d(:)
       enddo
       rkTend(:,:,:) = 0.0_RKIND
+      deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
+
+      if ( (trim(config_time_integration) == 'forward_euler') .or. &
+           ((trim(config_time_integration) == 'runge_kutta') .and. &
+           (config_rk_order == 1)) ) then
+         rkWeights(:) = 1.0_RKIND
+         rkSubstepWeights(:) = 1.0_RKIND
+      elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
+               (config_rk_order == 2) ) then
+         ! use classical (i.e., endpoint, or Heun's method) RK2. Could also
+         ! add config option to use midpoint
+         rkWeights(:) = 0.5_RKIND
+         rkSubstepWeights(:) = 1.0_RKIND
+      !elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
+      !         (config_rk_order == 3) ) then
+         ! use Strong Stability Preserving RK3?
+      elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
+               (config_rk_order == 4) ) then
+         rkWeights(1) = 1.0_RKIND / 6.0_RKIND
+         rkWeights(2) = 1.0_RKIND / 3.0_RKIND
+         rkWeights(3) = 1.0_RKIND / 3.0_RKIND
+         rkWeights(4) = 1.0_RKIND / 6.0_RKIND
+
+         rkSubstepWeights(1) = 0.5_RKIND
+         rkSubstepWeights(2) = 0.5_RKIND
+         rkSubstepWeights(3) = 1.0_RKIND
+         rkSubstepWeights(4) = 1.0_RKIND
+      else
+         err = 1
+         call mpas_log_write('config_time_integration = ' // trim(config_time_integration) &
+                             // ' is not supported with config_rk_order = $i', &
+                             intArgs=(/config_rk_order/), messageType=MPAS_LOG_ERR)
+      endif 
 ! *** Start RK loop ***
-      do rkStep = 1, 2
+      do rkStep = 1, config_rk_order
+         call mpas_log_write('beginning rk step $i;  rkSubstepWeight = $r', &
+                             intArgs=(/rkStep/), realArgs=(/rkSubstepWeights(rkStep)/))
+         deltat = deltatFull * rkSubstepWeights(rkStep)
          ! === calculate damage ===========
          if (config_calculate_damage) then
              call mpas_timer_start("damage")
-             call li_calculate_damage(domain, rkTend(2,:,:), err_tmp)
+             call li_calculate_damage(domain, rkTend(2,:,:), rkWeights(rkStep), err_tmp)
              err = ior(err, err_tmp)
              call mpas_timer_stop("damage")
          endif
 
          ! === Compute new state for prognostic variables ===
          call mpas_timer_start("advect thickness and tracers")
-         call advection_solver(domain, rkTend, err_tmp)
+         call advection_solver(domain, rkTend, rkWeights(rkStep), err_tmp)
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
@@ -257,19 +299,19 @@ module li_time_integration_fe
 
          ! Update thickness, damage, temperature or enthalpy, passiveTracer2d 
          ! before final velocity solve
-         if (rkStep .eq. 2) then ! or whichever is last rk step
+         if (rkStep .eq. config_rk_order) then ! or whichever is last rk step
             ! y_{n+1} = y_n + (k1 + k2) / 2
 
             ! Need layerThickness first in order to update other tracers
             if (trim(config_thickness_advection) == 'fct') then
-               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:) / 2.0_RKIND
+               layerThickness(:,:) = layerThicknessProv(:,:) + deltatFull * rkTend(4,:,:)
                thickness = sum(layerThickness, 1)
             endif
 
             if (trim(config_thermal_solver) == 'enthalpy') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   enthalpy(:,:) = ( enthalpyProv(:,:) * layerThicknessProv(:,:) + &
-                                    deltat * rkTend(1,:,:) / 2.0_RKIND ) / layerThickness(:,:)
+                                    deltatFull * rkTend(1,:,:) ) / layerThickness(:,:)
                ! elsewhere, what? 
                end where
                ! given the enthalpy, compute the temperature and water fraction
@@ -287,7 +329,7 @@ module li_time_integration_fe
             elseif (trim(config_thermal_solver) == 'temperature') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   temperature(:,:) = ( temperatureProv(:,:) * layerThicknessProv(:,:) + &
-                                       deltat * rkTend(1,:,:) / 2.0_RKIND ) / layerThickness(:,:)
+                                       deltatFull * rkTend(1,:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
                end where
             endif
@@ -297,7 +339,7 @@ module li_time_integration_fe
                   do k = 1, nVertLevels
                      if (layerThickness(k,iCell) > 0.0_RKIND) then 
                         damage3d(k,iCell) = ( damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                            deltat * rkTend(2,k,iCell) / 2.0_RKIND ) / layerThickness(k,iCell)
+                                            deltatFull * rkTend(2,k,iCell) ) / layerThickness(k,iCell)
                      else
                         damage3d(k,iCell) = 0.0_RKIND
                      endif
@@ -310,7 +352,7 @@ module li_time_integration_fe
                do k = 1, nVertLevels
                   if (layerThickness(k,iCell) > 0.0_RKIND) then
                      passiveTracer3d(k,iCell) = ( passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                                  deltat * rkTend(3,k,iCell) / 2.0_RKIND ) / layerThickness(k,iCell)
+                                                  deltatFull * rkTend(3,k,iCell) ) / layerThickness(k,iCell)
                   else
                      passiveTracer3d(k,iCell) = 0.0_RKIND
                   endif
@@ -335,6 +377,8 @@ module li_time_integration_fe
 ! *** end RK loop ***
       enddo
 
+! Reset time step to full length after RK loop
+      deltat = deltatFull
 ! === Calve ice ========================
       call mpas_timer_start("calve_ice")
 
@@ -755,7 +799,7 @@ module li_time_integration_fe
 !>        in calculate tendencies are now in prepare_advection.
 !-----------------------------------------------------------------------
 
-   subroutine advection_solver(domain, rkTend, err)
+   subroutine advection_solver(domain, rkTend, rkWeight, err)
 
       use mpas_timekeeping
       use li_mask
@@ -763,7 +807,7 @@ module li_time_integration_fe
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-
+      real (kind=RKIND), intent(in) :: rkWeight
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -887,6 +931,7 @@ module li_time_integration_fe
                  thermalPool,            &
                  scratchPool,            &
                  rkTend,                 &
+                 rkWeight,               &
                  err_tmp,                &
                  advectTracersIn = .true.)
 
@@ -907,6 +952,7 @@ module li_time_integration_fe
                  thermalPool,            &
                  scratchPool,            &
                  rkTend,                 &
+                 rkWeight,               &
                  err_tmp,                &
                  advectTracersIn = .false.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -841,6 +841,7 @@ module li_time_integration_fe
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 rkTend,                 &
                  err_tmp,                &
                  advectTracersIn = .true.)
 
@@ -860,6 +861,7 @@ module li_time_integration_fe
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 rkTend,                 &
                  err_tmp,                &
                  advectTracersIn = .false.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -113,7 +113,7 @@ module li_time_integration_fe_rk
       character (len=StrKIND), pointer :: config_thermal_solver
       character (len=StrKIND), pointer :: config_time_integration
       integer, pointer :: config_rk_order
-      integer :: rkStep, iCell, iTracer, k
+      integer :: rkStage, iCell, iTracer, k
       real (kind=RKIND), dimension(:,:,:), pointer :: rkTend
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                     temperature, &
@@ -122,6 +122,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessProv, &
+                                                        layerThicknessTmp, &
                                                         temperatureProv, &
                                                         enthalpyProv, &
                                                         passiveTracer3d, &
@@ -133,6 +134,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), pointer :: deltat
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkWeights, rkSubstepWeights
+      real (kind=RKIND), dimension(3) :: rkSSPweights
 
       err = 0
       err_tmp = 0
@@ -158,6 +160,7 @@ module li_time_integration_fe_rk
       allocate(temperatureProv(nVertLevels, nCells+1))
       allocate(enthalpyProv(nVertLevels, nCells+1))
       allocate(layerThicknessProv(nVertLevels, nCells+1))
+      allocate(layerThicknessTmp(nVertLevels, nCells+1))
       allocate(damage3dProv(nVertLevels, nCells+1))
       allocate(damage3d(nVertLevels, nCells+1))
       allocate(passiveTracer3dProv(nVertLevels, nCells+1))
@@ -166,6 +169,7 @@ module li_time_integration_fe_rk
       temperatureProv(:,:) = 0.0_RKIND
       enthalpyProv(:,:) = 0.0_RKIND
       layerThicknessProv(:,:) = 0.0_RKIND
+      layerThicknessTmp(:,:) = 0.0_RKIND
       damage3dProv(:,:) = 0.0_RKIND
       damage3d(:,:) = 0.0_RKIND
       passiveTracer3dProv(:,:) = 0.0_RKIND
@@ -237,6 +241,13 @@ module li_time_integration_fe_rk
       rkTend(:,:,:) = 0.0_RKIND
       deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
 
+      ! Set RK weights based on desired time integration method. Note
+      ! that rkSubstepWeights are used to update at each sub-step, and
+      ! are thus offset from the typical writing of the coefficients
+      ! by one index. e.g., the coefficients for RK4 are usually written
+      ! (0, 1/2, 1/2, 1), while we use (1/2, 1/2, 1). The last entry of 1.0
+      ! is simply for ease of implementation.
+      rkSSPweights(:) = 1.0_RKIND
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
@@ -249,9 +260,15 @@ module li_time_integration_fe_rk
          ! add config option to use midpoint
          rkWeights(:) = 0.5_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
-      !elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
-      !         (config_rk_order == 3) ) then
-         ! use Strong Stability Preserving RK3?
+      elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
+               (config_rk_order == 3) ) then
+         ! use Strong Stability Preserving RK3
+         rkWeights(:) = 1.0_RKIND
+         rkSubstepWeights(:) = 1.0_RKIND
+
+         rkSSPweights(1) = 1.0_RKIND
+         rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
+         rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 4) ) then
          rkWeights(1) = 1.0_RKIND / 6.0_RKIND
@@ -262,7 +279,7 @@ module li_time_integration_fe_rk
          rkSubstepWeights(1) = 0.5_RKIND
          rkSubstepWeights(2) = 0.5_RKIND
          rkSubstepWeights(3) = 1.0_RKIND
-         rkSubstepWeights(4) = 1.0_RKIND
+         rkSubstepWeights(4) = 1.0_RKIND ! not used
       else
          err = 1
          call mpas_log_write('config_time_integration = ' // trim(config_time_integration) &
@@ -270,21 +287,22 @@ module li_time_integration_fe_rk
                              intArgs=(/config_rk_order/), messageType=MPAS_LOG_ERR)
       endif 
 ! *** Start RK loop ***
-      do rkStep = 1, config_rk_order
+      do rkStage = 1, config_rk_order
          call mpas_log_write('beginning rk step $i;  rkSubstepWeight = $r', &
-                             intArgs=(/rkStep/), realArgs=(/rkSubstepWeights(rkStep)/))
-         deltat = deltatFull * rkSubstepWeights(rkStep)
+                             intArgs=(/rkStage/), realArgs=(/rkSubstepWeights(rkStage)/))
+         deltat = deltatFull * rkSubstepWeights(rkStage)
+
          ! === calculate damage ===========
          if (config_calculate_damage) then
              call mpas_timer_start("damage")
-             call li_calculate_damage(domain, rkTend(2,:,:), rkWeights(rkStep), err_tmp)
+             call li_calculate_damage(domain, rkTend(2,:,:), rkWeights(rkStage), err_tmp)
              err = ior(err, err_tmp)
              call mpas_timer_stop("damage")
          endif
 
          ! === Compute new state for prognostic variables ===
          call mpas_timer_start("advect thickness and tracers")
-         call advection_solver(domain, rkTend, rkWeights(rkStep), err_tmp)
+         call advection_solver(domain, rkTend, rkWeights(rkStage), err_tmp)
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
@@ -298,10 +316,88 @@ module li_time_integration_fe_rk
              call mpas_timer_stop("finalize damage")
          endif
 
-         ! If using Runge-Kutta time integration, update thickness, damage,
+         ! If using SSP RK3, then update thickness and tracers incrementally.
+         ! For first RK stage, thickness and tracer updates above are sufficient
+         if ( (config_rk_order == 3) .and. (rkStage > 1 ) ) then
+            call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+            call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
+            call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
+            call mpas_pool_get_array(geometryPool, 'damage', damage)
+
+            call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+            call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
+            call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
+
+            layerThicknessTmp(:,:) = layerThickness(:,:)
+               layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessProv(:,:) + &
+                                     (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)
+               thickness = sum(layerThickness, 1)
+
+            if (trim(config_thermal_solver) == 'enthalpy') then
+               where (layerThickness(:,:) > 0.0_RKIND)
+                  enthalpy(:,:) = ( rkSSPweights(rkStage) * enthalpyProv(:,:) * layerThicknessProv(:,:) + &
+                                    (1.0_RKIND - rkSSPweights(rkStage)) * enthalpy(:,:) * layerThicknessTmp(:,:) ) / layerThickness(:,:)
+               ! elsewhere, what?
+               end where
+               ! given the enthalpy, compute the temperature and water fraction
+               do iCell = 1, nCells
+
+                  call li_enthalpy_to_temperature_kelvin(&
+                       layerCenterSigma,                           &
+                       thickness(iCell),                           &
+                       enthalpy(:,iCell),     &
+                       temperature(:,iCell),  &
+                       waterFrac(:,iCell))
+
+               enddo
+
+            elseif (trim(config_thermal_solver) == 'temperature') then
+               where (layerThickness(:,:) > 0.0_RKIND)
+                  temperature(:,:) = ( rkSSPweights(rkStage) * temperatureProv(:,:) * layerThicknessProv(:,:) + &
+                                       (1.0_RKIND - rkSSPweights(rkStage)) * temperature(:,:) * layerThicknessTmp(:,:) ) / layerThickness(:,:)
+               ! elsewhere, what?
+               end where
+            endif
+
+            if (config_calculate_damage) then
+               do iCell = 1, nCells
+                  do k = 1, nVertLevels
+                     if (layerThickness(k,iCell) > 0.0_RKIND) then
+                        damage3d(k,iCell) = ( rkSSPweights(rkStage) * damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                                              (1.0_RKIND - rkSSPweights(rkStage)) * damage(iCell) * layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                     else
+                        damage3d(k,iCell) = 0.0_RKIND
+                     endif
+                  enddo
+                  damage(iCell) = sum(damage3d(:, iCell) * layerThicknessFractions)
+               enddo
+            endif
+
+            do iCell = 1, nCells
+               do k = 1, nVertLevels
+                  if (layerThickness(k,iCell) > 0.0_RKIND) then
+                     passiveTracer3d(k,iCell) = ( rkSSPweights(rkStage) * passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                                                  (1.0_RKIND - rkSSPweights(rkStage)) * passiveTracer2d(iCell) * layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                  else
+                     passiveTracer3d(k,iCell) = 0.0_RKIND
+                  endif
+               enddo
+               passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
+            enddo
+
+            ! === Ensure damage is within bounds after full time integration ===
+            if ( (rkStage .eq. config_rk_order) .and. (config_finalize_damage_after_advection) ) then
+                call mpas_timer_start("finalize damage")
+                call li_finalize_damage_after_advection(domain, err_tmp)
+                err = ior(err, err_tmp)
+                call mpas_timer_stop("finalize damage")
+            endif
+         endif  ! if config_rk_order == 3
+
+         ! If using RK2 or RK4 time integration, update thickness, damage,
          ! temperature or enthalpy, passiveTracer2d before final velocity solve.
-         ! If using forward Euler, these have already been updated above. 
-         if ( (rkStep .eq. config_rk_order) .and. (config_rk_order > 1) ) then
+         ! If using forward Euler or SSPRK3, these have already been updated above.
+         if ( (rkStage .eq. config_rk_order) .and. ( (config_rk_order == 2) .or. (config_rk_order == 4) ) ) then
 
             ! Need layerThickness first in order to update other tracers
             if (trim(config_thickness_advection) == 'fct') then
@@ -313,7 +409,7 @@ module li_time_integration_fe_rk
                where (layerThickness(:,:) > 0.0_RKIND)
                   enthalpy(:,:) = ( enthalpyProv(:,:) * layerThicknessProv(:,:) + &
                                     deltatFull * rkTend(1,:,:) ) / layerThickness(:,:)
-               ! elsewhere, what? 
+               ! elsewhere, what?
                end where
                ! given the enthalpy, compute the temperature and water fraction
                do iCell = 1, nCells
@@ -430,6 +526,7 @@ module li_time_integration_fe_rk
       deallocate(temperatureProv)
       deallocate(enthalpyProv)
       deallocate(layerThicknessProv)
+      deallocate(layerThicknessTmp)
       deallocate(damage3dProv)
       deallocate(damage3d)
       deallocate(passiveTracer3dProv)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -119,6 +119,16 @@ module li_time_integration_fe_rk
                                                     enthalpy, &
                                                     waterFrac
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
+      real (kind=RKIND), dimension(:), pointer :: sfcMassBalApplied, &
+                                                  basalMassBalApplied, &
+                                                  groundedSfcMassBalApplied, &
+                                                  groundedBasalMassBalApplied, &
+                                                  floatingBasalMassBalApplied
+      real (kind=RKIND), dimension(:), allocatable :: sfcMassBalAccum, &
+                                                      basalMassBalAccum, &
+                                                      groundedSfcMassBalAccum, &
+                                                      groundedBasalMassBalAccum, &
+                                                      floatingBasalMassBalAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
                                                         layerThicknessTmp, &
@@ -134,6 +144,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkSubstepWeights
       real (kind=RKIND), dimension(4) :: rkSSPweights
+      real (kind=RKIND), dimension(4) :: rkTendWeights ! Weights used for calculating budget terms
       integer :: nRKstages
 
       err = 0
@@ -167,6 +178,12 @@ module li_time_integration_fe_rk
       allocate(passiveTracer3dPrev(nVertLevels, nCells+1))
       allocate(passiveTracer3d(nVertLevels, nCells+1))
 
+      allocate(sfcMassBalAccum(nCells+1))
+      allocate(basalMassBalAccum(nCells+1))
+      allocate(groundedSfcMassBalAccum(nCells+1))
+      allocate(groundedBasalMassBalAccum(nCells+1))
+      allocate(floatingBasalMassBalAccum(nCells+1))
+
       temperaturePrev(:,:) = 0.0_RKIND
       enthalpyPrev(:,:) = 0.0_RKIND
       layerThicknessPrev(:,:) = 0.0_RKIND
@@ -175,6 +192,12 @@ module li_time_integration_fe_rk
       damage3d(:,:) = 0.0_RKIND
       passiveTracer3dPrev(:,:) = 0.0_RKIND
       passiveTracer3d(:,:) = 0.0_RKIND
+
+      sfcMassBalAccum(:) = 0.0_RKIND
+      basalMassBalAccum(:) = 0.0_RKIND
+      groundedSfcMassBalAccum(:) = 0.0_RKIND
+      groundedBasalMassBalAccum(:) = 0.0_RKIND
+      floatingBasalMassBalAccum(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -246,7 +269,8 @@ module li_time_integration_fe_rk
       ! by one index. e.g., the coefficients for RK4 are usually written
       ! (0, 1/2, 1/2, 1), while we use (1/2, 1/2, 1). The last entry of 1.0
       ! is simply for ease of implementation.
-      rkSSPweights(:) = 1.0_RKIND
+      rkSSPweights(:) = 1.0_RKIND ! updated for each case below
+      rkTendWeights(:) = 0.0_RKIND ! updated for each case below
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
@@ -265,6 +289,9 @@ module li_time_integration_fe_rk
          rkSSPweights(2) = 0.5_RKIND
          rkSSPweights(3) = 0.0_RKIND
          rkSSPweights(4) = 0.0_RKIND
+
+         rkTendWeights(1) = 0.5_RKIND
+         rkTendWeights(2) = 0.5_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 3) ) then
          if (config_rk3_stages == 3) then
@@ -276,6 +303,10 @@ module li_time_integration_fe_rk
             rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
             rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
             rkSSPweights(4) = 0.0_RKIND
+
+            rkTendWeights(1) = 1.0_RKIND / 6.0_RKIND
+            rkTendWeights(2) = 1.0_RKIND / 6.0_RKIND
+            rkTendWeights(3) = 2.0_RKIND / 3.0_RKIND
         ! 4-stage SSP-RK3? Allows for CFL=2.
         elseif (config_rk3_stages == 4) then
             nRKstages = 4
@@ -285,6 +316,11 @@ module li_time_integration_fe_rk
             rkSSPweights(2) = 0.0_RKIND
             rkSSPweights(3) = 2.0_RKIND / 3.0_RKIND
             rkSSPweights(4) = 0.0_RKIND
+
+            rkTendWeights(1) = 1.0_RKIND / 6.0_RKIND
+            rkTendWeights(2) = 1.0_RKIND / 6.0_RKIND
+            rkTendWeights(3) = 1.0_RKIND / 6.0_RKIND
+            rkTendWeights(4) = 1.0_RKIND / 2.0_RKIND
         else
             err = 1
             call mpas_log_write('config_rk3_stages must 3 or 4', &
@@ -390,16 +426,28 @@ module li_time_integration_fe_rk
                passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
             enddo
 
-         endif  ! if config_rk_order == 3
+         endif
         
-         ! === Ensure damage is within bounds after full time integration ===
-         if ( (rkStage .eq. nRKstages) .and. (config_finalize_damage_after_advection) ) then
+         ! === Ensure damage is within bounds before velocity solve ===
+         if ( config_finalize_damage_after_advection ) then
              call mpas_timer_start("finalize damage")
              call li_finalize_damage_after_advection(domain, err_tmp)
              err = ior(err, err_tmp)
              call mpas_timer_stop("finalize damage")
          endif
- 
+
+         call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+         ! update budgets
+         sfcMassBalAccum = sfcMassBalAccum + rkTendWeights(rkStage) * sfcMassBalApplied
+         groundedSfcMassBalAccum = groundedSfcMassBalAccum + rkTendWeights(rkStage) * groundedSfcMassBalApplied
+         basalMassBalAccum = basalMassBalAccum + rkTendWeights(rkStage) * basalMassBalApplied
+         groundedBasalMassBalAccum = groundedBasalMassBalAccum + rkTendWeights(rkStage) * groundedBasalMassBalApplied
+         floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
+         
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
          call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
@@ -408,8 +456,16 @@ module li_time_integration_fe_rk
 ! *** end RK loop ***
       enddo
 
+! Finalize budget updates
+      sfcMassBalApplied(:) = sfcMassBalAccum(:)
+      groundedSfcMassBalApplied(:) = sfcMassBalAccum(:)
+      basalMassBalApplied(:) = basalMassBalAccum(:)
+      groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
+      floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
+      
 ! Reset time step to full length after RK loop
       deltat = deltatFull
+
 ! === Calve ice ========================
       call mpas_timer_start("calve_ice")
 
@@ -465,6 +521,11 @@ module li_time_integration_fe_rk
       deallocate(damage3d)
       deallocate(passiveTracer3dPrev)
       deallocate(passiveTracer3d)
+      deallocate(sfcMassBalAccum)
+      deallocate(basalMassBalAccum)
+      deallocate(groundedSfcMassBalAccum)
+      deallocate(groundedBasalMassBalAccum)
+      deallocate(floatingBasalMassBalAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -127,6 +127,7 @@ module li_time_integration_fe_rk
                                                   groundedSfcMassBalApplied, &
                                                   groundedBasalMassBalApplied, &
                                                   floatingBasalMassBalApplied, &
+                                                  calvingThickness, &
                                                   fluxAcrossGroundingLine, &
                                                   fluxAcrossGroundingLineOnCells, &
                                                   groundedToFloatingThickness
@@ -135,6 +136,7 @@ module li_time_integration_fe_rk
                                                       groundedSfcMassBalAccum, &
                                                       groundedBasalMassBalAccum, &
                                                       floatingBasalMassBalAccum, &
+                                                      calvingThicknessAccum, &
                                                       fluxAcrossGroundingLineAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
       integer, dimension(:), pointer :: cellMaskPrev  ! cell mask before advection
@@ -201,6 +203,7 @@ module li_time_integration_fe_rk
       allocate(groundedSfcMassBalAccum(nCells+1))
       allocate(groundedBasalMassBalAccum(nCells+1))
       allocate(floatingBasalMassBalAccum(nCells+1))
+      allocate(calvingThicknessAccum(nCells+1))
       allocate(fluxAcrossGroundingLineAccum(nEdges+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
@@ -218,6 +221,7 @@ module li_time_integration_fe_rk
       groundedSfcMassBalAccum(:) = 0.0_RKIND
       groundedBasalMassBalAccum(:) = 0.0_RKIND
       floatingBasalMassBalAccum(:) = 0.0_RKIND
+      calvingThicknessAccum(:) = 0.0_RKIND
       fluxAcrossGroundingLineAccum(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
@@ -375,6 +379,18 @@ module li_time_integration_fe_rk
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
+         ! ==== Apply iceberg calving ====
+         call mpas_timer_start("calve_ice")
+         call li_calve_ice(domain, err_tmp)
+         err = ior(err, err_tmp)
+
+         if (config_restore_calving_front) then
+            ! restore the calving front to its initial position before velocity solve.
+            call li_restore_calving_front(domain, err_tmp)
+            err = ior(err, err_tmp)
+         endif
+         call mpas_timer_stop("calve_ice")
+
          ! If using SSP RK, then update thickness and tracers incrementally.
          ! For first RK stage, thickness and tracer updates above are sufficient.
          ! Likewise, for the 4-stage SSP RK3 the last stage is just a forward euler update.
@@ -453,6 +469,7 @@ module li_time_integration_fe_rk
          call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pooL_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
@@ -462,6 +479,7 @@ module li_time_integration_fe_rk
          basalMassBalAccum = basalMassBalAccum + rkTendWeights(rkStage) * basalMassBalApplied
          groundedBasalMassBalAccum = groundedBasalMassBalAccum + rkTendWeights(rkStage) * groundedBasalMassBalApplied
          floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
+         calvingThicknessAccum = calvingThicknessAccum + rkTendWeights(rkStage) * calvingThickness
          fluxAcrossGroundingLineAccum = fluxAcrossGroundingLineAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLine
 
          ! Halo updates
@@ -474,12 +492,6 @@ module li_time_integration_fe_rk
          call mpas_dmpar_field_halo_exch(domain, 'passiveTracer2d')
 
          call mpas_timer_stop("halo updates")
-
-         if (config_restore_calving_front) then
-            ! restore the calving front to its initial position before velocity solve.
-            call li_restore_calving_front(domain, err_tmp)
-            err = ior(err, err_tmp)
-         endif
 
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
@@ -506,6 +518,7 @@ module li_time_integration_fe_rk
       basalMassBalApplied(:) = basalMassBalAccum(:)
       groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
+      calvingThickness(:) = calvingThicknessAccum(:)
       fluxAcrossGroundingLine(:) = fluxAcrossGroundingLineAccum(:)
       
       fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
@@ -528,32 +541,6 @@ module li_time_integration_fe_rk
       enddo ! edges
 ! Reset time step to full length after RK loop
       deltat = deltatFull
-
-! === Calve ice ========================
-      call mpas_timer_start("calve_ice")
-
-      ! ice calving
-      call li_calve_ice(domain, err_tmp)
-      err = ior(err, err_tmp)
-
-      if (config_restore_calving_front .and. config_restore_calving_front_prevent_retreat) then
-         ! restore the calving front to its initial position before velocity solve.
-         call li_restore_calving_front(domain, err_tmp)
-         err = ior(err, err_tmp)
-      endif
-
-      call mpas_timer_stop("calve_ice")
-
-      call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'cellMask')
-      call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
-      call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
-      call mpas_timer_stop("halo updates")
-
-      ! Update stresses etc
-      ! === Solve Velocity =====================
-      call li_velocity_solve(domain, solveVelo=.false., err=err_tmp)
-      err = ior(err, err_tmp)
 
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.
@@ -589,6 +576,7 @@ module li_time_integration_fe_rk
       deallocate(groundedSfcMassBalAccum)
       deallocate(groundedBasalMassBalAccum)
       deallocate(floatingBasalMassBalAccum)
+      deallocate(calvingThicknessAccum)
       deallocate(fluxAcrossGroundingLineAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -541,6 +541,11 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
 
+      ! Update stresses etc
+      ! === Solve Velocity =====================
+      call li_velocity_solve(domain, solveVelo=.false., err=err_tmp)
+      err = ior(err, err_tmp)
+
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.
 ! Seems cleaner to do it either before or after all of the time evolution of the ice

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -112,7 +112,7 @@ module li_time_integration_fe_rk
       character (len=StrKIND), pointer :: config_thickness_advection
       character (len=StrKIND), pointer :: config_thermal_solver
       character (len=StrKIND), pointer :: config_time_integration
-      integer, pointer :: config_rk_order
+      integer, pointer :: config_rk_order, config_rk3_stages
       integer :: rkStage, iCell, iTracer, k
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                     temperature, &
@@ -133,7 +133,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), pointer :: deltat
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkSubstepWeights
-      real (kind=RKIND), dimension(3) :: rkSSPweights
+      real (kind=RKIND), dimension(4) :: rkSSPweights
       integer :: nRKstages
 
       err = 0
@@ -145,6 +145,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
       call mpas_pool_get_config(liConfigs, 'config_rk_order', config_rk_order)
+      call mpas_pool_get_config(liConfigs, 'config_rk3_stages', config_rk3_stages)
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
@@ -262,16 +263,33 @@ module li_time_integration_fe_rk
 
          rkSSPweights(1) = 1.0_RKIND
          rkSSPweights(2) = 0.5_RKIND
+         rkSSPweights(3) = 0.0_RKIND
+         rkSSPweights(4) = 0.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 3) ) then
-         ! use Strong Stability Preserving RK3
-         nRKstages = 3
-         rkSubstepWeights(:) = 1.0_RKIND
+         if (config_rk3_stages == 3) then
+            ! use Strong Stability Preserving RK3
+            nRKstages = 3
+            rkSubstepWeights(:) = 1.0_RKIND
 
-         rkSSPweights(1) = 1.0_RKIND
-         rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
-         rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
-        ! Add option for 4-stage SSP-RK3? Allows for CFL=2.
+            rkSSPweights(1) = 1.0_RKIND
+            rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
+            rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
+            rkSSPweights(4) = 0.0_RKIND
+        ! 4-stage SSP-RK3? Allows for CFL=2.
+        elseif (config_rk3_stages == 4) then
+            nRKstages = 4
+            rkSubstepWeights(:) = 0.5_RKIND
+
+            rkSSPweights(1) = 1.0_RKIND
+            rkSSPweights(2) = 0.0_RKIND
+            rkSSPweights(3) = 2.0_RKIND / 3.0_RKIND
+            rkSSPweights(4) = 0.0_RKIND
+        else
+            err = 1
+            call mpas_log_write('config_rk3_stages must 3 or 4', &
+                                messageType=MPAS_LOG_ERR)
+        endif
       else
          err = 1
          call mpas_log_write('config_time_integration = ' // trim(config_time_integration) &
@@ -299,8 +317,9 @@ module li_time_integration_fe_rk
          call mpas_timer_stop("advect thickness and tracers")
 
          ! If using SSP RK, then update thickness and tracers incrementally.
-         ! For first RK stage, thickness and tracer updates above are sufficient
-         if ( rkStage > 1 )  then
+         ! For first RK stage, thickness and tracer updates above are sufficient.
+         ! Likewise, for the 4-stage SSP RK3 the last stage is just a forward euler update.
+         if ( (rkStage > 1) .and. (rkStage < 4) )  then
             call mpas_pool_get_array(geometryPool, 'thickness', thickness)
             call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
             call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
@@ -507,7 +526,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(:,:), pointer :: normalVelocity
       real (kind=RKIND), dimension(:,:), pointer :: layerNormalVelocity
       real (kind=RKIND), pointer :: calvingCFLdt, faceMeltingCFLdt
-      integer, pointer :: processLimitingTimestep
+      integer, pointer :: processLimitingTimestep, config_rk_order, config_rk3_stages
       integer, dimension(:), pointer :: edgeMask
 
       logical, pointer :: config_print_thickness_advection_info
@@ -515,7 +534,8 @@ module li_time_integration_fe_rk
       logical, pointer :: config_adaptive_timestep_include_DCFL
 
       character (len=StrKIND), pointer :: &
-           config_thickness_advection   ! method for advecting thickness and tracers
+           config_thickness_advection, &  ! method for advecting thickness and tracers
+           config_time_integration
 
       integer :: &
            allowableAdvecDtProcNumberHere, &
@@ -567,6 +587,9 @@ module li_time_integration_fe_rk
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep', config_adaptive_timestep)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep_include_DCFL', config_adaptive_timestep_include_DCFL)
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
+      call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
+      call mpas_pool_get_config(liConfigs, 'config_rk_order', config_rk_order)
+      call mpas_pool_get_config(liConfigs, 'config_rk3_stages', config_rk3_stages)
 
       if (trim(config_thickness_advection) == 'none') then
          if (config_adaptive_timestep) then
@@ -612,7 +635,6 @@ module li_time_integration_fe_rk
          err = ior(err, err_tmp)
 
          allowableAdvecDtOnProc = min(allowableAdvecDtOnProc, allowableAdvecDt)
-
          ! Calculate diffusive CFL timestep, if needed
          ! This used to be only calculated if (config_adaptive_timestep_include_DCFL) but for simplicity,
          ! now it is always calculated.  That allows assessment of the DCFL even when it is not being obeyed
@@ -637,6 +659,12 @@ module li_time_integration_fe_rk
          block => block % next
       end do
 
+      ! If using 4-stage SSPRK3, CFL number of 2 is theoretically allowed
+      if ( (trim(config_time_integration) == 'runge_kutta') .and. &
+         (config_rk_order == 3) .and. (config_rk3_stages == 4) ) then
+          allowableAdvecDtOnProc = allowableAdvecDtOnProc * 2.0_RKIND
+          allowableDiffDtOnProc = allowableDiffDtOnProc * 2.0_RKIND
+      endif
 
       ! Local advective CFL info
       call mpas_set_timeInterval(allowableAdvecDtOnProcInterval, dt=allowableAdvecDtOnProc, ierr=err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -480,6 +480,19 @@ module li_time_integration_fe_rk
          floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
          fluxAcrossGroundingLineAccum = fluxAcrossGroundingLineAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLine
 
+         ! Halo updates
+         call mpas_timer_start("halo updates")
+
+         call mpas_dmpar_field_halo_exch(domain, 'thickness')
+         call mpas_dmpar_field_halo_exch(domain, 'temperature')
+         call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
+         call mpas_dmpar_field_halo_exch(domain, 'enthalpy')
+         call mpas_dmpar_field_halo_exch(domain, 'damage')
+         call mpas_dmpar_field_halo_exch(domain, 'passiveTracer2d')
+
+         call mpas_timer_stop("halo updates")
+
+
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
          call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -270,7 +270,7 @@ module li_time_integration_fe_rk
       ! (0, 1/2, 1/2, 1), while we use (1/2, 1/2, 1). The last entry of 1.0
       ! is simply for ease of implementation.
       rkSSPweights(:) = 1.0_RKIND ! updated for each case below
-      rkTendWeights(:) = 0.0_RKIND ! updated for each case below
+      rkTendWeights(:) = 1.0_RKIND ! updated for each case below
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -109,7 +109,8 @@ module li_time_integration_fe_rk
       integer :: err_tmp
       type (mpas_pool_type), pointer :: geometryPool, thermalPool, meshPool, velocityPool
       
-      logical, pointer :: config_restore_calving_front
+      logical, pointer :: config_restore_calving_front, &
+                          config_restore_calving_front_prevent_retreat
       logical, pointer :: config_calculate_damage
       logical, pointer :: config_finalize_damage_after_advection
       character (len=StrKIND), pointer :: config_thickness_advection
@@ -160,6 +161,7 @@ module li_time_integration_fe_rk
       err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
+      call mpas_pool_get_config(liConfigs, 'config_restore_calving_front_prevent_retreat', config_restore_calving_front_prevent_retreat)
       call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
       call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection', config_finalize_damage_after_advection)
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
@@ -475,6 +477,11 @@ module li_time_integration_fe_rk
 
          call mpas_timer_stop("halo updates")
 
+         if (config_restore_calving_front) then
+            ! restore the calving front to its initial position before velocity solve.
+            call li_restore_calving_front(domain, err_tmp)
+            err = ior(err, err_tmp)
+         endif
 
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
@@ -531,8 +538,8 @@ module li_time_integration_fe_rk
       call li_calve_ice(domain, err_tmp)
       err = ior(err, err_tmp)
 
-      if (config_restore_calving_front) then
-         ! restore the calving front to its initial position; calving options are ignored
+      if (config_restore_calving_front .and. config_restore_calving_front_prevent_retreat) then
+         ! restore the calving front to its initial position before velocity solve.
          call li_restore_calving_front(domain, err_tmp)
          err = ior(err, err_tmp)
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -202,6 +202,7 @@ module li_time_integration_fe_rk
       allocate(fluxAcrossGroundingLineAccum(nEdges+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
+      waterFracPrev(:,:) = 0.0_RKIND
       layerThicknessPrev(:,:) = 0.0_RKIND
       layerThicknessTmp(:,:) = 0.0_RKIND
       damage3dPrev(:,:) = 0.0_RKIND
@@ -293,7 +294,6 @@ module li_time_integration_fe_rk
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
-         config_rk_order = 1
          nRKstages = 1
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
@@ -344,12 +344,14 @@ module li_time_integration_fe_rk
             err = 1
             call mpas_log_write('config_rk3_stages must 3 or 4', &
                                 messageType=MPAS_LOG_ERR)
+            return
         endif
       else
          err = 1
          call mpas_log_write('config_time_integration = ' // trim(config_time_integration) &
                              // ' is not supported with config_rk_order = $i', &
                              intArgs=(/config_rk_order/), messageType=MPAS_LOG_ERR)
+         return
       endif 
 ! *** Start RK loop ***
       do rkStage = 1, nRKstages
@@ -387,6 +389,9 @@ module li_time_integration_fe_rk
             layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessPrev(:,:) + &
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)
             thickness = sum(layerThickness, 1)
+            ! Calculate masks after updating thickness
+            call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+            err = ior(err, err_tmp)
 
             if (trim(config_thermal_solver) .ne. 'none') then
                do iCell = 1, nCells
@@ -433,12 +438,6 @@ module li_time_integration_fe_rk
 
          endif
        
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
-         err = ior(err, err_tmp)
-
-         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
- 
          ! === Ensure damage is within bounds before velocity solve ===
          if ( config_finalize_damage_after_advection ) then
              call mpas_timer_start("finalize damage")
@@ -486,6 +485,14 @@ module li_time_integration_fe_rk
 ! Finalize budget updates
       ! Calculate volume converted from grounded to floating
       ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'cellMask')
+      call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
+      call mpas_timer_stop("halo updates")
+
       call li_grounded_to_floating(cellMaskPrev, cellMask, thickness, groundedToFloatingThickness, nCells)
       sfcMassBalApplied(:) = sfcMassBalAccum(:)
       groundedSfcMassBalApplied(:) = groundedSfcMassBalAccum(:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -295,7 +295,7 @@ module li_time_integration_fe_rk
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 3) ) then
          if (config_rk3_stages == 3) then
-            ! use Strong Stability Preserving RK3
+            ! use three-stage Strong Stability Preserving RK3
             nRKstages = 3
             rkSubstepWeights(:) = 1.0_RKIND
 
@@ -307,8 +307,8 @@ module li_time_integration_fe_rk
             rkTendWeights(1) = 1.0_RKIND / 6.0_RKIND
             rkTendWeights(2) = 1.0_RKIND / 6.0_RKIND
             rkTendWeights(3) = 2.0_RKIND / 3.0_RKIND
-        ! 4-stage SSP-RK3? Allows for CFL=2.
         elseif (config_rk3_stages == 4) then
+            ! use four-stage Strong Stability Preserving RK3
             nRKstages = 4
             rkSubstepWeights(:) = 0.5_RKIND
 
@@ -334,8 +334,8 @@ module li_time_integration_fe_rk
       endif 
 ! *** Start RK loop ***
       do rkStage = 1, nRKstages
-         call mpas_log_write('beginning rk step $i', &
-                             intArgs=(/rkStage/))
+         call mpas_log_write('beginning rk stage $i of $i', &
+                             intArgs=(/rkStage, nRKstages/))
          deltat = deltatFull * rkSubstepWeights(rkStage)
 
          ! === calculate damage ===========
@@ -493,12 +493,6 @@ module li_time_integration_fe_rk
 ! is complete.  Putting it after.
       call li_bedtopo_solve(domain, err=err_tmp)
       err = ior(err, err_tmp)
-
-! TODO: Determine whether we need to update velocities again
-! === Solve Velocity =====================
-!      ! During time-stepping, we always solveVelo
-!      call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
-!      err = ior(err, err_tmp)
 
 ! === Calculate diagnostic variables for new state =====================
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -296,9 +296,7 @@ module li_time_integration_fe_rk
                                       ! weights are updated for each case below
       rkTendWeights(:) = -9999.0_RKIND
       rkSubstepWeights(:) = -9999.0_RKIND
-      if ( (trim(config_time_integration) == 'forward_euler') .or. &
-           ((trim(config_time_integration) == 'runge_kutta') .and. &
-           (config_rk_order == 1)) ) then
+      if (trim(config_time_integration) == 'forward_euler') then
          nRKstages = 1
          rkSSPweights(1) = 1.0_RKIND
          rkTendWeights(1) = 1.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -120,14 +120,14 @@ module li_time_integration_fe_rk
                                                     waterFrac
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
-      real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessProv, &
+      real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
                                                         layerThicknessTmp, &
-                                                        temperatureProv, &
-                                                        enthalpyProv, &
+                                                        temperaturePrev, &
+                                                        enthalpyPrev, &
                                                         passiveTracer3d, &
-                                                        passiveTracer3dProv, &
+                                                        passiveTracer3dPrev, &
                                                         damage3d, &
-                                                        damage3dProv
+                                                        damage3dPrev
       integer, pointer :: nVertLevels
       integer, pointer :: nCells
       real (kind=RKIND), pointer :: deltat
@@ -157,22 +157,22 @@ module li_time_integration_fe_rk
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
-      allocate(temperatureProv(nVertLevels, nCells+1))
-      allocate(enthalpyProv(nVertLevels, nCells+1))
-      allocate(layerThicknessProv(nVertLevels, nCells+1))
+      allocate(temperaturePrev(nVertLevels, nCells+1))
+      allocate(enthalpyPrev(nVertLevels, nCells+1))
+      allocate(layerThicknessPrev(nVertLevels, nCells+1))
       allocate(layerThicknessTmp(nVertLevels, nCells+1))
-      allocate(damage3dProv(nVertLevels, nCells+1))
+      allocate(damage3dPrev(nVertLevels, nCells+1))
       allocate(damage3d(nVertLevels, nCells+1))
-      allocate(passiveTracer3dProv(nVertLevels, nCells+1))
+      allocate(passiveTracer3dPrev(nVertLevels, nCells+1))
       allocate(passiveTracer3d(nVertLevels, nCells+1))
 
-      temperatureProv(:,:) = 0.0_RKIND
-      enthalpyProv(:,:) = 0.0_RKIND
-      layerThicknessProv(:,:) = 0.0_RKIND
+      temperaturePrev(:,:) = 0.0_RKIND
+      enthalpyPrev(:,:) = 0.0_RKIND
+      layerThicknessPrev(:,:) = 0.0_RKIND
       layerThicknessTmp(:,:) = 0.0_RKIND
-      damage3dProv(:,:) = 0.0_RKIND
+      damage3dPrev(:,:) = 0.0_RKIND
       damage3d(:,:) = 0.0_RKIND
-      passiveTracer3dProv(:,:) = 0.0_RKIND
+      passiveTracer3dPrev(:,:) = 0.0_RKIND
       passiveTracer3d(:,:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
@@ -230,12 +230,12 @@ module li_time_integration_fe_rk
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       ! Save relevant fields before RK loop, to be used in update at the end
-      temperatureProv(:,:) = temperature(:,:)
-      enthalpyProv(:,:) =  enthalpy(:,:)
-      layerThicknessProv(:,:) = layerThickness(:,:)
+      temperaturePrev(:,:) = temperature(:,:)
+      enthalpyPrev(:,:) =  enthalpy(:,:)
+      layerThicknessPrev(:,:) = layerThickness(:,:)
       do k = 1, nVertLevels
-         damage3dProv(k,:) = damage(:)
-         passiveTracer3dProv(k,:) = passiveTracer2d(:)
+         damage3dPrev(k,:) = damage(:)
+         passiveTracer3dPrev(k,:) = passiveTracer2d(:)
       enddo
       deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
 
@@ -254,7 +254,7 @@ module li_time_integration_fe_rk
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 2) ) then
-         ! use classical (i.e., endpoint, or Heun's method) RK2. Could also
+         ! use Strong Stability Preserving RK2. Could also
          ! add config option to use standard endpoint or midpoint methods, but
          ! these are algorithmically more complex and less suitable for our domains 
          nRKstages = 2
@@ -280,8 +280,8 @@ module li_time_integration_fe_rk
       endif 
 ! *** Start RK loop ***
       do rkStage = 1, nRKstages
-         call mpas_log_write('beginning rk step $i;  rkSubstepWeight = $r', &
-                             intArgs=(/rkStage/), realArgs=(/rkSubstepWeights(rkStage)/))
+         call mpas_log_write('beginning rk step $i', &
+                             intArgs=(/rkStage/))
          deltat = deltatFull * rkSubstepWeights(rkStage)
 
          ! === calculate damage ===========
@@ -311,13 +311,13 @@ module li_time_integration_fe_rk
             call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
 
             layerThicknessTmp(:,:) = layerThickness(:,:)
-            layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessProv(:,:) + &
+            layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessPrev(:,:) + &
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)
             thickness = sum(layerThickness, 1)
 
             if (trim(config_thermal_solver) == 'enthalpy') then
                where (layerThickness(:,:) > 0.0_RKIND)
-                  enthalpy(:,:) = ( rkSSPweights(rkStage) * enthalpyProv(:,:) * layerThicknessProv(:,:) + &
+                  enthalpy(:,:) = ( rkSSPweights(rkStage) * enthalpyPrev(:,:) * layerThicknessPrev(:,:) + &
                                     (1.0_RKIND - rkSSPweights(rkStage)) * enthalpy(:,:) * &
                                     layerThicknessTmp(:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
@@ -336,7 +336,7 @@ module li_time_integration_fe_rk
 
             elseif (trim(config_thermal_solver) == 'temperature') then
                where (layerThickness(:,:) > 0.0_RKIND)
-                  temperature(:,:) = ( rkSSPweights(rkStage) * temperatureProv(:,:) * layerThicknessProv(:,:) + &
+                  temperature(:,:) = ( rkSSPweights(rkStage) * temperaturePrev(:,:) * layerThicknessPrev(:,:) + &
                                        (1.0_RKIND - rkSSPweights(rkStage)) * temperature(:,:) * &
                                        layerThicknessTmp(:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
@@ -347,7 +347,7 @@ module li_time_integration_fe_rk
                do iCell = 1, nCells
                   do k = 1, nVertLevels
                      if (layerThickness(k,iCell) > 0.0_RKIND) then
-                        damage3d(k,iCell) = ( rkSSPweights(rkStage) * damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                        damage3d(k,iCell) = ( rkSSPweights(rkStage) * damage3dPrev(k,iCell) * layerThicknessPrev(k,iCell) + &
                                               (1.0_RKIND - rkSSPweights(rkStage)) * damage(iCell) * &
                                               layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
                      else
@@ -361,7 +361,7 @@ module li_time_integration_fe_rk
             do iCell = 1, nCells
                do k = 1, nVertLevels
                   if (layerThickness(k,iCell) > 0.0_RKIND) then
-                     passiveTracer3d(k,iCell) = ( rkSSPweights(rkStage) * passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
+                     passiveTracer3d(k,iCell) = ( rkSSPweights(rkStage) * passiveTracer3dPrev(k,iCell) * layerThicknessPrev(k,iCell) + &
                                                   (1.0_RKIND - rkSSPweights(rkStage)) * passiveTracer2d(iCell) * &
                                                   layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
                   else
@@ -438,13 +438,13 @@ module li_time_integration_fe_rk
           call mpas_log_write("An error has occurred in li_time_integrator_forwardeuler_rungekutta.", MPAS_LOG_ERR)
       endif
 
-      deallocate(temperatureProv)
-      deallocate(enthalpyProv)
-      deallocate(layerThicknessProv)
+      deallocate(temperaturePrev)
+      deallocate(enthalpyPrev)
+      deallocate(layerThicknessPrev)
       deallocate(layerThicknessTmp)
-      deallocate(damage3dProv)
+      deallocate(damage3dPrev)
       deallocate(damage3d)
-      deallocate(passiveTracer3dProv)
+      deallocate(passiveTracer3dPrev)
       deallocate(passiveTracer3d)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -458,7 +458,7 @@ module li_time_integration_fe_rk
 
 ! Finalize budget updates
       sfcMassBalApplied(:) = sfcMassBalAccum(:)
-      groundedSfcMassBalApplied(:) = sfcMassBalAccum(:)
+      groundedSfcMassBalApplied(:) = groundedSfcMassBalAccum(:)
       basalMassBalApplied(:) = basalMassBalAccum(:)
       groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -36,6 +36,7 @@ module li_time_integration_fe_rk
    use li_setup
    use li_constants
    use li_mesh
+   use li_mask
 
    implicit none
    private
@@ -82,6 +83,8 @@ module li_time_integration_fe_rk
       use li_subglacial_hydro
       use li_velocity
       use li_bedtopo
+      use li_mask
+      use li_advection, only: li_grounded_to_floating
 
       !-----------------------------------------------------------------
       ! input variables
@@ -104,7 +107,7 @@ module li_time_integration_fe_rk
       !-----------------------------------------------------------------
       type (block_type), pointer :: block
       integer :: err_tmp
-      type (mpas_pool_type), pointer :: geometryPool, thermalPool, meshPool
+      type (mpas_pool_type), pointer :: geometryPool, thermalPool, meshPool, velocityPool
       
       logical, pointer :: config_restore_calving_front
       logical, pointer :: config_calculate_damage
@@ -123,13 +126,18 @@ module li_time_integration_fe_rk
                                                   basalMassBalApplied, &
                                                   groundedSfcMassBalApplied, &
                                                   groundedBasalMassBalApplied, &
-                                                  floatingBasalMassBalApplied
+                                                  floatingBasalMassBalApplied, &
+                                                  fluxAcrossGroundingLine, &
+                                                  fluxAcrossGroundingLineOnCells, &
+                                                  groundedToFloatingThickness
       real (kind=RKIND), dimension(:), allocatable :: sfcMassBalAccum, &
                                                       basalMassBalAccum, &
                                                       groundedSfcMassBalAccum, &
                                                       groundedBasalMassBalAccum, &
-                                                      floatingBasalMassBalAccum
+                                                      floatingBasalMassBalAccum, &
+                                                      fluxAcrossGroundingLineAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
+      integer, dimension(:), pointer :: cellMaskPrev  ! cell mask before advection
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
                                                         layerThicknessTmp, &
                                                         temperaturePrev, &
@@ -139,8 +147,10 @@ module li_time_integration_fe_rk
                                                         damage3d, &
                                                         damage3dPrev
       integer, pointer :: nVertLevels
-      integer, pointer :: nCells
-      real (kind=RKIND), pointer :: deltat
+      integer, pointer :: nCells, nEdges
+      integer :: iCell1, iCell2, iEdge, theGroundedCell
+      integer, dimension(:), pointer :: edgeMask, cellMask
+      real (kind=RKIND), pointer :: deltat, config_ice_density
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkSubstepWeights
       real (kind=RKIND), dimension(4) :: rkSSPweights
@@ -158,16 +168,22 @@ module li_time_integration_fe_rk
       call mpas_pool_get_config(liConfigs, 'config_rk_order', config_rk_order)
       call mpas_pool_get_config(liConfigs, 'config_rk3_stages', config_rk3_stages)
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
+      call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'thermal', thermalPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
 
       call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
       call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(meshPool, 'layerCenterSigma', layerCenterSigma)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+
+      call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
+      call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
 
       allocate(temperaturePrev(nVertLevels, nCells+1))
       allocate(enthalpyPrev(nVertLevels, nCells+1))
@@ -177,12 +193,14 @@ module li_time_integration_fe_rk
       allocate(damage3d(nVertLevels, nCells+1))
       allocate(passiveTracer3dPrev(nVertLevels, nCells+1))
       allocate(passiveTracer3d(nVertLevels, nCells+1))
+      allocate(cellMaskPrev(nCells+1))
 
       allocate(sfcMassBalAccum(nCells+1))
       allocate(basalMassBalAccum(nCells+1))
       allocate(groundedSfcMassBalAccum(nCells+1))
       allocate(groundedBasalMassBalAccum(nCells+1))
       allocate(floatingBasalMassBalAccum(nCells+1))
+      allocate(fluxAcrossGroundingLineAccum(nEdges+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
       enthalpyPrev(:,:) = 0.0_RKIND
@@ -191,6 +209,7 @@ module li_time_integration_fe_rk
       damage3dPrev(:,:) = 0.0_RKIND
       damage3d(:,:) = 0.0_RKIND
       passiveTracer3dPrev(:,:) = 0.0_RKIND
+      cellMaskPrev(:) = 0
       passiveTracer3d(:,:) = 0.0_RKIND
 
       sfcMassBalAccum(:) = 0.0_RKIND
@@ -198,6 +217,7 @@ module li_time_integration_fe_rk
       groundedSfcMassBalAccum(:) = 0.0_RKIND
       groundedBasalMassBalAccum(:) = 0.0_RKIND
       floatingBasalMassBalAccum(:) = 0.0_RKIND
+      fluxAcrossGroundingLineAccum(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -249,6 +269,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
@@ -257,6 +278,7 @@ module li_time_integration_fe_rk
       temperaturePrev(:,:) = temperature(:,:)
       enthalpyPrev(:,:) =  enthalpy(:,:)
       layerThicknessPrev(:,:) = layerThickness(:,:)
+      cellMaskPrev(:) = cellMask(:)
       do k = 1, nVertLevels
          damage3dPrev(k,:) = damage(:)
          passiveTracer3dPrev(k,:) = passiveTracer2d(:)
@@ -427,7 +449,13 @@ module li_time_integration_fe_rk
             enddo
 
          endif
-        
+       
+         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         err = ior(err, err_tmp)
+
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+ 
          ! === Ensure damage is within bounds before velocity solve ===
          if ( config_finalize_damage_after_advection ) then
              call mpas_timer_start("finalize damage")
@@ -441,13 +469,17 @@ module li_time_integration_fe_rk
          call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+         call mpas_pooL_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+
          ! update budgets
          sfcMassBalAccum = sfcMassBalAccum + rkTendWeights(rkStage) * sfcMassBalApplied
          groundedSfcMassBalAccum = groundedSfcMassBalAccum + rkTendWeights(rkStage) * groundedSfcMassBalApplied
          basalMassBalAccum = basalMassBalAccum + rkTendWeights(rkStage) * basalMassBalApplied
          groundedBasalMassBalAccum = groundedBasalMassBalAccum + rkTendWeights(rkStage) * groundedBasalMassBalApplied
          floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
-         
+         fluxAcrossGroundingLineAccum = fluxAcrossGroundingLineAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLine
+
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
          call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
@@ -457,12 +489,34 @@ module li_time_integration_fe_rk
       enddo
 
 ! Finalize budget updates
+      ! Calculate volume converted from grounded to floating
+      ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
+      call li_grounded_to_floating(cellMaskPrev, cellMask, thickness, groundedToFloatingThickness, nCells)
       sfcMassBalApplied(:) = sfcMassBalAccum(:)
       groundedSfcMassBalApplied(:) = groundedSfcMassBalAccum(:)
       basalMassBalApplied(:) = basalMassBalAccum(:)
       groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
+      fluxAcrossGroundingLine(:) = fluxAcrossGroundingLineAccum(:)
       
+      fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
+      do iEdge = 1, nEdges
+         if (li_mask_is_grounding_line(edgeMask(iEdge))) then
+            iCell1 = cellsOnEdge(1,iEdge)
+            iCell2 = cellsOnEdge(2,iEdge)
+            if (li_mask_is_grounded_ice(cellMask(iCell1))) then
+               theGroundedCell = iCell1
+            else
+               theGroundedCell = iCell2
+            endif
+            if ( thickness(theGroundedCell) > 0.0_RKIND ) then
+               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
+                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
+            else
+               fluxAcrossGroundingLineOnCells(theGroundedCell) = 0.0_RKIND
+            endif
+         endif
+      enddo ! edges
 ! Reset time step to full length after RK loop
       deltat = deltatFull
 
@@ -515,11 +569,13 @@ module li_time_integration_fe_rk
       deallocate(damage3d)
       deallocate(passiveTracer3dPrev)
       deallocate(passiveTracer3d)
+      deallocate(cellMaskPrev)
       deallocate(sfcMassBalAccum)
       deallocate(basalMassBalAccum)
       deallocate(groundedSfcMassBalAccum)
       deallocate(groundedBasalMassBalAccum)
       deallocate(floatingBasalMassBalAccum)
+      deallocate(fluxAcrossGroundingLineAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -119,7 +119,6 @@ module li_time_integration_fe_rk
       integer :: rkStage, iCell, iTracer, k
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                     temperature, &
-                                                    enthalpy, &
                                                     waterFrac
       real (kind=RKIND), dimension(:), pointer :: thickness, damage, passiveTracer2d
       real (kind=RKIND), dimension(:), pointer :: sfcMassBalApplied, &
@@ -141,7 +140,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
                                                         layerThicknessTmp, &
                                                         temperaturePrev, &
-                                                        enthalpyPrev, &
+                                                        waterFracPrev, &
                                                         passiveTracer3d, &
                                                         passiveTracer3dPrev, &
                                                         damage3d, &
@@ -186,7 +185,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
 
       allocate(temperaturePrev(nVertLevels, nCells+1))
-      allocate(enthalpyPrev(nVertLevels, nCells+1))
+      allocate(waterFracPrev(nVertLevels, nCells+1))
       allocate(layerThicknessPrev(nVertLevels, nCells+1))
       allocate(layerThicknessTmp(nVertLevels, nCells+1))
       allocate(damage3dPrev(nVertLevels, nCells+1))
@@ -203,7 +202,6 @@ module li_time_integration_fe_rk
       allocate(fluxAcrossGroundingLineAccum(nEdges+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
-      enthalpyPrev(:,:) = 0.0_RKIND
       layerThicknessPrev(:,:) = 0.0_RKIND
       layerThicknessTmp(:,:) = 0.0_RKIND
       damage3dPrev(:,:) = 0.0_RKIND
@@ -272,11 +270,10 @@ module li_time_integration_fe_rk
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       ! Save relevant fields before RK loop, to be used in update at the end
       temperaturePrev(:,:) = temperature(:,:)
-      enthalpyPrev(:,:) =  enthalpy(:,:)
+      waterFracPrev(:,:) = waterFrac(:,:)
       layerThicknessPrev(:,:) = layerThickness(:,:)
       cellMaskPrev(:) = cellMask(:)
       do k = 1, nVertLevels
@@ -384,7 +381,6 @@ module li_time_integration_fe_rk
             call mpas_pool_get_array(geometryPool, 'damage', damage)
 
             call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-            call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
             call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
 
             layerThicknessTmp(:,:) = layerThickness(:,:)
@@ -392,32 +388,19 @@ module li_time_integration_fe_rk
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)
             thickness = sum(layerThickness, 1)
 
-            if (trim(config_thermal_solver) == 'enthalpy') then
-               where (layerThickness(:,:) > 0.0_RKIND)
-                  enthalpy(:,:) = ( rkSSPweights(rkStage) * enthalpyPrev(:,:) * layerThicknessPrev(:,:) + &
-                                    (1.0_RKIND - rkSSPweights(rkStage)) * enthalpy(:,:) * &
-                                    layerThicknessTmp(:,:) ) / layerThickness(:,:)
-               ! elsewhere, what?
-               end where
-               ! given the enthalpy, compute the temperature and water fraction
+            if (trim(config_thermal_solver) .ne. 'none') then
                do iCell = 1, nCells
-
-                  call li_enthalpy_to_temperature_kelvin(&
-                       layerCenterSigma,                           &
-                       thickness(iCell),                           &
-                       enthalpy(:,iCell),     &
-                       temperature(:,iCell),  &
-                       waterFrac(:,iCell))
-
+                  do k = 1, nVertLevels
+                     if (layerThickness(k,iCell) > 0.0_RKIND) then
+                        temperature(k,iCell) = ( rkSSPweights(rkStage) * temperaturePrev(k,iCell) * layerThicknessPrev(k,iCell) + &
+                                             (1.0_RKIND - rkSSPweights(rkStage)) * temperature(k,iCell) * &
+                                             layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                        waterFrac(k,iCell) = ( rkSSPweights(rkStage) * waterFracPrev(k,iCell) * layerThicknessPrev(k,iCell) + &
+                                             (1.0_RKIND - rkSSPweights(rkStage)) * waterFrac(k,iCell) * &
+                                             layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                     endif
+                  enddo
                enddo
-
-            elseif (trim(config_thermal_solver) == 'temperature') then
-               where (layerThickness(:,:) > 0.0_RKIND)
-                  temperature(:,:) = ( rkSSPweights(rkStage) * temperaturePrev(:,:) * layerThicknessPrev(:,:) + &
-                                       (1.0_RKIND - rkSSPweights(rkStage)) * temperature(:,:) * &
-                                       layerThicknessTmp(:,:) ) / layerThickness(:,:)
-               ! elsewhere, what?
-               end where
             endif
 
             if (config_calculate_damage) then
@@ -486,7 +469,6 @@ module li_time_integration_fe_rk
          call mpas_dmpar_field_halo_exch(domain, 'thickness')
          call mpas_dmpar_field_halo_exch(domain, 'temperature')
          call mpas_dmpar_field_halo_exch(domain, 'waterFrac')
-         call mpas_dmpar_field_halo_exch(domain, 'enthalpy')
          call mpas_dmpar_field_halo_exch(domain, 'damage')
          call mpas_dmpar_field_halo_exch(domain, 'passiveTracer2d')
 
@@ -580,7 +562,7 @@ module li_time_integration_fe_rk
       endif
 
       deallocate(temperaturePrev)
-      deallocate(enthalpyPrev)
+      deallocate(waterFracPrev)
       deallocate(layerThicknessPrev)
       deallocate(layerThicknessTmp)
       deallocate(damage3dPrev)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -289,25 +289,28 @@ module li_time_integration_fe_rk
       ! by one index. e.g., the coefficients for RK4 are usually written
       ! (0, 1/2, 1/2, 1), while we use (1/2, 1/2, 1). The last entry of 1.0
       ! is simply for ease of implementation.
-      rkSSPweights(:) = 1.0_RKIND ! updated for each case below
-      rkTendWeights(:) = 1.0_RKIND ! updated for each case below
+      rkSSPweights(:) = -9999.0_RKIND ! Initialized to this value to make it obvious if
+                                      ! a weight is used that should not be. Appropriate
+                                      ! weights are updated for each case below
+      rkTendWeights(:) = -9999.0_RKIND
+      rkSubstepWeights(:) = -9999.0_RKIND
       if ( (trim(config_time_integration) == 'forward_euler') .or. &
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
          nRKstages = 1
-         rkSubstepWeights(:) = 1.0_RKIND
+         rkSSPweights(1) = 1.0_RKIND
+         rkTendWeights(1) = 1.0_RKIND
+         rkSubstepWeights(1) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 2) ) then
          ! use Strong Stability Preserving RK2. Could also
          ! add config option to use standard endpoint or midpoint methods, but
          ! these are algorithmically more complex and less suitable for our domains 
          nRKstages = 2
-         rkSubstepWeights(:) = 1.0_RKIND
+         rkSubstepWeights(1:2) = 1.0_RKIND
 
          rkSSPweights(1) = 1.0_RKIND
          rkSSPweights(2) = 0.5_RKIND
-         rkSSPweights(3) = 0.0_RKIND
-         rkSSPweights(4) = 0.0_RKIND
 
          rkTendWeights(1) = 0.5_RKIND
          rkTendWeights(2) = 0.5_RKIND
@@ -316,12 +319,11 @@ module li_time_integration_fe_rk
          if (config_rk3_stages == 3) then
             ! use three-stage Strong Stability Preserving RK3
             nRKstages = 3
-            rkSubstepWeights(:) = 1.0_RKIND
+            rkSubstepWeights(1:3) = 1.0_RKIND
 
             rkSSPweights(1) = 1.0_RKIND
             rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
             rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
-            rkSSPweights(4) = 0.0_RKIND
 
             rkTendWeights(1) = 1.0_RKIND / 6.0_RKIND
             rkTendWeights(2) = 1.0_RKIND / 6.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -403,6 +403,8 @@ module li_time_integration_fe_rk
             call mpas_pool_get_array(thermalPool, 'temperature', temperature)
             call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
 
+            ! get layerThickness after calving
+            call li_calculate_layerThickness(meshPool, thickness, layerThickness)
             layerThicknessTmp(:,:) = layerThickness(:,:)
             layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessPrev(:,:) + &
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -96,12 +96,10 @@ module li_time_integration_fe_rk
 
       type (domain_type), intent(inout) :: &
          domain          !< Input/Output: domain object
-
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-
       !-----------------------------------------------------------------
       ! local variables
       !-----------------------------------------------------------------
@@ -113,6 +111,7 @@ module li_time_integration_fe_rk
                           config_restore_calving_front_prevent_retreat
       logical, pointer :: config_calculate_damage
       logical, pointer :: config_finalize_damage_after_advection
+      logical, pointer :: config_update_velocity_before_calving
       character (len=StrKIND), pointer :: config_thickness_advection
       character (len=StrKIND), pointer :: config_thermal_solver
       character (len=StrKIND), pointer :: config_time_integration
@@ -157,9 +156,11 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(4) :: rkSSPweights
       real (kind=RKIND), dimension(4) :: rkTendWeights ! Weights used for calculating budget terms
       integer :: nRKstages
+      logical :: solveVeloAfterCalving
 
       err = 0
       err_tmp = 0
+      solveVeloAfterCalving = .false.
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front_prevent_retreat', config_restore_calving_front_prevent_retreat)
@@ -171,6 +172,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_config(liConfigs, 'config_rk3_stages', config_rk3_stages)
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
+      call mpas_pool_get_config(liConfigs, 'config_update_velocity_before_calving', config_update_velocity_before_calving)
 
       call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'thermal', thermalPool)
@@ -480,17 +482,20 @@ module li_time_integration_fe_rk
 
          call mpas_timer_stop("halo updates")
 
-         if (config_restore_calving_front) then
-            ! restore the calving front to its initial position before velocity solve.
-            call li_restore_calving_front(domain, err_tmp)
-            err = ior(err, err_tmp)
-         endif
-
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
-         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
-         err = ior(err, err_tmp)
+         if ( config_update_velocity_before_calving .or. ( (.not. config_update_velocity_before_calving) &
+              .and. (rkStage < nRKstages) ) ) then
 
+            if (config_restore_calving_front) then
+               ! restore the calving front to its initial position before velocity solve.
+               call li_restore_calving_front(domain, err_tmp)
+               err = ior(err, err_tmp)
+            endif
+
+            call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+            err = ior(err, err_tmp)
+         endif
 ! *** end RK loop ***
       enddo
 
@@ -526,15 +531,13 @@ module li_time_integration_fe_rk
       call mpas_timer_start("calve_ice")
 
       ! ice calving
-      call li_calve_ice(domain, err_tmp)
+      call li_calve_ice(domain, err_tmp, solveVeloAfterCalving)
       err = ior(err, err_tmp)
-
-      if (config_restore_calving_front .and. config_restore_calving_front_prevent_retreat) then
+      if (config_restore_calving_front) then
          ! restore the calving front to its initial position before velocity solve.
          call li_restore_calving_front(domain, err_tmp)
          err = ior(err, err_tmp)
       endif
-
       call mpas_timer_stop("calve_ice")
 
       call mpas_timer_start("halo updates")
@@ -543,11 +546,11 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
 
-      ! Update stresses etc
-      ! === Solve Velocity =====================
-      call li_velocity_solve(domain, solveVelo=.false., err=err_tmp)
-      err = ior(err, err_tmp)
-
+! === Solve velocity for final state =====================
+      if (solveVeloAfterCalving) then
+         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+         err = ior(err, err_tmp)
+      endif
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.
 ! Seems cleaner to do it either before or after all of the time evolution of the ice

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -71,8 +71,8 @@ module li_time_integration_fe_rk
 !  routine li_time_integrator_forwardeuler_rungekutta
 !
 !> \brief   Forward Euler and Runge-Kutta time integration schemes
-!> \author  Matthew Hoffman
-!> \date    10 January 2012
+!> \author  Matthew Hoffman, Trevor Hillebrand
+!> \date    10 January 2012, updated Sept 2023 for Runge-Kutta
 !> \details
 !>  This routine performs Forward Euler and Runge-Kutta time integration.
 !
@@ -114,7 +114,6 @@ module li_time_integration_fe_rk
       character (len=StrKIND), pointer :: config_time_integration
       integer, pointer :: config_rk_order
       integer :: rkStage, iCell, iTracer, k
-      real (kind=RKIND), dimension(:,:,:), pointer :: rkTendAccum, rkTend
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                     temperature, &
                                                     enthalpy, &
@@ -133,7 +132,7 @@ module li_time_integration_fe_rk
       integer, pointer :: nCells
       real (kind=RKIND), pointer :: deltat
       real (kind=RKIND) :: deltatFull
-      real (kind=RKIND), dimension(4) :: rkWeights, rkSubstepWeights
+      real (kind=RKIND), dimension(4) :: rkSubstepWeights
       real (kind=RKIND), dimension(3) :: rkSSPweights
       integer :: nRKstages
 
@@ -222,8 +221,6 @@ module li_time_integration_fe_rk
       call mpas_timer_stop("subglacial hydro")
 
 ! *** TODO: Should basal melt rate calculation, column physics, and hydrology go inside RK loop? ***
-      call mpas_pool_get_array(geometryPool, 'rkTendAccum', rkTendAccum)
-      call mpas_pool_get_array(geometryPool, 'rkTend', rkTend)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
@@ -240,8 +237,6 @@ module li_time_integration_fe_rk
          damage3dProv(k,:) = damage(:)
          passiveTracer3dProv(k,:) = passiveTracer2d(:)
       enddo
-      rkTendAccum(:,:,:) = 0.0_RKIND
-      rkTend(:,:,:) = 0.0_RKIND
       deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
 
       ! Set RK weights based on desired time integration method. Note
@@ -256,38 +251,27 @@ module li_time_integration_fe_rk
            (config_rk_order == 1)) ) then
          config_rk_order = 1
          nRKstages = 1
-         rkWeights(:) = 1.0_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 2) ) then
          ! use classical (i.e., endpoint, or Heun's method) RK2. Could also
-         ! add config option to use midpoint
-         nRKstages = 1
-         rkWeights(:) = 0.5_RKIND
+         ! add config option to use standard endpoint or midpoint methods, but
+         ! these are algorithmically more complex and less suitable for our domains 
+         nRKstages = 2
          rkSubstepWeights(:) = 1.0_RKIND
+
+         rkSSPweights(1) = 1.0_RKIND
+         rkSSPweights(2) = 0.5_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 3) ) then
          ! use Strong Stability Preserving RK3
          nRKstages = 3
-         rkWeights(:) = 1.0_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
 
          rkSSPweights(1) = 1.0_RKIND
          rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
          rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
         ! Add option for 4-stage SSP-RK3? Allows for CFL=2.
-      elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
-               (config_rk_order == 4) ) then
-         nRKstages = 4
-         rkWeights(1) = 1.0_RKIND / 6.0_RKIND
-         rkWeights(2) = 1.0_RKIND / 3.0_RKIND
-         rkWeights(3) = 1.0_RKIND / 3.0_RKIND
-         rkWeights(4) = 1.0_RKIND / 6.0_RKIND
-
-         rkSubstepWeights(1) = 0.5_RKIND
-         rkSubstepWeights(2) = 0.5_RKIND
-         rkSubstepWeights(3) = 1.0_RKIND
-         rkSubstepWeights(4) = 1.0_RKIND ! not used
       else
          err = 1
          call mpas_log_write('config_time_integration = ' // trim(config_time_integration) &
@@ -299,27 +283,24 @@ module li_time_integration_fe_rk
          call mpas_log_write('beginning rk step $i;  rkSubstepWeight = $r', &
                              intArgs=(/rkStage/), realArgs=(/rkSubstepWeights(rkStage)/))
          deltat = deltatFull * rkSubstepWeights(rkStage)
-         rkTend(:,:,:) = 0.0_RKIND
 
          ! === calculate damage ===========
          if (config_calculate_damage) then
              call mpas_timer_start("damage")
-             call li_calculate_damage(domain, rkTendAccum(2,:,:), rkTend(2,:,:), rkWeights(rkStage), err_tmp)
+             call li_calculate_damage(domain, err_tmp)
              err = ior(err, err_tmp)
              call mpas_timer_stop("damage")
          endif
 
          ! === Compute new state for prognostic variables ===
          call mpas_timer_start("advect thickness and tracers")
-         call advection_solver(domain, rkTendAccum, rkTend, rkWeights(rkStage), err_tmp)
+         call advection_solver(domain, err_tmp)
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
-         call mpas_dmpar_field_halo_exch(domain, 'rkTendAccum')
-
-         ! If using SSP RK3, then update thickness and tracers incrementally.
+         ! If using SSP RK, then update thickness and tracers incrementally.
          ! For first RK stage, thickness and tracer updates above are sufficient
-         if ( (config_rk_order == 3) .and. (rkStage > 1 ) ) then
+         if ( rkStage > 1 )  then
             call mpas_pool_get_array(geometryPool, 'thickness', thickness)
             call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
             call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
@@ -391,77 +372,6 @@ module li_time_integration_fe_rk
             enddo
 
          endif  ! if config_rk_order == 3
-
-         ! If using RK2 or RK4 time integration, update thickness, damage,
-         ! temperature or enthalpy, passiveTracer2d before final velocity solve.
-         ! If using forward Euler or SSPRK3, these have already been updated above.
-         if ( (config_rk_order == 2) .or. (config_rk_order == 4) ) then
-            if (rkStage == nRKstages) then
-               deltat = deltatFull
-               rkTend(:,:,:) = rkTendAccum(:,:,:)
-            endif
-
-            ! Need layerThickness first in order to update other tracers
-            if (trim(config_thickness_advection) == 'fct') then
-               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:)
-               thickness = sum(layerThickness, 1)
-            endif
-
-            if (trim(config_thermal_solver) == 'enthalpy') then
-               where (layerThickness(:,:) > 0.0_RKIND)
-                  enthalpy(:,:) = ( enthalpyProv(:,:) * layerThicknessProv(:,:) + &
-                                    deltat * rkTend(1,:,:) ) / layerThickness(:,:)
-               ! elsewhere, what?
-               end where
-               ! given the enthalpy, compute the temperature and water fraction
-               do iCell = 1, nCells
-
-                  call li_enthalpy_to_temperature_kelvin(&
-                       layerCenterSigma,                           &
-                       thickness(iCell),                           &
-                       enthalpy(:,iCell),     &
-                       temperature(:,iCell),  &
-                       waterFrac(:,iCell))
-
-               enddo
-
-            elseif (trim(config_thermal_solver) == 'temperature') then
-               where (layerThickness(:,:) > 0.0_RKIND)
-                  temperature(:,:) = ( temperatureProv(:,:) * layerThicknessProv(:,:) + &
-                                       deltat * rkTend(1,:,:) ) / layerThickness(:,:)
-               ! elsewhere, what?
-               end where
-            endif
-
-            damage3d(:,:) = 0.0_RKIND
-            if (config_calculate_damage) then
-               do iCell = 1, nCells
-                  do k = 1, nVertLevels
-                     if (layerThickness(k,iCell) > 0.0_RKIND) then 
-                        damage3d(k,iCell) = ( damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                            deltat * rkTend(2,k,iCell) ) / layerThickness(k,iCell)
-                     else
-                        damage3d(k,iCell) = 0.0_RKIND
-                     endif
-                  enddo
-                  damage(iCell) = sum(damage3d(:, iCell) * layerThicknessFractions)
-               enddo
-            endif
-
-            passiveTracer3d(:,:) = 0.0_RKIND
-            do iCell = 1, nCells
-               do k = 1, nVertLevels
-                  if (layerThickness(k,iCell) > 0.0_RKIND) then
-                     passiveTracer3d(k,iCell) = ( passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                                  deltat * rkTend(3,k,iCell) ) / layerThickness(k,iCell)
-                  else
-                     passiveTracer3d(k,iCell) = 0.0_RKIND
-                  endif
-               enddo
-               passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
-            enddo
-
-         endif ! config_rk_order == 2 or 4
         
          ! === Ensure damage is within bounds after full time integration ===
          if ( (rkStage .eq. nRKstages) .and. (config_finalize_damage_after_advection) ) then
@@ -902,7 +812,7 @@ module li_time_integration_fe_rk
 !>        in calculate tendencies are now in prepare_advection.
 !-----------------------------------------------------------------------
 
-   subroutine advection_solver(domain, rkTendAccum, rkTend, rkWeight, err)
+   subroutine advection_solver(domain, err)
 
       use mpas_timekeeping
       use li_mask
@@ -910,12 +820,11 @@ module li_time_integration_fe_rk
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-      real (kind=RKIND), intent(in) :: rkWeight
+
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: rkTendAccum, rkTend
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
@@ -1033,9 +942,6 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
-                 rkTendAccum,            &
-                 rkTend,                 &
-                 rkWeight,               &
                  err_tmp,                &
                  advectTracersIn = .true.)
 
@@ -1055,9 +961,6 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
-                 rkTendAccum,            &
-                 rkTend,                 &
-                 rkWeight,               &
                  err_tmp,                &
                  advectTracersIn = .false.)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -127,7 +127,6 @@ module li_time_integration_fe_rk
                                                   groundedSfcMassBalApplied, &
                                                   groundedBasalMassBalApplied, &
                                                   floatingBasalMassBalApplied, &
-                                                  calvingThickness, &
                                                   fluxAcrossGroundingLine, &
                                                   fluxAcrossGroundingLineOnCells, &
                                                   groundedToFloatingThickness
@@ -136,7 +135,6 @@ module li_time_integration_fe_rk
                                                       groundedSfcMassBalAccum, &
                                                       groundedBasalMassBalAccum, &
                                                       floatingBasalMassBalAccum, &
-                                                      calvingThicknessAccum, &
                                                       fluxAcrossGroundingLineAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
       integer, dimension(:), pointer :: cellMaskPrev  ! cell mask before advection
@@ -203,7 +201,6 @@ module li_time_integration_fe_rk
       allocate(groundedSfcMassBalAccum(nCells+1))
       allocate(groundedBasalMassBalAccum(nCells+1))
       allocate(floatingBasalMassBalAccum(nCells+1))
-      allocate(calvingThicknessAccum(nCells+1))
       allocate(fluxAcrossGroundingLineAccum(nEdges+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
@@ -221,7 +218,6 @@ module li_time_integration_fe_rk
       groundedSfcMassBalAccum(:) = 0.0_RKIND
       groundedBasalMassBalAccum(:) = 0.0_RKIND
       floatingBasalMassBalAccum(:) = 0.0_RKIND
-      calvingThicknessAccum(:) = 0.0_RKIND
       fluxAcrossGroundingLineAccum(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
@@ -379,18 +375,6 @@ module li_time_integration_fe_rk
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
-         ! ==== Apply iceberg calving ====
-         call mpas_timer_start("calve_ice")
-         call li_calve_ice(domain, err_tmp)
-         err = ior(err, err_tmp)
-
-         if (config_restore_calving_front) then
-            ! restore the calving front to its initial position before velocity solve.
-            call li_restore_calving_front(domain, err_tmp)
-            err = ior(err, err_tmp)
-         endif
-         call mpas_timer_stop("calve_ice")
-
          ! If using SSP RK, then update thickness and tracers incrementally.
          ! For first RK stage, thickness and tracer updates above are sufficient.
          ! Likewise, for the 4-stage SSP RK3 the last stage is just a forward euler update.
@@ -469,7 +453,6 @@ module li_time_integration_fe_rk
          call mpas_pool_get_array(geometryPool, 'basalMassBalApplied', basalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
-         call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pooL_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
@@ -479,7 +462,6 @@ module li_time_integration_fe_rk
          basalMassBalAccum = basalMassBalAccum + rkTendWeights(rkStage) * basalMassBalApplied
          groundedBasalMassBalAccum = groundedBasalMassBalAccum + rkTendWeights(rkStage) * groundedBasalMassBalApplied
          floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
-         calvingThicknessAccum = calvingThicknessAccum + rkTendWeights(rkStage) * calvingThickness
          fluxAcrossGroundingLineAccum = fluxAcrossGroundingLineAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLine
 
          ! Halo updates
@@ -492,6 +474,12 @@ module li_time_integration_fe_rk
          call mpas_dmpar_field_halo_exch(domain, 'passiveTracer2d')
 
          call mpas_timer_stop("halo updates")
+
+         if (config_restore_calving_front) then
+            ! restore the calving front to its initial position before velocity solve.
+            call li_restore_calving_front(domain, err_tmp)
+            err = ior(err, err_tmp)
+         endif
 
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
@@ -518,7 +506,6 @@ module li_time_integration_fe_rk
       basalMassBalApplied(:) = basalMassBalAccum(:)
       groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
-      calvingThickness(:) = calvingThicknessAccum(:)
       fluxAcrossGroundingLine(:) = fluxAcrossGroundingLineAccum(:)
       
       fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
@@ -541,6 +528,32 @@ module li_time_integration_fe_rk
       enddo ! edges
 ! Reset time step to full length after RK loop
       deltat = deltatFull
+
+! === Calve ice ========================
+      call mpas_timer_start("calve_ice")
+
+      ! ice calving
+      call li_calve_ice(domain, err_tmp)
+      err = ior(err, err_tmp)
+
+      if (config_restore_calving_front .and. config_restore_calving_front_prevent_retreat) then
+         ! restore the calving front to its initial position before velocity solve.
+         call li_restore_calving_front(domain, err_tmp)
+         err = ior(err, err_tmp)
+      endif
+
+      call mpas_timer_stop("calve_ice")
+
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'cellMask')
+      call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
+      call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
+      call mpas_timer_stop("halo updates")
+
+      ! Update stresses etc
+      ! === Solve Velocity =====================
+      call li_velocity_solve(domain, solveVelo=.false., err=err_tmp)
+      err = ior(err, err_tmp)
 
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.
@@ -576,7 +589,6 @@ module li_time_integration_fe_rk
       deallocate(groundedSfcMassBalAccum)
       deallocate(groundedBasalMassBalAccum)
       deallocate(floatingBasalMassBalAccum)
-      deallocate(calvingThicknessAccum)
       deallocate(fluxAcrossGroundingLineAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -259,17 +259,6 @@ module li_time_integration_fe_rk
       err = ior(err, err_tmp)
       call mpas_timer_stop("vertical therm")
 
-! === Update subglacial hydrology  ===========
-! It's not clear where the best place to call this should be.
-! Seems sensible to put it after thermal evolution is complete to get updated basal melting source term.
-! Also seems (might be?) better to put it after geometry evolution.
-! We want it before the velocity solve since the hydro model can control  the velo basal b.c.
-! This was moved to be before geometry evolution to simplify RK time integration.
-      call mpas_timer_start("subglacial hydro")
-      call li_SGH_solve(domain, err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_timer_stop("subglacial hydro")
-
 ! *** TODO: Should basal melt rate calculation, column physics, and hydrology go inside RK loop? ***
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
@@ -510,6 +499,7 @@ module li_time_integration_fe_rk
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'cellMask')
       call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
+      call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
 
       ! Calculate volume converted from grounded to floating
@@ -526,6 +516,16 @@ module li_time_integration_fe_rk
 
 ! Reset time step to full length after RK loop
       deltat = deltatFull
+
+! === Update subglacial hydrology  ===========
+! It's not clear where the best place to call this should be.
+! Seems sensible to put it after thermal evolution is complete to get updated basal melting source term.
+! Also seems (might be?) better to put it after geometry evolution.
+! We want it before the velocity solve since the hydro model can control  the velo basal b.c.
+      call mpas_timer_start("subglacial hydro")
+      call li_SGH_solve(domain, err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_timer_stop("subglacial hydro")
 
 ! === Calve ice ========================
       call mpas_timer_start("calve_ice")
@@ -552,17 +552,18 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'vertexMask')
       call mpas_timer_stop("halo updates")
 
-! === Solve velocity for final state =====================
-      if (solveVeloAfterCalving) then
-         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
-         err = ior(err, err_tmp)
-      endif
 ! === Update bed topo =====================
 ! It's not clear when the best time to do this is.
 ! Seems cleaner to do it either before or after all of the time evolution of the ice
 ! is complete.  Putting it after.
       call li_bedtopo_solve(domain, err=err_tmp)
       err = ior(err, err_tmp)
+
+! === Solve velocity for final state =====================
+      if (solveVeloAfterCalving) then
+         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+         err = ior(err, err_tmp)
+      endif
 
 ! === Calculate diagnostic variables for new state =====================
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -9,17 +9,17 @@
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  li_time_integration_fe
+!  li_time_integration_fe_rk
 !
-!> \brief MPAS land ice Forward Euler time integration scheme
-!> \author Matt Hoffman
-!> \date   17 April 2011
+!> \brief MPAS land ice Forward Euler and Runge-Kutta time integration schemes
+!> \author Matt Hoffman, Trevor Hillebrand
+!> \date   17 April 2011, Runge-Kutta added Sept 2023
 !> \details
-!>  This module contains the Forward Euler time integration scheme
+!>  This module contains the Forward Euler and Runge-Kutta time integration schemes
 !
 !-----------------------------------------------------------------------
 
-module li_time_integration_fe
+module li_time_integration_fe_rk
 
    use mpas_derived_types
    use mpas_pool_routines
@@ -52,7 +52,7 @@ module li_time_integration_fe
    !
    !--------------------------------------------------------------------
 
-   public :: li_time_integrator_forwardeuler
+   public :: li_time_integrator_forwardeuler_rungekutta
 
    !--------------------------------------------------------------------
    !
@@ -68,16 +68,16 @@ module li_time_integration_fe
 
 !***********************************************************************
 !
-!  routine li_time_integrator_forwardeuler
+!  routine li_time_integrator_forwardeuler_rungekutta
 !
-!> \brief   Forward Euler time integration scheme
+!> \brief   Forward Euler and Runge-Kutta time integration schemes
 !> \author  Matthew Hoffman
 !> \date    10 January 2012
 !> \details
-!>  This routine performs Forward Euler time integration.
+!>  This routine performs Forward Euler and Runge-Kutta time integration.
 !
 !-----------------------------------------------------------------------
-   subroutine li_time_integrator_forwardeuler(domain, err)
+   subroutine li_time_integrator_forwardeuler_rungekutta(domain, err)
 
       use li_subglacial_hydro
       use li_velocity
@@ -424,7 +424,7 @@ module li_time_integration_fe
 
       ! === error check
       if (err == 1) then
-          call mpas_log_write("An error has occurred in li_time_integrator_forwardeuler.", MPAS_LOG_ERR)
+          call mpas_log_write("An error has occurred in li_time_integrator_forwardeuler_rungekutta.", MPAS_LOG_ERR)
       endif
 
       deallocate(temperatureProv)
@@ -435,7 +435,7 @@ module li_time_integration_fe
       deallocate(passiveTracer3dProv)
       deallocate(passiveTracer3d)
    !--------------------------------------------------------------------
-   end subroutine li_time_integrator_forwardeuler
+   end subroutine li_time_integrator_forwardeuler_rungekutta
 
 
 
@@ -1414,5 +1414,5 @@ module li_time_integration_fe
     end subroutine advance_clock
 
 
-end module li_time_integration_fe
+end module li_time_integration_fe_rk
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -135,7 +135,8 @@ module li_time_integration_fe_rk
                                                       groundedSfcMassBalAccum, &
                                                       groundedBasalMassBalAccum, &
                                                       floatingBasalMassBalAccum, &
-                                                      fluxAcrossGroundingLineAccum
+                                                      fluxAcrossGroundingLineAccum, &
+                                                      fluxAcrossGroundingLineOnCellsAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
       integer, dimension(:), pointer :: cellMaskPrev  ! cell mask before advection
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
@@ -202,6 +203,7 @@ module li_time_integration_fe_rk
       allocate(groundedBasalMassBalAccum(nCells+1))
       allocate(floatingBasalMassBalAccum(nCells+1))
       allocate(fluxAcrossGroundingLineAccum(nEdges+1))
+      allocate(fluxAcrossGroundingLineOnCellsAccum(nCells+1))
 
       temperaturePrev(:,:) = 0.0_RKIND
       waterFracPrev(:,:) = 0.0_RKIND
@@ -219,6 +221,7 @@ module li_time_integration_fe_rk
       groundedBasalMassBalAccum(:) = 0.0_RKIND
       floatingBasalMassBalAccum(:) = 0.0_RKIND
       fluxAcrossGroundingLineAccum(:) = 0.0_RKIND
+      fluxAcrossGroundingLineOnCellsAccum(:) = 0.0_RKIND
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
@@ -454,6 +457,7 @@ module li_time_integration_fe_rk
          call mpas_pool_get_array(geometryPool, 'floatingBasalMassBalApplied', floatingBasalMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
          call mpas_pooL_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
+         call mpas_pooL_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
 
          ! update budgets
@@ -463,6 +467,7 @@ module li_time_integration_fe_rk
          groundedBasalMassBalAccum = groundedBasalMassBalAccum + rkTendWeights(rkStage) * groundedBasalMassBalApplied
          floatingBasalMassBalAccum = floatingBasalMassBalAccum + rkTendWeights(rkStage) * floatingBasalMassBalApplied
          fluxAcrossGroundingLineAccum = fluxAcrossGroundingLineAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLine
+         fluxAcrossGroundingLineOnCellsAccum = fluxAcrossGroundingLineOnCellsAccum + rkTendWeights(rkStage) * fluxAcrossGroundingLineOnCells
 
          ! Halo updates
          call mpas_timer_start("halo updates")
@@ -490,8 +495,10 @@ module li_time_integration_fe_rk
       enddo
 
 ! Finalize budget updates
-      ! Calculate volume converted from grounded to floating
-      ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
+      ! Update masks after RK integration
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+      err = ior(err, err_tmp)
+
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
 
@@ -500,32 +507,18 @@ module li_time_integration_fe_rk
       call mpas_dmpar_field_halo_exch(domain, 'edgeMask')
       call mpas_timer_stop("halo updates")
 
+      ! Calculate volume converted from grounded to floating
+      ! This needs to be determined after SMB/BMB are applied because those can change floating/grounded state
       call li_grounded_to_floating(cellMaskPrev, cellMask, thickness, groundedToFloatingThickness, nCells)
+
       sfcMassBalApplied(:) = sfcMassBalAccum(:)
       groundedSfcMassBalApplied(:) = groundedSfcMassBalAccum(:)
       basalMassBalApplied(:) = basalMassBalAccum(:)
       groundedBasalMassBalApplied(:) = groundedBasalMassBalAccum(:)
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
       fluxAcrossGroundingLine(:) = fluxAcrossGroundingLineAccum(:)
-      
-      fluxAcrossGroundingLineOnCells(:) = 0.0_RKIND
-      do iEdge = 1, nEdges
-         if (li_mask_is_grounding_line(edgeMask(iEdge))) then
-            iCell1 = cellsOnEdge(1,iEdge)
-            iCell2 = cellsOnEdge(2,iEdge)
-            if (li_mask_is_grounded_ice(cellMask(iCell1))) then
-               theGroundedCell = iCell1
-            else
-               theGroundedCell = iCell2
-            endif
-            if ( thickness(theGroundedCell) > 0.0_RKIND ) then
-               fluxAcrossGroundingLineOnCells(theGroundedCell) = fluxAcrossGroundingLineOnCells(theGroundedCell) + &
-                       fluxAcrossGroundingLine(iEdge) / thickness(theGroundedCell) * config_ice_density  ! adjust to correct units
-            else
-               fluxAcrossGroundingLineOnCells(theGroundedCell) = 0.0_RKIND
-            endif
-         endif
-      enddo ! edges
+      fluxAcrossGroundingLineOnCells(:) = fluxAcrossGroundingLineOnCellsAccum(:)
+
 ! Reset time step to full length after RK loop
       deltat = deltatFull
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -114,7 +114,7 @@ module li_time_integration_fe_rk
       character (len=StrKIND), pointer :: config_time_integration
       integer, pointer :: config_rk_order
       integer :: rkStage, iCell, iTracer, k
-      real (kind=RKIND), dimension(:,:,:), pointer :: rkTend
+      real (kind=RKIND), dimension(:,:,:), pointer :: rkTendAccum, rkTend
       real (kind=RKIND), dimension(:,:), pointer :: layerThickness, &
                                                     temperature, &
                                                     enthalpy, &
@@ -135,6 +135,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkWeights, rkSubstepWeights
       real (kind=RKIND), dimension(3) :: rkSSPweights
+      integer :: nRKstages
 
       err = 0
       err_tmp = 0
@@ -221,6 +222,7 @@ module li_time_integration_fe_rk
       call mpas_timer_stop("subglacial hydro")
 
 ! *** TODO: Should basal melt rate calculation, column physics, and hydrology go inside RK loop? ***
+      call mpas_pool_get_array(geometryPool, 'rkTendAccum', rkTendAccum)
       call mpas_pool_get_array(geometryPool, 'rkTend', rkTend)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
@@ -238,6 +240,7 @@ module li_time_integration_fe_rk
          damage3dProv(k,:) = damage(:)
          passiveTracer3dProv(k,:) = passiveTracer2d(:)
       enddo
+      rkTendAccum(:,:,:) = 0.0_RKIND
       rkTend(:,:,:) = 0.0_RKIND
       deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
 
@@ -252,25 +255,30 @@ module li_time_integration_fe_rk
            ((trim(config_time_integration) == 'runge_kutta') .and. &
            (config_rk_order == 1)) ) then
          config_rk_order = 1
+         nRKstages = 1
          rkWeights(:) = 1.0_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 2) ) then
          ! use classical (i.e., endpoint, or Heun's method) RK2. Could also
          ! add config option to use midpoint
+         nRKstages = 1
          rkWeights(:) = 0.5_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 3) ) then
          ! use Strong Stability Preserving RK3
+         nRKstages = 3
          rkWeights(:) = 1.0_RKIND
          rkSubstepWeights(:) = 1.0_RKIND
 
          rkSSPweights(1) = 1.0_RKIND
          rkSSPweights(2) = 3.0_RKIND / 4.0_RKIND
          rkSSPweights(3) = 1.0_RKIND / 3.0_RKIND
+        ! Add option for 4-stage SSP-RK3? Allows for CFL=2.
       elseif ( (trim(config_time_integration) == 'runge_kutta') .and. &
                (config_rk_order == 4) ) then
+         nRKstages = 4
          rkWeights(1) = 1.0_RKIND / 6.0_RKIND
          rkWeights(2) = 1.0_RKIND / 3.0_RKIND
          rkWeights(3) = 1.0_RKIND / 3.0_RKIND
@@ -287,34 +295,27 @@ module li_time_integration_fe_rk
                              intArgs=(/config_rk_order/), messageType=MPAS_LOG_ERR)
       endif 
 ! *** Start RK loop ***
-      do rkStage = 1, config_rk_order
+      do rkStage = 1, nRKstages
          call mpas_log_write('beginning rk step $i;  rkSubstepWeight = $r', &
                              intArgs=(/rkStage/), realArgs=(/rkSubstepWeights(rkStage)/))
          deltat = deltatFull * rkSubstepWeights(rkStage)
+         rkTend(:,:,:) = 0.0_RKIND
 
          ! === calculate damage ===========
          if (config_calculate_damage) then
              call mpas_timer_start("damage")
-             call li_calculate_damage(domain, rkTend(2,:,:), rkWeights(rkStage), err_tmp)
+             call li_calculate_damage(domain, rkTendAccum(2,:,:), rkTend(2,:,:), rkWeights(rkStage), err_tmp)
              err = ior(err, err_tmp)
              call mpas_timer_stop("damage")
          endif
 
          ! === Compute new state for prognostic variables ===
          call mpas_timer_start("advect thickness and tracers")
-         call advection_solver(domain, rkTend, rkWeights(rkStage), err_tmp)
+         call advection_solver(domain, rkTendAccum, rkTend, rkWeights(rkStage), err_tmp)
          err = ior(err, err_tmp)
          call mpas_timer_stop("advect thickness and tracers")
 
-         call mpas_dmpar_field_halo_exch(domain, 'rkTend')
-
-         ! === finalize damage after advection ===========
-         if (config_finalize_damage_after_advection) then
-             call mpas_timer_start("finalize damage")
-             call li_finalize_damage_after_advection(domain, err_tmp)
-             err = ior(err, err_tmp)
-             call mpas_timer_stop("finalize damage")
-         endif
+         call mpas_dmpar_field_halo_exch(domain, 'rkTendAccum')
 
          ! If using SSP RK3, then update thickness and tracers incrementally.
          ! For first RK stage, thickness and tracer updates above are sufficient
@@ -329,14 +330,15 @@ module li_time_integration_fe_rk
             call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
 
             layerThicknessTmp(:,:) = layerThickness(:,:)
-               layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessProv(:,:) + &
+            layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessProv(:,:) + &
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)
-               thickness = sum(layerThickness, 1)
+            thickness = sum(layerThickness, 1)
 
             if (trim(config_thermal_solver) == 'enthalpy') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   enthalpy(:,:) = ( rkSSPweights(rkStage) * enthalpyProv(:,:) * layerThicknessProv(:,:) + &
-                                    (1.0_RKIND - rkSSPweights(rkStage)) * enthalpy(:,:) * layerThicknessTmp(:,:) ) / layerThickness(:,:)
+                                    (1.0_RKIND - rkSSPweights(rkStage)) * enthalpy(:,:) * &
+                                    layerThicknessTmp(:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
                end where
                ! given the enthalpy, compute the temperature and water fraction
@@ -354,7 +356,8 @@ module li_time_integration_fe_rk
             elseif (trim(config_thermal_solver) == 'temperature') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   temperature(:,:) = ( rkSSPweights(rkStage) * temperatureProv(:,:) * layerThicknessProv(:,:) + &
-                                       (1.0_RKIND - rkSSPweights(rkStage)) * temperature(:,:) * layerThicknessTmp(:,:) ) / layerThickness(:,:)
+                                       (1.0_RKIND - rkSSPweights(rkStage)) * temperature(:,:) * &
+                                       layerThicknessTmp(:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
                end where
             endif
@@ -364,7 +367,8 @@ module li_time_integration_fe_rk
                   do k = 1, nVertLevels
                      if (layerThickness(k,iCell) > 0.0_RKIND) then
                         damage3d(k,iCell) = ( rkSSPweights(rkStage) * damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                              (1.0_RKIND - rkSSPweights(rkStage)) * damage(iCell) * layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                                              (1.0_RKIND - rkSSPweights(rkStage)) * damage(iCell) * &
+                                              layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
                      else
                         damage3d(k,iCell) = 0.0_RKIND
                      endif
@@ -377,7 +381,8 @@ module li_time_integration_fe_rk
                do k = 1, nVertLevels
                   if (layerThickness(k,iCell) > 0.0_RKIND) then
                      passiveTracer3d(k,iCell) = ( rkSSPweights(rkStage) * passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                                  (1.0_RKIND - rkSSPweights(rkStage)) * passiveTracer2d(iCell) * layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
+                                                  (1.0_RKIND - rkSSPweights(rkStage)) * passiveTracer2d(iCell) * &
+                                                  layerThicknessTmp(k,iCell) ) / layerThickness(k,iCell)
                   else
                      passiveTracer3d(k,iCell) = 0.0_RKIND
                   endif
@@ -385,30 +390,27 @@ module li_time_integration_fe_rk
                passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
             enddo
 
-            ! === Ensure damage is within bounds after full time integration ===
-            if ( (rkStage .eq. config_rk_order) .and. (config_finalize_damage_after_advection) ) then
-                call mpas_timer_start("finalize damage")
-                call li_finalize_damage_after_advection(domain, err_tmp)
-                err = ior(err, err_tmp)
-                call mpas_timer_stop("finalize damage")
-            endif
          endif  ! if config_rk_order == 3
 
          ! If using RK2 or RK4 time integration, update thickness, damage,
          ! temperature or enthalpy, passiveTracer2d before final velocity solve.
          ! If using forward Euler or SSPRK3, these have already been updated above.
-         if ( (rkStage .eq. config_rk_order) .and. ( (config_rk_order == 2) .or. (config_rk_order == 4) ) ) then
+         if ( (config_rk_order == 2) .or. (config_rk_order == 4) ) then
+            if (rkStage == nRKstages) then
+               deltat = deltatFull
+               rkTend(:,:,:) = rkTendAccum(:,:,:)
+            endif
 
             ! Need layerThickness first in order to update other tracers
             if (trim(config_thickness_advection) == 'fct') then
-               layerThickness(:,:) = layerThicknessProv(:,:) + deltatFull * rkTend(4,:,:)
+               layerThickness(:,:) = layerThicknessProv(:,:) + deltat * rkTend(4,:,:)
                thickness = sum(layerThickness, 1)
             endif
 
             if (trim(config_thermal_solver) == 'enthalpy') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   enthalpy(:,:) = ( enthalpyProv(:,:) * layerThicknessProv(:,:) + &
-                                    deltatFull * rkTend(1,:,:) ) / layerThickness(:,:)
+                                    deltat * rkTend(1,:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
                end where
                ! given the enthalpy, compute the temperature and water fraction
@@ -426,17 +428,18 @@ module li_time_integration_fe_rk
             elseif (trim(config_thermal_solver) == 'temperature') then
                where (layerThickness(:,:) > 0.0_RKIND)
                   temperature(:,:) = ( temperatureProv(:,:) * layerThicknessProv(:,:) + &
-                                       deltatFull * rkTend(1,:,:) ) / layerThickness(:,:)
+                                       deltat * rkTend(1,:,:) ) / layerThickness(:,:)
                ! elsewhere, what?
                end where
             endif
 
+            damage3d(:,:) = 0.0_RKIND
             if (config_calculate_damage) then
                do iCell = 1, nCells
                   do k = 1, nVertLevels
                      if (layerThickness(k,iCell) > 0.0_RKIND) then 
                         damage3d(k,iCell) = ( damage3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                            deltatFull * rkTend(2,k,iCell) ) / layerThickness(k,iCell)
+                                            deltat * rkTend(2,k,iCell) ) / layerThickness(k,iCell)
                      else
                         damage3d(k,iCell) = 0.0_RKIND
                      endif
@@ -445,11 +448,12 @@ module li_time_integration_fe_rk
                enddo
             endif
 
+            passiveTracer3d(:,:) = 0.0_RKIND
             do iCell = 1, nCells
                do k = 1, nVertLevels
                   if (layerThickness(k,iCell) > 0.0_RKIND) then
                      passiveTracer3d(k,iCell) = ( passiveTracer3dProv(k,iCell) * layerThicknessProv(k,iCell) + &
-                                                  deltatFull * rkTend(3,k,iCell) ) / layerThickness(k,iCell)
+                                                  deltat * rkTend(3,k,iCell) ) / layerThickness(k,iCell)
                   else
                      passiveTracer3d(k,iCell) = 0.0_RKIND
                   endif
@@ -457,15 +461,16 @@ module li_time_integration_fe_rk
                passiveTracer2d(iCell) = sum(passiveTracer3d(:,iCell) * layerThicknessFractions)
             enddo
 
-            ! === Ensure damage is within bounds after full time integration ===
-            if (config_finalize_damage_after_advection) then
-                call mpas_timer_start("finalize damage")
-                call li_finalize_damage_after_advection(domain, err_tmp)
-                err = ior(err, err_tmp)
-                call mpas_timer_stop("finalize damage")
-            endif
+         endif ! config_rk_order == 2 or 4
+        
+         ! === Ensure damage is within bounds after full time integration ===
+         if ( (rkStage .eq. nRKstages) .and. (config_finalize_damage_after_advection) ) then
+             call mpas_timer_start("finalize damage")
+             call li_finalize_damage_after_advection(domain, err_tmp)
+             err = ior(err, err_tmp)
+             call mpas_timer_stop("finalize damage")
          endif
-         
+ 
          ! Update velocity for each RK step
          ! === Solve Velocity =====================
          call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
@@ -897,7 +902,7 @@ module li_time_integration_fe_rk
 !>        in calculate tendencies are now in prepare_advection.
 !-----------------------------------------------------------------------
 
-   subroutine advection_solver(domain, rkTend, rkWeight, err)
+   subroutine advection_solver(domain, rkTendAccum, rkTend, rkWeight, err)
 
       use mpas_timekeeping
       use li_mask
@@ -910,7 +915,7 @@ module li_time_integration_fe_rk
       ! input/output variables
       !-----------------------------------------------------------------
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
-      real (kind=RKIND), dimension(:,:,:), intent(inout) :: rkTend
+      real (kind=RKIND), dimension(:,:,:), intent(inout) :: rkTendAccum, rkTend
       !-----------------------------------------------------------------
       ! output variables
       !-----------------------------------------------------------------
@@ -1028,6 +1033,7 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 rkTendAccum,            &
                  rkTend,                 &
                  rkWeight,               &
                  err_tmp,                &
@@ -1049,6 +1055,7 @@ module li_time_integration_fe_rk
                  geometryPool,           &
                  thermalPool,            &
                  scratchPool,            &
+                 rkTendAccum,            &
                  rkTend,                 &
                  rkWeight,               &
                  err_tmp,                &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -403,8 +403,6 @@ module li_time_integration_fe_rk
             call mpas_pool_get_array(thermalPool, 'temperature', temperature)
             call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
 
-            ! get layerThickness after calving
-            call li_calculate_layerThickness(meshPool, thickness, layerThickness)
             layerThicknessTmp(:,:) = layerThickness(:,:)
             layerThickness(:,:) = rkSSPweights(rkStage) * layerThicknessPrev(:,:) + &
                                      (1.0_RKIND - rkSSPweights(rkStage)) * layerThickness(:,:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -985,6 +985,7 @@ module li_time_integration_fe_rk
       real (kind=RKIND), dimension(:), pointer :: thicknessOld
       real (kind=RKIND), dimension(:), pointer :: thicknessNew
       real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
 
       real (kind=RKIND), dimension(:,:), pointer :: temperature
       real (kind=RKIND), dimension(:,:), pointer :: waterFrac
@@ -1173,7 +1174,10 @@ module li_time_integration_fe_rk
          if ( config_restore_thickness_after_advection ) then
             call mpas_pool_get_array(geometryPool, 'thickness', thickness)
             call mpas_pool_get_array(geometryPool, 'thicknessOld', thicknessOld)
+            call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
             thickness(:) = thicknessOld(:)
+
+            call li_calculate_layerThickness(meshPool, thickness, layerThickness)
          endif
 
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -531,7 +531,13 @@ module li_time_integration_fe_rk
       call mpas_timer_start("calve_ice")
 
       ! ice calving
-      call li_calve_ice(domain, err_tmp, solveVeloAfterCalving)
+      if ( config_update_velocity_before_calving ) then
+         call li_calve_ice(domain, err_tmp, solveVeloAfterCalving)
+      else
+         call li_calve_ice(domain, err_tmp)
+         solveVeloAfterCalving = .true.
+      endif
+
       err = ior(err, err_tmp)
       if (config_restore_calving_front) then
          ! restore the calving front to its initial position before velocity solve.


### PR DESCRIPTION
This merge adds Runge-Kutta time integration to MALI, which is likely necessary when using higher-order advection. Currently, Runge-Kutta integration is used for damage evolution and thickness and tracer advection. Surface and basal mass balances are applied within the Runge-Kutta loop and budgets are calculated at the end of the loop. Front ablation (i.e., calving and face-melting) and bed topography updates are applied via forward Euler outside the Runge-Kutta loop. This could conceivably be updated for full consistency.

The Runge-Kutta formulations used here are the two-stage second-order and and three-stage third-order strong stability preserving schemes of Shu and Osher (1988), as well as the four-stage third-order strong stability preserving scheme of Spiteri and Ruuth (2002). See equations 2.47–2.49 in Durran (2010) for an overview.

There is one velocity solve per Runge-Kutta stage and an optional solve before calving (more on that below), meaning that the four-stage RK3 scheme is ~25–33% more expensive than the three-stage RK3 scheme for a given time step length. However, the four-stage scheme theoretically allows for an effective CFL fraction of 2.0, while the three-stage scheme is limited to CFL fraction of 1.0. Testing indicates stable results using the four-stage scheme for an effective CFL fraction of 1.8 for a simple grounded slab advecting at uniform speed. Note that when using the four-stage scheme in MALI, the maximum allowable time step is updated, so `config_adaptive_timestep_CFL_fraction` should still be between 0.0 and 1.0.

There is now an optional extra velocity solve between advection and calving in addition to the final velocity solve at the end of the time step, for any choice of time integration scheme. The extra velocity solution prior to calving ensures a self-consistent set of inputs to calving routines; i.e., the velocity, stress, and strain rate fields will be consistent with the geometry used for calving, which is not the case when velocity is solved only after calving. This makes calving more accurate, but is obviously significantly more expensive. The extra velocity solution is enabled using `config_update_velocity_before_calving = .true.`. It is disabled by default to allow regression tests to pass baseline comparison. Note that the extra velocity solution is not necessary for some calving laws, such as damage threshold calving, so the user should carefully consider this option when setting up simulations. There is currently no check in the code to ensure the combination of calving and extra velocity solve settings are sensible. Also of note is that `li_restore_calving_front` (if enabled) is called before the extra velocity solution to prevent solving velocities on an extended geometry, while the remaining calving routines are called after the velocity solve. If the volume of dynamic ice is not changed by calving, then the final velocity solution is automatically skipped.

References:
Durran, Dale R. Numerical Methods for Fluid Dynamics. Vol. 32. Texts in Applied Mathematics. New York, NY: Springer New York, 2010. https://doi.org/10.1007/978-1-4419-6412-0.

Shu CW, Osher S (1988) Efficient implementation of essentially nonoscillatory shock-capturing schemes. J Comp Phys 77:439–471

Spiteri RJ, Ruuth SJ (2002) A new class of optimal high-order strong-stability-preserving time discretization methods. SIAM J Numer Anal 40:469–491
