### PR TITLE
Fix ice-shelf calving bug introduced by `openOceanMask`

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1225,7 +1225,7 @@ is the value of that variable from the *previous* time level!
                         description="mask of grid cells that should be calved.  0=no calving, 1=should be calved"
                 />
                 <var name="openOceanMask" type="integer" dimensions="nCells Time" units="" time_levs="1"
-                        description="mask of open ocean cells.  Used to eliminate holes in ice shelf from calving"
+                        description="mask of open ocean cells, including floating non-dynamic cells.  Used to eliminate holes in ice shelf from calving"
                 />
                 <var name="calvingFrontMask" type="integer" dimensions="nCells Time" units="none" time_levs="1"
                         description="mask of the calving front position on cells"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3058,7 +3058,7 @@ module li_calving
       integer, dimension(:,:), pointer :: cellsOnCell ! list of cells that neighbor each cell
       integer, dimension(:), pointer :: nEdgesOnCell
       type (field1dInteger), pointer :: seedMaskField, growMaskField
-      integer, dimension(:), pointer :: seedMask, growMask
+      integer, dimension(:), pointer :: seedMask, growMask, cellMask
       real (kind=RKIND), dimension(:), pointer :: bedTopography, thickness
       real (kind=RKIND), pointer :: config_sea_level
       integer, pointer :: nCells
@@ -3076,6 +3076,7 @@ module li_calving
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
@@ -3088,8 +3089,8 @@ module li_calving
       seedMask(:) = 0
       growMask(:) = 0
       do iCell = 1, nCells
-         if ((bedTopography(iCell) < config_sea_level) .and. (thickness(iCell) == 0.0_RKIND)) then
-            growMask(iCell) = 1
+         if ((bedTopography(iCell) < config_sea_level) .and. ( .not. li_mask_is_dynamic_ice(cellMask(iCell)) ) ) then
+            growMask(iCell) = 1  ! includes floating non-dynamic cells
             do iNeighbor = 1, nEdgesOnCell(iCell)
                jCell = cellsOnCell(iNeighbor, iCell)
                if (jCell == nCells + 1) then


### PR DESCRIPTION
This merge fixes a bug that was introduced when `openOceanMask` was added to prevent calving into holes within the ice shelf. The previous implementation shut down calving if there was a non-dynamic cell between the dynamic margin and the open ocean, which is clearly not correct and led to large areas of Antarctica not calving at all in runs on the ISMIP6 mesh using von Mises calving. The fix in this merge adds non-dynamic cells to `openOceanMask`, which is the simples fix for this problem, and also fixes the edge case in which a single non-dynamic cell could shut off all calving between two closely adjacent ice shelves (at Thwaites, for instance).