### PR TITLE
Add option to set floatingBasalMassBal equal to flux divergence

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -345,7 +345,7 @@
         <nml_record name="iceshelf_melt" in_defaults="true">
                 <nml_option name="config_basal_mass_bal_float" type="character" default_value="none" units="unitless"
                             description="Selection of the method for computing the basal mass balance of floating ice.  'none' sets the basalMassBal field to 0 everywhere.  'file' uses without modification whatever value was read in through an input or forcing file or the value set by an ESM coupler.  'constant', 'mismip', 'seroussi' use hardcoded fields defined in the code applicable to Thwaites Glacier. 'temperature_profile' generates a depth-melt relation based on an ocean temperature profile and sill depth. ISMIP6 is the method prescribed by ISMIP6."
-                            possible_values="'none', 'file', 'constant', 'mismip', 'seroussi', 'temperature_profile', 'ismip6'"
+                            possible_values="'none', 'file', 'constant', 'mismip', 'seroussi', 'temperature_profile', 'ismip6', 'flux_divergence'"
                 />
                 <nml_option name="config_bmlt_float_flux" type="real" default_value="0.0" units="W m^{-2}"
 		            description="Value of the constant heat flux applied to the base of floating ice (positive upward)."

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -205,7 +205,8 @@ module li_advection
       real (kind=RKIND), dimension(:), pointer :: dvEdge
 
       character (len=StrKIND), pointer :: &
-           config_thickness_advection   ! method for advecting thickness and tracers
+           config_thickness_advection, &  ! method for advecting thickness and tracers
+           config_basal_mass_bal_float
 
       logical, pointer :: &
            config_print_thickness_advection_info, &  !TODO - change to config_print_advection_info?
@@ -304,6 +305,7 @@ module li_advection
 
       ! get config variables
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
+      call mpas_pool_get_config(liConfigs, 'config_basal_mass_bal_float', config_basal_mass_bal_float)
       call mpas_pool_get_config(liConfigs, 'config_print_thickness_advection_info', config_print_thickness_advection_info)
       call mpas_pool_get_config(liConfigs, 'config_print_thermal_info', config_print_thermal_info)
       call mpas_pool_get_config(liConfigs, 'config_thermal_calculate_bmb', config_thermal_calculate_bmb)
@@ -532,14 +534,17 @@ module li_advection
          ! Calculate dynamicThickening (layerThickness is updated by advection at this point, while thickness is still old)
          dynamicThickening = (sum(layerThickness, 1) - thickness) / dt * scyr  ! units of m/yr
 
-
          ! Update the thickness and cellMask before applying the mass balance.
          ! The update is needed because the SMB and BMB depend on whether ice is present.
          thickness = sum(layerThickness, 1)
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
-
-
+         if (trim(config_basal_mass_bal_float) == 'flux_divergence') then
+            do iCell = 1, nCells
+               floatingBasalMassBal(iCell) = -1.0_RKIND * dynamicThickening(iCell) * config_ice_density / scyr * &
+                                             real(li_mask_is_floating_ice_int(cellMask(iCell)),RKIND)
+            enddo
+         endif
          !-----------------------------------------------------------------
          ! Add the surface and basal mass balance to the layer thickness
          !-----------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -414,6 +414,9 @@ module li_iceshelf_melt
             elseif (trim(config_basal_mass_bal_float) == 'file') then
                ! Do nothing, handled above
 
+            elseif (trim(config_basal_mass_bal_float) == 'flux_divergence') then
+               ! Do nothing. Handled when dynamicThickening is calculated. 
+
             elseif (trim(config_basal_mass_bal_float) == 'constant') then
 
                ! set melt rate to a constant value for floating ice


### PR DESCRIPTION
Add option to set `floatingBasalMassBal` equal to flux divergence, using `config_basal_mass_bal_float = 'flux_divergence`.