### PR TITLE
Remove commented code and unused variables from `li_mesh`

### DIFF
--- a/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mesh.F
@@ -15,7 +15,7 @@
 !>  \brief MALI mesh structure with GPU support
 !> \author Rob Aulwes and Phil Jones, modified for MALI
 !>         by Trevor Hillebrand and Matthew Hoffman
-!> \date   14 Jan 2020
+!> \date   14 Jan 2020, added to MALI 2023
 !> \details
 !> This module creates and maintains a primary land ice mesh structure
 !> and ensures all mesh variables are copied to an accelerator device
@@ -32,8 +32,6 @@ module li_mesh
    use mpas_pool_routines
    use mpas_constants
    use mpas_log
-
-!   use ocn_config
 
    implicit none
    private
@@ -62,7 +60,6 @@ module li_mesh
       maxEdges2, &! 2x the largest number of edges any polygon has
       vertexDegree, &! number of cells or edges touching each vertex
       nVertLevels ! number of vertical levels
-!      nVertLevelsP1 ! number of vertical interfaces (levels plus one)
 
    integer, public, dimension(:), allocatable :: &
       nCellsHalo, &! number of owned+halo(n) cells in local domain
@@ -72,16 +69,6 @@ module li_mesh
    integer, public, dimension(:), pointer :: &
       nEdgesOnEdge, &! number of edges connected to each edge point
       nEdgesOnCell, & ! number of edges associated with each cell center
-!      minLevelCell, &! max ocean level at bottom of cell
-!      minLevelEdgeTop, &! max ocean level at top    of edge column
-!      minLevelEdgeBot, &! max ocean level at bottom of edge column
-!      minLevelVertexTop, &! max ocean level at top    of each vertex
-!      minLevelVertexBot, &! max ocean level at bottom of each vertex
-!      maxLevelCell, &! max ocean level at bottom of cell
-!      maxLevelEdgeTop, &! max ocean level at top    of edge column
-!      maxLevelEdgeBot, &! max ocean level at bottom of edge column
-!      maxLevelVertexTop, &! max ocean level at top    of each vertex
-!      maxLevelVertexBot, &! max ocean level at bottom of each vertex
       indexToCellID, &! global ID of each local cell
       indexToEdgeID, &! global ID of each local edge
       indexToVertexID    ! global ID of each local vertex
@@ -97,7 +84,6 @@ module li_mesh
       edgesOnVertex, & ! index of edges connected to each vertex
       edgeSignOnCell, &! sign of edge contributions to a cell
       edgeSignOnVertex ! sign of edge contributions to a vertex
-!      kiteIndexOnCell ! index of kite associated with each cell
 
    real(kind=RKIND), public, dimension(:), pointer :: &
       latCell, &! latitude  of cell centers
@@ -115,46 +101,29 @@ module li_mesh
       xVertex, &! Cartesian coord of vertex
       yVertex, &! Cartesian y coord of vertex
       zVertex, &! Cartesian z coord of vertex
-!      fEdge, &! Coriolus parameter at edge
-!      fVertex, &! Coriolus parameter at vertex
-!      fCell, &! Coriolus parameter at cell center
       dcEdge, &! length of edge = dist between cells across edge
       dvEdge, &! length of edge = dist between vertices along edge
       areaCell, &! area of each cell
       areaTriangle, &! area of each cell on dual grid
-!      bottomDepth, &! ocean bottom depth at each cell center
-!      refBottomDepth, &! ocean depth at bottom of cell for reference profile
-!      refBottomDepthTopOfCell, &! depth at top of cell for reference profile
-!      vertCoordMovementWeights, &! weights for distributing height perturb
-!      meshScalingDel2, &! mesh scaling factor for use in del2 diffusion
-!      meshScalingDel4, &! mesh scaling factor for use in del4 diffusion
       meshDensity, &! density of mesh
       angleEdge ! angle the edge normal makes with local east
-!      distanceToCoast ! distance to nearest coast cell 
 
    real(kind=RKIND), public, dimension(:), allocatable :: &
       invAreaCell   ! inverse of area of each cell
 
    ! Multiplicative masks and vectors for various conditions
    integer, public, dimension(:), allocatable :: &
-      boundaryEdge, &! mask for boundary edges    at each level
-      boundaryCell, &! mask for boundary cells    at each level
-      boundaryVertex ! mask for boundary vertices at each level
+      boundaryCell ! mask for boundary cells    at each level
 
    real(kind=RKIND), public, dimension(:, :), pointer :: &
       weightsOnEdge, &! weights on each edge
       kiteAreasOnVertex, &! real (vertexDegree nVertices)
-      edgeTangentVectors, &! tangent unit vector at edge
       edgeNormalVectors, &! normal  unit vector at edge
       localVerticalUnitVectors ! local unit vector iin vertical
 
    real(kind=RKIND), public, dimension(:, :, :), pointer :: &
       cellTangentPlane, &! two vectors defining tangent plane at cell center
       coeffs_reconstruct  ! coeffs for reconstructing vectors at cell centers
-
-   ! Derived mesh values needed
-   real(kind=RKIND), public, dimension(:, :), allocatable :: &
-      edgeAreaFractionOfCell
 
    !}}}
 
@@ -167,7 +136,6 @@ module li_mesh
 
    public :: &
       li_meshCreate, &
-      li_meshUpdateFields, &
       li_meshDestroy
    !}}}
 
@@ -288,8 +256,6 @@ contains
                                    vertexDegreeTmp)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', &
                                    nVertLevelsTmp)
-!      call mpas_pool_get_dimension(meshPool, 'nVertLevelsP1', &
-!                                   nVertLevelsP1Tmp)
       call mpas_pool_get_dimension(meshPool, 'nCellsArray', &
                                    nCellsArrayTmp)
       call mpas_pool_get_dimension(meshPool, 'nEdgesArray', &
@@ -304,7 +270,6 @@ contains
       maxEdges2 = maxEdges2Tmp
       vertexDegree = vertexDegreeTmp
       nVertLevels = nVertLevelsTmp
-!      nVertLevelsP1 = nVertLevelsP1Tmp
 
       ! convert previous index limits into new halo definitions
       nCells = nCellsTmp
@@ -337,26 +302,6 @@ contains
                                nEdgesOnEdge)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', &
                                nEdgesOnCell)
-!      call mpas_pool_get_array(meshPool, 'minLevelCell', &
-!                               minLevelCell)
-!      call mpas_pool_get_array(meshPool, 'minLevelEdgeTop', &
-!                               minLevelEdgeTop)
-!      call mpas_pool_get_array(meshPool, 'minLevelEdgeBot', &
-!                               minLevelEdgeBot)
-!      call mpas_pool_get_array(meshPool, 'minLevelVertexTop', &
-!                               minLevelVertexTop)
-!      call mpas_pool_get_array(meshPool, 'minLevelVertexBot', &
-!                               minLevelVertexBot)
-!      call mpas_pool_get_array(meshPool, 'maxLevelCell', &
-!                               maxLevelCell)
-!      call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop', &
-!                               maxLevelEdgeTop)
-!      call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot', &
-!                            maxLevelEdgeBot)
-!      call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
-!                               maxLevelVertexTop)
-!      call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
-!                               maxLevelVertexBot)
       call mpas_pool_get_array(meshPool, 'indexToCellID', &
                                indexToCellID)
       call mpas_pool_get_array(meshPool, 'indexToEdgeID', &
@@ -379,8 +324,6 @@ contains
                                cellsOnVertex)
       call mpas_pool_get_array(meshPool, 'edgesOnVertex', &
                                edgesOnVertex)
-!      call mpas_pool_get_array(meshPool, 'kiteIndexOnCell', &
-!                               kiteIndexOnCell)
 
       ! now set a number of physics and numerical properties of mesh
       call mpas_pool_get_array(meshPool, 'latCell', &
@@ -413,12 +356,6 @@ contains
                                yVertex)
       call mpas_pool_get_array(meshPool, 'zVertex', &
                                zVertex)
-!      call mpas_pool_get_array(meshPool, 'fEdge', &
-!                               fEdge)
-!      call mpas_pool_get_array(meshPool, 'fVertex', &
-!                               fVertex)
-!      call mpas_pool_get_array(meshPool, 'fCell', &
-!                               fCell)
       call mpas_pool_get_array(meshPool, 'dcEdge', &
                                dcEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', &
@@ -429,31 +366,14 @@ contains
                                areaTriangle)
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
-!      call mpas_pool_get_array(meshPool, 'bottomDepth', &
-!                               bottomDepth)
-!      call mpas_pool_get_array(meshPool, 'refBottomDepth', &
-!                               refBottomDepth)
-!      call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell', &
-!                               refBottomDepthTopOfCell)
-!      call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights', &
-!                               vertCoordMovementWeights)
-!      call mpas_pool_get_array(meshPool, 'meshScalingDel2', &
-!                               meshScalingDel2)
-!      call mpas_pool_get_array(meshPool, 'meshScalingDel4', &
-!                               meshScalingDel4)
       call mpas_pool_get_array(meshPool, 'meshDensity', &
                                meshDensity)
       call mpas_pool_get_array(meshPool, 'angleEdge', &
                                angleEdge)
-!      call mpas_pool_get_array(meshPool, 'distanceToCoast', &
-!                               distanceToCoast)
-
       call mpas_pool_get_array(meshPool, 'weightsOnEdge', &
                                weightsOnEdge)
       call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex', &
                                kiteAreasOnVertex)
-      call mpas_pool_get_array(meshPool, 'edgeTangentVectors', &
-                               edgeTangentVectors)
       call mpas_pool_get_array(meshPool, 'edgeNormalVectors', &
                                edgeNormalVectors)
       call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors', &
@@ -472,9 +392,7 @@ contains
                                edgeSignOnVertex)
 
       allocate ( &
-            boundaryEdge(nEdges+1), &
             boundaryCell(nCells+1), &
-            boundaryVertex(nVertices+1), &
             invAreaCell(nCells+1))
 
       !-----------------------------------------------------------------
@@ -484,53 +402,8 @@ contains
 
       ! Start by initializing vertical mesh, min/max cells and
       ! sign/index fields
-      !call meshVertCoordInit(domain)
-      call meshMinMaxLevel()
       call meshSignIndexFields()
 
-      ! Compute max mesh density and mesh scaling
-!      if (config_maxMeshDensity < 0.0_RKIND) then
-!         maxDensityLocal = maxval(meshDensity)
-!         call mpas_dmpar_max_real(domain%dminfo, maxDensityLocal, &
-!                                                 maxDensityGlobal)
-!         config_maxMeshDensity = maxDensityGlobal 
-!      endif
-!      call meshScaling()
-   
-      ! Routine calls above initialized the real mask arrays
-      ! so convert the meshPool integer pointers here
-!      do n = 1, nCells+1
-!      do k = 1, nVertLevels
-!         boundaryCellTmp(k,n) = nint(boundaryCell(k,n))
-!      end do
-!      end do
-!
-!      do n = 1, nCells+1
-!      do k = 1, maxEdges
-!         edgeSignOnCellTmp(k, n) = nint(edgeSignOnCell(k,n))
-!      end do
-!      end do
-!
-!      do n = 1, nEdges+1
-!      do k = 1, nVertLevels
-!         boundaryEdgeTmp(k, n) = nint(boundaryEdge(k,n))
-!      end do
-!      end do
-!
-!      do n = 1, nVertices+1
-!      do k = 1, nVertLevels
-!         boundaryVertexTmp(k, n) = nint(boundaryVertex(k,n))
-!      end do
-!      end do
-!
-!      do n = 1, nVertices+1
-!      do k = 1, vertexDegree
-!         edgeSignOnVertexTmp(k,n) = nint(edgeSignOnVertex(k,n))
-!      end do
-!      end do
-
-      ! Compute area weighting for some interpolation
-      call meshAreaWeights()
       areaCell(nCells+1) = -1.0e34_RKIND
 
       ! Compute the inverse of areaCell
@@ -538,96 +411,6 @@ contains
          invAreaCell(n) = 1.0_RKIND / areaCell(n)
       end do
       invAreaCell(nCells+1) = 0.0_RKIND
-
-      !-----------------------------------------------------------------
-      ! Copy mesh data to accelerator if needed.
-      !-----------------------------------------------------------------
-
-         !$acc enter data copyin( &
-         !$acc                   onSphere,                 &
-         !$acc                   sphereRadius,             &
-         !$acc                   nCells,                &
-         !$acc                   nEdges,                &
-         !$acc                   nVertices,             &
-         !$acc                   nCellsSolve,              &
-         !$acc                   nEdgesSolve,              &
-         !$acc                   nVerticesSolve,           &
-         !$acc                   maxEdges,                 &
-         !$acc                   maxEdges2,                &
-         !$acc                   vertexDegree,             &
-         !$acc                   nVertLevels,              &
-         !$acc                   nVertLevelsP1,            &
-         !$acc                   nEdgesHalo,               &
-         !$acc                   nCellsHalo,               &
-         !$acc                   nVerticesHalo,            &
-         !$acc                   nEdgesOnEdge,             &
-         !$acc                   nEdgesOnCell,             &
-         !$acc                   minLevelCell,             &
-         !$acc                   minLevelEdgeTop,          &
-         !$acc                   minLevelEdgeBot,          &
-         !$acc                   minLevelVertexTop,        &
-         !$acc                   minLevelVertexBot,        &
-         !$acc                   maxLevelCell,             &
-         !$acc                   maxLevelEdgeTop,          &
-         !$acc                   maxLevelEdgeBot,          &
-         !$acc                   maxLevelVertexTop,        &
-         !$acc                   maxLevelVertexBot,        &
-         !$acc                   indexToCellID,            &
-         !$acc                   indexToEdgeID,            &
-         !$acc                   indexToVertexID,          &
-         !$acc                   edgesOnEdge,              &
-         !$acc                   cellsOnEdge,              &
-         !$acc                   verticesOnEdge,           &
-         !$acc                   cellsOnCell,              &
-         !$acc                   edgesOnCell,              &
-         !$acc                   verticesOnCell,           &
-         !$acc                   cellsOnVertex,            &
-         !$acc                   edgesOnVertex,            &
-         !$acc                   kiteIndexOnCell,          &
-         !$acc                   latCell,                  &
-         !$acc                   lonCell,                  &
-         !$acc                   xCell,                    &
-         !$acc                   yCell,                    &
-         !$acc                   zCell,                    &
-         !$acc                   latEdge,                  &
-         !$acc                   lonEdge,                  &
-         !$acc                   xEdge,                    &
-         !$acc                   yEdge,                    &
-         !$acc                   zEdge,                    &
-         !$acc                   latVertex,                &
-         !$acc                   lonVertex,                &
-         !$acc                   xVertex,                  &
-         !$acc                   yVertex,                  &
-         !$acc                   zVertex,                  &
-         !$acc                   fEdge,                    &
-         !$acc                   fVertex,                  &
-         !$acc                   fCell,                    &
-         !$acc                   dcEdge,                   &
-         !$acc                   dvEdge,                   &
-         !$acc                   areaCell,                 &
-         !$acc                   invAreaCell,              &
-         !$acc                   areaTriangle,             &
-         !$acc                   bottomDepth,              &
-         !$acc                   refBottomDepth,           &
-         !$acc                   refBottomDepthTopOfCell,  &
-         !$acc                   vertCoordMovementWeights, &
-         !$acc                   meshScalingDel2,          &
-         !$acc                   meshScalingDel4,          &
-         !$acc                   meshDensity,              &
-         !$acc                   angleEdge,                &
-         !$acc                   distanceToCoast,          &
-         !$acc                   boundaryEdge,             &
-         !$acc                   boundaryCell,             &
-         !$acc                   boundaryVertex,           &
-         !$acc                   edgeSignOnCell,           &
-         !$acc                   edgeSignOnVertex,         &
-         !$acc                   weightsOnEdge,            &
-         !$acc                   kiteAreasOnVertex,        &
-         !$acc                   edgeTangentVectors,       &
-         !$acc                   edgeNormalVectors,        &
-         !$acc                   localVerticalUnitVectors, &
-         !$acc                   cellTangentPlane,         &
-         !$acc                   coeffs_reconstruct)
 
 !-------------------------------------------------------------------------------
 
@@ -668,94 +451,6 @@ contains
 
       err = 0
 
-      ! First remove data from the device. Must remove components first,
-      ! then remove the mesh type itself.
-
-      !$acc exit data delete(onSphere,          &
-      !$acc                  sphereRadius,      &
-      !$acc                  nCells,         &
-      !$acc                  nEdges,         &
-      !$acc                  nVertices,      &
-      !$acc                  nCellsSolve,       &
-      !$acc                  nEdgesSolve,       &
-      !$acc                  nVerticesSolve,    &
-      !$acc                  maxEdges,          &
-      !$acc                  maxEdges2,         &
-      !$acc                  vertexDegree,      &
-      !$acc                  nVertLevels,       &
-      !$acc                  nVertLevelsP1,     &
-      !$acc                  nEdgesHalo,        &
-      !$acc                  nCellsHalo,        &
-      !$acc                  nVerticesHalo,     &
-      !$acc                  nEdgesOnEdge,      &
-      !$acc                  nEdgesOnCell,      &
-      !$acc                  minLevelCell,      &
-      !$acc                  minLevelEdgeTop,   &
-      !$acc                  minLevelEdgeBot,   &
-      !$acc                  minLevelVertexTop, &
-      !$acc                  minLevelVertexBot, &
-      !$acc                  maxLevelCell,      &
-      !$acc                  maxLevelEdgeTop,   &
-      !$acc                  maxLevelEdgeBot,   &
-      !$acc                  maxLevelVertexTop, &
-      !$acc                  maxLevelVertexBot, &
-      !$acc                  indexToCellID,     &
-      !$acc                  indexToEdgeID,     &
-      !$acc                  indexToVertexID,   &
-      !$acc                  edgesOnEdge,       &
-      !$acc                  cellsOnEdge,       &
-      !$acc                  verticesOnEdge,    &
-      !$acc                  cellsOnCell,       &
-      !$acc                  edgesOnCell,       &
-      !$acc                  verticesOnCell,    &
-      !$acc                  cellsOnVertex,     &
-      !$acc                  edgesOnVertex,     &
-      !$acc                  kiteIndexOnCell,   &
-      !$acc                  latCell,           &
-      !$acc                  lonCell,           &
-      !$acc                  xCell,             &
-      !$acc                  yCell,             &
-      !$acc                  zCell,             &
-      !$acc                  latEdge,           &
-      !$acc                  lonEdge,           &
-      !$acc                  xEdge,             &
-      !$acc                  yEdge,             &
-      !$acc                  zEdge,             &
-      !$acc                  latVertex,         &
-      !$acc                  lonVertex,         &
-      !$acc                  xVertex,           &
-      !$acc                  yVertex,           &
-      !$acc                  zVertex,           &
-      !$acc                  fEdge,             &
-      !$acc                  fVertex,           &
-      !$acc                  fCell,             &
-      !$acc                  dcEdge,            &
-      !$acc                  dvEdge,            &
-      !$acc                  areaCell,          &
-      !$acc                  invAreaCell,       &
-      !$acc                  areaTriangle,      &
-      !$acc                  bottomDepth,       &
-      !$acc                  refBottomDepth,    &
-      !$acc                  refBottomDepthTopOfCell, &
-      !$acc                  vertCoordMovementWeights, &
-      !$acc                  meshScalingDel2,   &
-      !$acc                  meshScalingDel4,   &
-      !$acc                  meshDensity,       &
-      !$acc                  angleEdge,         &
-      !$acc                  distanceToCoast,   &
-      !$acc                  boundaryEdge,      &
-      !$acc                  boundaryCell,      &
-      !$acc                  boundaryVertex,    &
-      !$acc                  edgeSignOnCell,    &
-      !$acc                  edgeSignOnVertex,  &
-      !$acc                  weightsOnEdge,     &
-      !$acc                  kiteAreasOnVertex, &
-      !$acc                  edgeTangentVectors,&
-      !$acc                  edgeNormalVectors, &
-      !$acc                  localVerticalUnitVectors, &
-      !$acc                  cellTangentPlane,  &
-      !$acc                  coeffs_reconstruct)
-
       ! Reset all scalars to zero
       onSphere  = .false.
       sphereRadius = 0.0_RKIND
@@ -769,7 +464,6 @@ contains
       maxEdges2 = 0
       vertexDegree = 0
       nVertLevels = 0
-!      nVertLevelsP1 = 0
 
       ! Now nullify all pointers to invalidate fields
       ! If this becomes the only mesh structure and mesh pool is eliminated,
@@ -777,16 +471,6 @@ contains
 
       nullify (nEdgesOnEdge, &
                nEdgesOnCell, &
-               !minLevelCell, &
-               !minLevelEdgeTop, &
-               !minLevelEdgeBot, &
-               !minLevelVertexTop, &
-               !minLevelVertexBot, &
-               !maxLevelCell, &
-               !maxLevelEdgeTop, &
-               !maxLevelEdgeBot, &
-               !maxLevelVertexTop, &
-               !maxLevelVertexBot, &
                indexToCellID, &
                indexToEdgeID, &
                indexToVertexID, &
@@ -798,7 +482,6 @@ contains
                verticesOnCell, &
                cellsOnVertex, &
                edgesOnVertex, &
-               !kiteIndexOnCell, &
                latCell, &
                lonCell, &
                xCell, &
@@ -814,25 +497,14 @@ contains
                xVertex, &
                yVertex, &
                zVertex, &
-               !fEdge, &
-               !fVertex, &
-               !fCell, &
                dcEdge, &
                dvEdge, &
                areaCell, &
                areaTriangle, &
-               !bottomDepth, &
-               !refBottomDepth, &
-               !refBottomDepthTopOfCell, &
-               !vertCoordMovementWeights, &
-               !meshScalingDel2, &
-               !meshScalingDel4, &
                meshDensity, &
                angleEdge, &
-               !distanceToCoast, &
                weightsOnEdge, &
                kiteAreasOnVertex, &
-               edgeTangentVectors, &
                edgeNormalVectors, &
                localVerticalUnitVectors, &
                cellTangentPlane, &
@@ -840,500 +512,15 @@ contains
                edgeSignOnVertex, &
                coeffs_reconstruct)
 
-#ifdef MPAS_OPENACC
-      !$acc exit data delete(edgeAreaFractionOfCell)
-#endif
       deallocate (nEdgesHalo, &
                   nCellsHalo, &
                   nVerticesHalo, &
-                  boundaryEdge, &
                   boundaryCell, &
-                  boundaryVertex, &
-                  edgeAreaFractionOfCell, &
                   invAreaCell)
 
 !-------------------------------------------------------------------------------
 
    end subroutine li_meshDestroy !}}}
-
-!*******************************************************************************
-!
-!  li_meshUpdateFields
-!
-!> \brief Updates fields on an accelerator device
-!> \author Rob Aulwes and Phil Jones
-!> \date   14 Jan 2020
-!> \details
-!> Many mesh fields are computed or input later in the initialization
-!> phase after the meshCreate call. This routine updates these fields
-!> on the device. The routine is not needed if the original mesh pool is
-!> eliminated and this mesh becomes the only mesh structure and can be
-!> updated directly.
-!
-!-------------------------------------------------------------------------------
-
-   subroutine li_meshUpdateFields(domain) !{{{
-
-      ! Input arguments
-
-      type(domain_type) :: &
-         domain                    !< [in] MPAS type to describe domain
-
-      ! Local variables
-
-      type(block_type), pointer :: &
-         block                    ! variables in current subblock
-
-      type(mpas_pool_type), pointer :: &
-         meshPool                 ! mesh variables in MPAS pool structure
-
-      ! temporary pointers for converting masks
-      integer k, n          ! loop indices
-      integer, dimension(:, :), pointer :: &
-         edgeSignOnCellTmp, &
-         edgeSignOnVertexTmp
-
-      !***
-      !*** end of preamble, begin code
-      !***
-
-      ! already check during create that there should only be one block
-      block => domain%blocklist
-
-      ! retrieve the mpas mesh pool
-      call mpas_pool_get_subpool(block%structs, 'mesh', meshPool)
-
-      ! Mesh dimensions should not have changed so no updates
-
-      ! Because these fields are pointers into meshPool, they do not need
-      ! to be updated - they capture the updates automatically.
-      !call mpas_pool_get_array(meshPool, 'nEdgesOnEdge',      &
-      !                                    nEdgesOnEdge)
-      !call mpas_pool_get_array(meshPool, 'nEdgesOnCell',      &
-      !                                    nEdgesOnCell)
-      !call mpas_pool_get_array(meshPool, 'maxLevelCell',      &
-      !                                    maxLevelCell)
-      !call mpas_pool_get_array(meshPool, 'maxLevelEdgeTop',   &
-      !                                    maxLevelEdgeTop)
-      !call mpas_pool_get_array(meshPool, 'maxLevelEdgeBot',   &
-      !                                    maxLevelEdgeBot)
-      !call mpas_pool_get_array(meshPool, 'maxLevelVertexTop', &
-      !                                    maxLevelVertexTop)
-      !call mpas_pool_get_array(meshPool, 'maxLevelVertexBot', &
-      !                                    maxLevelVertexBot)
-      !call mpas_pool_get_array(meshPool, 'indexToCellID',     &
-      !                                    indexToCellID)
-      !call mpas_pool_get_array(meshPool, 'indexToEdgeID',     &
-      !                                    indexToEdgeID)
-      !call mpas_pool_get_array(meshPool, 'indexToVertexID',   &
-      !                                    indexToVertexID)
-      !call mpas_pool_get_array(meshPool, 'edgesOnEdge',       &
-      !                                    edgesOnEdge)
-      !call mpas_pool_get_array(meshPool, 'cellsOnEdge',       &
-      !                                    cellsOnEdge)
-      !call mpas_pool_get_array(meshPool, 'verticesOnEdge',    &
-      !                                    verticesOnEdge)
-      !call mpas_pool_get_array(meshPool, 'cellsOnCell',       &
-      !                                    cellsOnCell)
-      !call mpas_pool_get_array(meshPool, 'edgesOnCell',       &
-      !                                    edgesOnCell)
-      !call mpas_pool_get_array(meshPool, 'verticesOnCell',    &
-      !                                    verticesOnCell)
-      !call mpas_pool_get_array(meshPool, 'cellsOnVertex',     &
-      !                                    cellsOnVertex)
-      !call mpas_pool_get_array(meshPool, 'edgesOnVertex',     &
-      !                                    edgesOnVertex)
-      !call mpas_pool_get_array(meshPool, 'kiteIndexOnCell',   &
-      !                                    kiteIndexOnCell)
-
-      ! these are also pointers that do not require updating
-      ! now set a number of physics and numerical properties of mesh
-      !call mpas_pool_get_array(meshPool, 'latCell',           &
-      !                                    latCell)
-      !call mpas_pool_get_array(meshPool, 'lonCell',           &
-      !                                    lonCell)
-      !call mpas_pool_get_array(meshPool, 'xCell',             &
-      !                                    xCell)
-      !call mpas_pool_get_array(meshPool, 'yCell',             &
-      !                                    yCell)
-      !call mpas_pool_get_array(meshPool, 'zCell',             &
-      !                                    zCell)
-      !call mpas_pool_get_array(meshPool, 'latEdge',           &
-      !                                    latEdge)
-      !call mpas_pool_get_array(meshPool, 'lonEdge',           &
-      !                                    lonEdge)
-      !call mpas_pool_get_array(meshPool, 'xEdge',             &
-      !                                    xEdge)
-      !call mpas_pool_get_array(meshPool, 'yEdge',             &
-      !                                    yEdge)
-      !call mpas_pool_get_array(meshPool, 'zEdge',             &
-      !                                    zEdge)
-      !call mpas_pool_get_array(meshPool, 'latVertex',         &
-      !                                    latVertex)
-      !call mpas_pool_get_array(meshPool, 'lonVertex',         &
-      !                                    lonVertex)
-      !call mpas_pool_get_array(meshPool, 'xVertex',           &
-      !                                    xVertex)
-      !call mpas_pool_get_array(meshPool, 'yVertex',           &
-      !                                    yVertex)
-      !call mpas_pool_get_array(meshPool, 'zVertex',           &
-      !                                    zVertex)
-      !call mpas_pool_get_array(meshPool, 'fEdge',             &
-      !                                    fEdge)
-      !call mpas_pool_get_array(meshPool, 'fVertex',           &
-      !                                    fVertex)
-      !call mpas_pool_get_array(meshPool, 'fCell',             &
-      !                                    fCell)
-      !call mpas_pool_get_array(meshPool, 'dcEdge',            &
-      !                                    dcEdge)
-      !call mpas_pool_get_array(meshPool, 'dvEdge',            &
-      !                                    dvEdge)
-      !call mpas_pool_get_array(meshPool, 'areaCell',          &
-      !                                    areaCell)
-      !call mpas_pool_get_array(meshPool, 'areaTriangle',      &
-      !                                    areaTriangle)
-      !call mpas_pool_get_array(meshPool, 'weightsOnEdge',     &
-      !                                    weightsOnEdge)
-      !call mpas_pool_get_array(meshPool, 'bottomDepth',       &
-      !                                    bottomDepth)
-      !call mpas_pool_get_array(meshPool, 'refBottomDepth',    &
-      !                                    refBottomDepth)
-      !call mpas_pool_get_array(meshPool, 'refBottomDepthTopOfCell',   &
-      !                                    refBottomDepthTopOfCell)
-      !call mpas_pool_get_array(meshPool, 'vertCoordMovementWeights',  &
-      !                                    vertCoordMovementWeights)
-      !call mpas_pool_get_array(meshPool, 'meshScalingDel2',   &
-      !                                    meshScalingDel2)
-      !call mpas_pool_get_array(meshPool, 'meshScalingDel4',   &
-      !                                    meshScalingDel4)
-      !call mpas_pool_get_array(meshPool, 'meshDensity',       &
-      !                                    meshDensity)
-      !call mpas_pool_get_array(meshPool, 'angleEdge',         &
-      !                                    angleEdge)
-      !call mpas_pool_get_array(meshPool, 'distanceToCoast',   &
-      !                                    distanceToCoast)
-      !
-      !call mpas_pool_get_array(meshPool, 'weightsOnEdge',             &
-      !                                    weightsOnEdge)
-      !call mpas_pool_get_array(meshPool, 'kiteAreasOnVertex',         &
-      !                                    kiteAreasOnVertex)
-      !call mpas_pool_get_array(meshPool, 'edgeTangentVectors',        &
-      !                                    edgeTangentVectors)
-      !call mpas_pool_get_array(meshPool, 'edgeNormalVectors',         &
-      !                                    edgeNormalVectors)
-      !call mpas_pool_get_array(meshPool, 'localVerticalUnitVectors',  &
-      !                                    localVerticalUnitVectors)
-      !call mpas_pool_get_array(meshPool, 'cellTangentPlane',          &
-      !                                    cellTangentPlane)
-      !call mpas_pool_get_array(meshPool, 'coeffs_reconstruct',        &
-      !                                    coeffs_reconstruct)
-
-      ! For masks, we converted to real masks, so need to recompute for
-      ! updated values. Probably only the edgeSign masks need updating, but
-      ! do them all to be sure.
-      call mpas_pool_get_array(meshPool, 'edgeSignOnCell', &
-                               edgeSignOnCell)
-      call mpas_pool_get_array(meshPool, 'edgeSignOnVertex', &
-                               edgeSignOnVertex)
-
-!      do n = 1, nCells+1
-!      do k = 1, nVertLevels
-!         boundaryCell(k, n) = real(boundaryCellTmp(k, n), RKIND)
-!      end do
-!      end do
-!
-!      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
-!      ! pointer needs to be udpated
-!      do n = 1, nCells+1
-!      do k = 1, maxEdges
-!         edgeSignOnCellTmp(k, n) = int(edgeSignOnCell(k, n))
-!      end do
-!      end do
-!
-!      do n = 1, nEdges+1
-!      do k = 1, nVertLevels
-!         boundaryEdge(k, n) = real(boundaryEdgeTmp(k, n), RKIND)
-!      end do
-!      end do
-!
-!      do n = 1, nVertices+1
-!      do k = 1, nVertLevels
-!         boundaryVertex(k, n) = real(boundaryVertexTmp(k, n), RKIND)
-!      end do
-!      end do
-!
-!      ! Allocatable array was updated in ocn_init_routines_setup_sign_and_index_fields.  Now the
-!      ! pointer needs to be udpated
-!      do n = 1, nVertices+1
-!      do k = 1, vertexDegree
-!         edgeSignOnVertexTmp(k, n) = &
-!            int(edgeSignOnVertex(k, n))
-!      end do
-!      end do
-
-      ! Go ahead and update all fields on device to be safe.
-      ! NOTE: if we end up computing some fields on the device during
-      !       init, the update must go the opposite direction (update host)
-
-      !$acc update device(onSphere,                 &
-      !$acc               sphereRadius,             &
-      !$acc               nCells,                &
-      !$acc               nEdges,                &
-      !$acc               nVertices,             &
-      !$acc               nCellsSolve,              &
-      !$acc               nEdgesSolve,              &
-      !$acc               nVerticesSolve,           &
-      !$acc               maxEdges,                 &
-      !$acc               maxEdges2,                &
-      !$acc               vertexDegree,             &
-      !$acc               nVertLevels,              &
-      !$acc               nVertLevelsP1,            &
-      !$acc               nEdgesHalo,               &
-      !$acc               nCellsHalo,               &
-      !$acc               nVerticesHalo,            &
-      !$acc               nEdgesOnEdge,             &
-      !$acc               nEdgesOnCell,             &
-      !$acc               minLevelCell,             &
-      !$acc               minLevelEdgeTop,          &
-      !$acc               minLevelEdgeBot,          &
-      !$acc               minLevelVertexTop,        &
-      !$acc               minLevelVertexBot,        &
-      !$acc               maxLevelCell,             &
-      !$acc               maxLevelEdgeTop,          &
-      !$acc               maxLevelEdgeBot,          &
-      !$acc               maxLevelVertexTop,        &
-      !$acc               maxLevelVertexBot,        &
-      !$acc               indexToCellID,            &
-      !$acc               indexToEdgeID,            &
-      !$acc               indexToVertexID,          &
-      !$acc               edgesOnEdge,              &
-      !$acc               cellsOnEdge,              &
-      !$acc               verticesOnEdge,           &
-      !$acc               cellsOnCell,              &
-      !$acc               edgesOnCell,              &
-      !$acc               verticesOnCell,           &
-      !$acc               cellsOnVertex,            &
-      !$acc               edgesOnVertex,            &
-      !$acc               kiteIndexOnCell,          &
-      !$acc               latCell,                  &
-      !$acc               lonCell,                  &
-      !$acc               xCell,                    &
-      !$acc               yCell,                    &
-      !$acc               zCell,                    &
-      !$acc               latEdge,                  &
-      !$acc               lonEdge,                  &
-      !$acc               xEdge,                    &
-      !$acc               yEdge,                    &
-      !$acc               zEdge,                    &
-      !$acc               latVertex,                &
-      !$acc               lonVertex,                &
-      !$acc               xVertex,                  &
-      !$acc               yVertex,                  &
-      !$acc               zVertex,                  &
-      !$acc               fEdge,                    &
-      !$acc               fVertex,                  &
-      !$acc               fCell,                    &
-      !$acc               dcEdge,                   &
-      !$acc               dvEdge,                   &
-      !$acc               areaCell,                 &
-      !$acc               invAreaCell,              &
-      !$acc               areaTriangle,             &
-      !$acc               bottomDepth,              &
-      !$acc               refBottomDepth,           &
-      !$acc               refBottomDepthTopOfCell,  &
-      !$acc               vertCoordMovementWeights, &
-      !$acc               meshScalingDel2,          &
-      !$acc               meshScalingDel4,          &
-      !$acc               meshDensity,              &
-      !$acc               angleEdge,                &
-      !$acc               distanceToCoast,          &
-      !$acc               boundaryEdge,             &
-      !$acc               boundaryCell,             &
-      !$acc               boundaryVertex,           &
-      !$acc               edgeSignOnCell,           &
-      !$acc               edgeSignOnVertex,         &
-      !$acc               weightsOnEdge,            &
-      !$acc               kiteAreasOnVertex,        &
-      !$acc               edgeTangentVectors,       &
-      !$acc               edgeNormalVectors,        &
-      !$acc               localVerticalUnitVectors, &
-      !$acc               cellTangentPlane,         &
-      !$acc               coeffs_reconstruct)
-
-!-------------------------------------------------------------------------------
-
-   end subroutine li_meshUpdateFields !}}}
-
-!***********************************************************************
-!
-!  routine ocn_MeshMinMaxLevel
-!
-!> \brief  initialize max level and boundary mask variables
-!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date   September 2011
-!> \details
-!>  This routine initializes max level and boundary mask variables
-!
-!-----------------------------------------------------------------------
-
-   subroutine meshMinMaxLevel()!{{{
-
-      !-----------------------------------------------------------------
-      ! local variables
-      !-----------------------------------------------------------------
-
-      integer :: &
-         iCell, iEdge, iVertex, &! loop indices for cells,edges,vertices
-         i, k                    ! loop indices for neighbors, vertical
-
-      ! End preamble
-      !-------------
-      ! Begin code
-
-      ! minLevelEdgeTop is the minimum (shallowest) of surrounding cells
-      ! if the water column is dry, set minLevelCell outside of bounds
-      ! to prevent dry cells from determining minimum
-      !do iCell = 1, nCells+1
-      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell)=nVertLevels+1 
-      !end do
-      !do iEdge = 1, nEdges
-      !   minLevelEdgeTop(iEdge) = &
-      !      min( minLevelCell(cellsOnEdge(1,iEdge)), &
-      !           minLevelCell(cellsOnEdge(2,iEdge)) )
-      !end do
-      !minLevelEdgeTop(nEdges+1) = 0
-
-      !! minLevelEdgeBot is the maximum (deepest) of surrounding cells
-      !! prevent dry cells from determining maximum
-      !do iCell = 1, nCells+1
-      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1 
-      !end do
-      !do iEdge = 1, nEdges
-      !   minLevelEdgeBot(iEdge) = &
-      !      max( minLevelCell(cellsOnEdge(1,iEdge)), &
-      !           minLevelCell(cellsOnEdge(2,iEdge)) )
-      !end do
-      !minLevelEdgeBot(nEdges+1) = 0
-
-      !! minLevelVertexBot is the maximum (deepest) of surrounding cells
-      !do iVertex = 1,nVertices
-      !   minLevelVertexBot(iVertex) = &
-      !        minLevelCell(cellsOnVertex(1,iVertex))
-      !   do i = 2, vertexDegree
-      !      minLevelVertexBot(iVertex) = &
-      !         max( minLevelVertexBot(iVertex), &
-      !              minLevelCell(cellsOnVertex(i,iVertex)))
-      !   end do
-      !end do
-      !minLevelVertexBot(nVertices+1) = 0
-
-      !! minLevelVertexTop is the minimum (shallowest) of surrounding cells
-      !! if the water column is dry, set minLevelCell outside of bounds
-      !! to prevent dry cells from determining minimum
-      !do iCell = 1, nCells+1
-      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = nVertLevels+1 
-      !end do
-      !do iVertex = 1,nVertices
-      !   minLevelVertexTop(iVertex) = minLevelCell(cellsOnVertex(1,iVertex))
-      !   do i = 2, vertexDegree
-      !      minLevelVertexTop(iVertex) = &
-      !         min( minLevelVertexTop(iVertex), &
-      !              minLevelCell(cellsOnVertex(i,iVertex)))
-      !   end do
-      !end do
-      !minLevelVertexTop(nVertices+1) = 0
-
-      !! if the water column is dry, set minLevelCell = 1
-      !do iCell = 1, nCells+1
-      !   if (maxLevelCell(iCell) == 0) minLevelCell(iCell) = 1
-      !end do
-      !
-      !! maxLevelEdgeTop is the minimum (shallowest) of surrounding cells
-      !do iEdge = 1, nEdges
-      !   maxLevelEdgeTop(iEdge) = &
-      !      min( maxLevelCell(cellsOnEdge(1,iEdge)), &
-      !           maxLevelCell(cellsOnEdge(2,iEdge)) )
-      !end do
-      !maxLevelEdgeTop(nEdges+1) = 0
-
-      !! maxLevelEdgeBot is the maximum (deepest) of surrounding cells
-      !do iEdge = 1, nEdges
-      !   maxLevelEdgeBot(iEdge) = &
-      !      max( maxLevelCell(cellsOnEdge(1,iEdge)), &
-      !           maxLevelCell(cellsOnEdge(2,iEdge)) )
-      !end do
-      !maxLevelEdgeBot(nEdges+1) = 0
-
-      !! maxLevelVertexBot is the maximum (deepest) of surrounding cells
-      !do iVertex = 1,nVertices
-      !   maxLevelVertexBot(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
-      !   do i = 2, vertexDegree
-      !      maxLevelVertexBot(iVertex) = &
-      !         max( maxLevelVertexBot(iVertex), &
-      !              maxLevelCell(cellsOnVertex(i,iVertex)))
-      !   end do
-      !end do
-      !maxLevelVertexBot(nVertices+1) = 0
-
-      !! maxLevelVertexTop is the minimum (shallowest) of surrounding cells
-      !do iVertex = 1,nVertices
-      !   maxLevelVertexTop(iVertex) = maxLevelCell(cellsOnVertex(1,iVertex))
-      !   do i = 2, vertexDegree
-      !      maxLevelVertexTop(iVertex) = &
-      !         min( maxLevelVertexTop(iVertex), &
-      !              maxLevelCell(cellsOnVertex(i,iVertex)))
-      !   end do
-      !end do
-      !maxLevelVertexTop(nVertices+1) = 0
-
-      ! set boundary edge
-      boundaryEdge(1:nEdges+1)=0.0_RKIND
-      !edgeMask(1:nEdges+1)=0
-
-      ! TODO: Replace this loop over levels with MALI levels
-      !do iEdge = 1, nEdges
-      !do k= minLevelEdgeBot(iEdge),maxLevelEdgeTop(iEdge)
-      !   boundaryEdge(k,iEdge)=0.0_RKIND
-      !end do
-      !end do
-
-      ! Find cells and vertices that have an edge on the boundary
-      boundaryCell(1:nCells+1) = 0.0_RKIND
-      boundaryVertex(1:nVertices+1) = 0.0_RKIND
-
-      do iEdge = 1, nEdges
-      do k = 1, nVertLevels
-         if (boundaryEdge(iEdge) == 1) then
-            boundaryCell(cellsOnEdge(1,iEdge)) = 1.0_RKIND
-            boundaryCell(cellsOnEdge(2,iEdge)) = 1.0_RKIND
-            boundaryVertex(verticesOnEdge(1,iEdge)) = 1.0_RKIND
-            boundaryVertex(verticesOnEdge(2,iEdge)) = 1.0_RKIND
-         endif
-      end do
-      end do
-
-      !do iCell = 1, nCells
-      !do k = 1, nVertLevels
-      !   if ( minLevelCell(iCell) <= k .and. &
-      !        maxLevelCell(iCell) >= k ) then
-      !   end if
-      !end do
-      !end do
-
-      !do iVertex = 1, nVertices
-      !do k = 1, nVertLevels
-      !   if ( minLevelVertexTop(iVertex) <= k .and. &
-      !        maxLevelVertexBot(iVertex) >= k ) then
-      !   end if
-      !end do
-      !end do
-
-      ! Note: We do not update halos on maxLevel* variables.  We want
-      ! the outside edge of a halo to be zero on each processor.
-
-   !--------------------------------------------------------------------
-
-   end subroutine meshMinMaxLevel !}}}
 
 !***********************************************************************
 !
@@ -1394,372 +581,6 @@ contains
    !--------------------------------------------------------------------
 
    end subroutine meshSignIndexFields !}}}
-
-!***********************************************************************
-!
-!  routine li_meshVertCoordInit
-!
-!> \brief  initialize vertical coordinate variables
-!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date   September 2011
-!> \details
-!>  This routine initializes vertical coordinate variables, including
-!>  zlevel-type variables and adjusted initial conditions for partial
-!>  bottom cells.
-!
-!-----------------------------------------------------------------------
-
-!   subroutine meshVertCoordInit(domain)!{{{
-!
-!      !-----------------------------------------------------------------
-!      ! Input/output variables
-!      !-----------------------------------------------------------------
-!
-!      type (domain_type), intent(inout) :: domain !< [inout] ocean state
-!
-!      !-----------------------------------------------------------------
-!      ! Local variables
-!      !-----------------------------------------------------------------
-!
-!      type (block_type), pointer :: block ! all ocn data in a block
-!
-!      type (mpas_pool_type), pointer :: &
-!         verticalMeshPool, &! vertical mesh data
-!         statePool,        &! ocean state (layer thickness)
-!         forcingPool        ! forcing data (land ice mask)
-!
-!      integer :: &
-!         iCell, k,         &! loop indices for cell, vertical loops
-!         kmin, kmax         ! min, max active levels in column
-!
-!      logical :: &
-!         consistentSSH,    &! flag if SSH consistent with depth
-!         landIceFlag,      &! flag if land ice mask exists
-!         checkSSH           ! flag for checking SSH in cell column
-!
-!      real (kind=RKIND) &
-!         thickDepth         ! depth based on sum of layer thicknesses
-!
-!      integer, dimension(:), pointer :: &
-!         landIceMask        ! land ice mask
-!
-!      real (kind=RKIND), dimension(:), pointer :: &
-!         refZMid,                  &! reference depth at mid-layer
-!         refLayerThickness          ! reference profile layer thickness
-!
-!      real (kind=RKIND), dimension(:,:), pointer :: &
-!         layerThickness     ! current layer thickness
-!
-!      ! End preamble
-!      !-------------
-!      ! Begin code
-!
-!      ! Extract pools from domain
-!      block => domain % blocklist
-!      call mpas_pool_get_subpool(block%structs, 'state', statePool)
-!      call mpas_pool_get_subpool(block%structs, 'verticalMesh', &
-!                                                 verticalMeshPool)
-!      call mpas_pool_get_subpool(block%structs, 'forcing', forcingPool)
-!
-!      ! Extract needed variables from pools
-!      call mpas_pool_get_array(statePool, 'layerThickness', &
-!                                           layerThickness, 1)
-!
-!      call mpas_pool_get_array(verticalMeshPool, 'refZMid', refZMid)
-!      call mpas_pool_get_array(verticalMeshPool, 'refLayerThickness', &
-!                                                  refLayerThickness)
-!
-!      call mpas_pool_get_array(forcingPool, 'landIceMask', landIceMask)
-!      if (associated(landIceMask)) then
-!         landIceFlag = .true.  ! ice shelves
-!      else
-!         landIceFlag = .false. ! ice shelves
-!      endif
-!
-!      ! Initialize reference z coordinates based on refBottomDepth
-!      refBottomDepthTopOfCell(1) = 0.0_RKIND
-!      do k = 1, nVertLevels
-!         refBottomDepthTopOfCell(k+1) = refBottomDepth(k)
-!         refLayerThickness(k) = refBottomDepth(k) - &
-!                                refBottomDepthTopOfCell(k)
-!         refZMid(k) = - refBottomDepthTopOfCell(k) - &
-!                        refLayerThickness(k)/2.0_RKIND
-!      end do
-!
-!      ! Initialization of vertCoordMovementWeights. 
-!      ! This determines how SSH perturbations are distributed throughout
-!      ! the column. Check for invalid choice of vert coord movement.
-!
-!      call mpas_log_write(' Vertical coordinate movement is: ' // &
-!                          trim(config_vert_coord_movement))
-!
-!
-!      select case (trim(config_vert_coord_movement))
-!      case ('fixed')
-!
-!         vertCoordMovementWeights = 0.0_RKIND
-!         vertCoordMovementWeights(1) = 1.0_RKIND
-!
-!      case ('uniform_stretching')
-!
-!         vertCoordMovementWeights = 1.0_RKIND
-!
-!      case ('tapered')
-!
-!         ! Set weight tapering:
-!         !  1.0 shallower than config_vert_taper_weight_depth_1
-!         !  linear in between
-!         !  0.0 deeper than config_vert_taper_weight_depth_2
-!         do k = 1, nVertLevels
-!            vertCoordMovementWeights(k) = 1.0_RKIND + &
-!                 (refZMid(k) + config_vert_taper_weight_depth_1) / &
-!                 (config_vert_taper_weight_depth_2 - &
-!                  config_vert_taper_weight_depth_1)
-!            ! limit range to (0,1)
-!            vertCoordMovementWeights(k) = max( 0.0_RKIND, &
-!                      min( 1.0_RKIND, vertCoordMovementWeights(k) ) )
-!         end do
-!
-!      case ('impermeable_interfaces')
-!
-!         ! weights are never used, no init needed
-!
-!      case ('user_specified')
-!
-!         ! weights should be input? probably should check
-!
-!      case default
-!
-!         call mpas_log_write( &
-!            'Incorrect choice of config_vert_coord_movement.', &
-!             MPAS_LOG_CRIT)
-!
-!      end select
-!
-!      !-----------------------------------------------------------------
-!      ! Check consistency and validity of options
-!      !-----------------------------------------------------------------
-!
-!      ! SSH consistency
-!      if (config_check_ssh_consistency) then
-!
-!         ! Check if abs(ssh)>20m.  If so, print warning.
-!         consistentSSH = .true.
-!         do iCell = 1,nCells
-!
-!            ! Only check for open ocean when land ice is being used
-!            checkSSH = .true.
-!            if (landIceFlag) then
-!               if (landIceMask(iCell) /= 0) checkSSH = .false.
-!            endif
-!
-!            ! Check whether thickness is consistent with bottom depth
-!            if (checkSSH) then
-!               kmin = minLevelCell(iCell)
-!               kmax = maxLevelCell(iCell)
-!
-!               thickDepth = sum(layerThickness(kmin:kmax,iCell))
-!
-!               if (abs(thickDepth - bottomDepth(iCell)) > 20.0_RKIND) then
-!                  consistentSSH = .false.
-!
-!                  call mpas_log_write( &
-!                     ' Warning: Sea surface height outside of acceptable range (20m)', &
-!                     MPAS_LOG_ERR)
-!                  call mpas_log_write( &
-!                     ' iCell: $i, minLevelCell(iCell), maxLevelCell(iCell): $i, $i, bottomDepth(iCell): $r, sum(h): $r', &
-!                     intArgs=(/iCell, minLevelCell(iCell), maxLevelCell(iCell) /), &
-!                     realArgs=(/ bottomDepth(iCell), thickDepth /) )
-!               endif ! depth diff check
-!            endif ! checkSSH
-!         end do ! cell loop
-!
-!         if (.not. consistentSSH) call mpas_log_write( &
-!            'Warning: SSH not consistent - ' // &
-!            'initial layerThickness does not match bottomDepth.')
-!
-!      endif ! config_check_ssh_consistency
-!
-!      ! Z-level consistency
-!      if (config_check_zlevel_consistency) then
-!         do iCell = 1,nCells
-!            ! Check that bottomDepth and maxLevelCell match.  Some
-!            ! older meshs do not have the bottomDepth variable.
-!            kmax = maxLevelCell(iCell)
-!            if (bottomDepth(iCell) > refBottomDepth(kmax) .or. &
-!                bottomDepth(iCell) < refBottomDepthTopOfCell(kmax)) then
-!               call mpas_log_write( &
-!                 ' fatal error: bottomDepth and maxLevelCell do not match:',  &
-!                 MPAS_LOG_ERR)
-!               call mpas_log_write( &
-!                 ' iCell: $i, maxLevelCell(iCell): $i, bottomDepth(iCell): $r', &
-!                 intArgs=(/iCell, kmax /), &
-!                 realArgs=(/ bottomDepth(iCell) /) )
-!            endif
-!         enddo ! cell loop
-!      endif ! check_zlevel_consistency
-!
-!      ! pressure gradient compatibility
-!      if (config_vert_coord_movement /= 'impermeable_interfaces' .and. &
-!          config_pressure_gradient_type == 'MontgomeryPotential') then
-!         call mpas_log_write( 'Incompatible choice of ' // &
-!            'impermeable vertical interfaces and Montgomery Potential',&
-!            MPAS_LOG_CRIT)
-!      end if
-!
-!      ! barotropic filter mode compatibility
-!      if (config_filter_btr_mode .and. &
-!          config_vert_coord_movement /= 'fixed')then
-!         call mpas_log_write( &
-!          'filter_btr_mode has only been tested with ' // &
-!          'config_vert_coord_movement=fixed.', &
-!          MPAS_LOG_CRIT)
-!      endif
-!
-!   !--------------------------------------------------------------------
-!
-!   end subroutine meshVertCoordInit !}}}
-
-!***********************************************************************
-!
-!  routine li_meshAreaWeights
-!
-!> \brief  set up area weighting
-!> \author Mark Petersen
-!> \date   June 2020
-!> \details
-!>  This routine initializes edgeAreaFractionOfCell which is defined as
-!>  the fractional area of cell iCell encompassed by the triangle with
-!>  edge iEdge connected to the cell center of cell iCell. On a perfect
-!>  planar hex mesh this is always 1/6. This weighting is used to
-!>  interpolate scalars from edges to cell centers.
-!>  Use 2*edgeAreaFractionOfCell to interpolate normal vectors at
-!>  edges to vector norms at cell centers.
-!
-!-----------------------------------------------------------------------
-
-   subroutine meshAreaWeights()!{{{
-
-      !-----------------------------------------------------------------
-      ! Local variables
-      !-----------------------------------------------------------------
-
-      integer :: &
-         iCell, iEdge, &! cell, edge addresses
-         i,            &! edge on cell index
-         ierr           ! internal error flag
-
-      ! End preamble
-      !-------------
-      ! Begin code
-
-      ! Allocate space
-      allocate (edgeAreaFractionOfCell(maxEdges,nCells), STAT=ierr)
-#ifdef MPAS_OPENACC
-      !$acc enter data create(edgeAreaFractionOfCell)
-#endif
-      if (ierr /= 0) call mpas_log_write( &
-         'Error allocating edgeAreaFractionOfCell in li_mesh', &
-          MPAS_LOG_CRIT)
-
-      do iCell = 1, nCells
-      do i = 1, nEdgesOnCell(iCell)
-         iEdge = edgesOnCell(i, iCell)
-         edgeAreaFractionOfCell(i, iCell) = 0.25_RKIND* &
-               dcEdge(iEdge)*dvEdge(iEdge)/areaCell(iCell)
-      end do
-      end do
-#ifdef MPAS_OPENACC
-      !$acc update device(edgeAreaFractionOfCell)
-#endif
-
-   !--------------------------------------------------------------------
-
-   end subroutine meshAreaWeights !}}}
-
-!***********************************************************************
-!
-!  routine li_meshScaling
-!
-!> \brief  Computes mesh scaling variables for mixing
-!> \author Doug Jacobsen, Mark Petersen, Todd Ringler
-!> \date   September 2011
-!> \details
-!>  This routine initializes meshScalingDel2 and meshScalingDel4
-!>  that are used to scale coefficients with mesh size.
-!
-!-----------------------------------------------------------------------
-
-!   subroutine meshScaling() !{{{
-!
-!      !-----------------------------------------------------------------
-!      ! local variables
-!      !-----------------------------------------------------------------
-!
-!      integer :: &
-!         iEdge,       &! loop index/address for edges
-!         cell1, cell2  ! cell addresses for neighbors across edge
-!
-!      real (kind=RKIND) :: &
-!         cellWidth,   &! reference cell width for scaling
-!         avgDensity    ! avg mesh density across edge
-!
-!      ! End preamble
-!      !-------------
-!      ! Begin code
-!
-!      if (config_hmix_scaleWithMesh) then
-!         if (config_hmix_use_ref_cell_width) then
-!            ! Mesh scaling is set by areaCell and and an input
-!            ! reference widht config_hmix_ref_cell_width
-!            ! See description of config_hmix_ref_cell_width in
-!            ! Registry.xml for more detail.
-!            do iEdge = 1, nEdges
-!               cell1 = cellsOnEdge(1,iEdge)
-!               cell2 = cellsOnEdge(2,iEdge)
-!               ! Effective cell width at edge iEdge, assuming
-!               ! neighboring cells are circles for this calculation.
-!               cellWidth = 2.0_RKIND* &
-!                           sqrt((areaCell(cell1) + areaCell(cell2))/ &
-!                                2.0_RKIND/pii)
-!               meshScalingDel2(iEdge) =  cellWidth/ &
-!                                         config_hmix_ref_cell_width
-!               meshScalingDel4(iEdge) = (cellWidth/ &
-!                                         config_hmix_ref_cell_width)**3
-!            end do
-!
-!         else ! not using ref cell width
-!            ! Mesh scaling is set by meshDensity. This is both confusing
-!            ! and inconvenient, as the flags like config_mom_del2 need
-!            ! to be reset for every resolution. It is kept for backwards
-!            ! compatibility, but should become defunct.
-!            ! del2 scales as dc**1, del4 scales as dc**3
-!            do iEdge = 1, nEdges
-!               cell1 = cellsOnEdge(1,iEdge)
-!               cell2 = cellsOnEdge(2,iEdge)
-!               avgDensity = (meshDensity(cell1) + meshDensity(cell2))/ &
-!                            2.0_RKIND
-!               meshScalingDel2(iEdge) = 1.0_RKIND/ &
-!                  (avgDensity/config_maxMeshDensity)**(1.0_RKIND/4.0_RKIND)
-!               meshScalingDel4(iEdge) = 1.0_RKIND/ &
-!                  (avgDensity/config_maxMeshDensity)**(3.0_RKIND/4.0_RKIND)
-!            end do
-!         end if
-!
-!      else ! no scaling with mesh
-!
-!         ! If config_hmix_scaleWithMesh is false, hmix coefficients
-!         ! do not vary with cell size but remain constant across domain.
-!         do iEdge = 1, nEdges
-!            meshScalingDel2(iEdge) = 1.0_RKIND
-!            meshScalingDel4(iEdge) = 1.0_RKIND
-!         end do
-!      end if
-!
-!   !--------------------------------------------------------------------
-!
-!   end subroutine meshScaling !}}}
-
 !***********************************************************************
 
 end module li_mesh


### PR DESCRIPTION
Remove commented code and unused variables from li_mesh that were left over after porting this module from MPAS-Ocean to MALI.