### PR TITLE
Calculate higher-order flux across grounding line

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1434,7 +1434,7 @@ is the value of that variable from the *previous* time level!
                      description="horizonal velocity, normal component to an edge, layer midpoint"
                 />
 		<var name="layerThicknessEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-1}"
-                     description="layer-normal thickness flux on edges for higher-order advection"
+                     description="layer-normal thickness flux on edges"
 		/>
                 <var name="normalVelocityInitial" type="real" dimensions="nVertInterfaces nEdges Time" units="m s^{-1}"
                      description="horizonal velocity, normal component to an edge, computed at initialization"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1433,6 +1433,9 @@ is the value of that variable from the *previous* time level!
                 <var name="layerNormalVelocity" type="real" dimensions="nVertLevels nEdges Time" units="m s^{-1}"
                      description="horizonal velocity, normal component to an edge, layer midpoint"
                 />
+		<var name="layerThicknessEdgeFlux" type="real" dimensions="nVertLevels nEdges Time" units="m^2 s^{-1}"
+                     description="layer-normal thickness flux on edges for higher-order advection"
+		/>
                 <var name="normalVelocityInitial" type="real" dimensions="nVertInterfaces nEdges Time" units="m s^{-1}"
                      description="horizonal velocity, normal component to an edge, computed at initialization"
                 />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -642,10 +642,16 @@ module li_advection
                   GLfluxSign = -1.0_RKIND
                   theGroundedCell = iCell2
                endif
-               do k = 1, nVertLevels
-                  thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
-                  fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
-               enddo
+               if (trim(config_thickness_advection) == 'fct') then
+                  do k = 1, nVertLevels
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
+                  enddo
+               else
+                  do k = 1, nVertLevels
+                     thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
+                  enddo
+               endif
                ! assign to grounded cell in fluxAcrossGroundingLineOnCells
                if (thickness(theGroundedCell) <= 0.0_RKIND) then
                   ! This should never be the case, but checking to avoid possible divide by zero

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -166,7 +166,8 @@ module li_advection
            layerThickness,        & ! thickness of each layer
            layerThicknessOld,     & ! old layer thickness
            layerThicknessEdge,    & ! layer thickness on upstream edge of cell
-           normalVelocity           ! horizontal velocity on interfaces
+           normalVelocity,        & ! horizontal velocity on interfaces
+           layerThicknessEdgeFlux   ! higher order thickness flux on layers and edges
 
       real (kind=RKIND), dimension(:,:,:), pointer :: &
            advectedTracers,       & ! values of advected tracers
@@ -193,7 +194,6 @@ module li_advection
 
       ! Allocatable arrays need for flux-corrected transport advection
       real (kind=RKIND), dimension(:,:,:), allocatable :: tend
-      real (kind=RKIND), dimension(:,:,:), allocatable :: activeTracerHorizontalAdvectionEdgeFlux
 
       integer, dimension(:), pointer :: &
            cellMask,              & ! integer bitmask for cells
@@ -292,6 +292,7 @@ module li_advection
 
       ! get arrays from the velocity pool
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
+      call mpas_pool_get_array(velocityPool, 'layerThicknessEdgeFlux', layerThicknessEdgeFlux)
       call mpas_pool_get_array(velocityPool, 'normalVelocity', normalVelocity)
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
@@ -413,8 +414,7 @@ module li_advection
              (trim(config_tracer_advection) .eq. 'fct' ) ) then
             allocate(tend(nTracers,nVertLevels,nCells+1))
             tend(:,:,:) = 0.0_RKIND
-            allocate(activeTracerHorizontalAdvectionEdgeFlux(nTracers,nVertLevels+1,nEdges+1))
-            activeTracerHorizontalAdvectionEdgeFlux(:,:,:) = 0.0_RKIND
+            layerThicknessEdgeFlux(:,:) = 0.0_RKIND
          endif
 
          ! Transport thickness and tracers
@@ -481,25 +481,25 @@ module li_advection
              call li_tracer_advection_fct_tend(&
                   tend, advectedTracers, layerThicknessOld, &
                   layerThicknessEdge * layerNormalVelocity, 0 * normalVelocity, dt,    &
-                  nTracers, activeTracerHorizontalAdvectionEdgeFlux, computeBudgets=.false.)!{{{
+                  nTracers, layerThicknessEdgeFlux, computeBudgets=.false.)!{{{
          elseif (trim(config_thickness_advection) .eq. 'fct') then
-             ! Call fct routine for thickness first, and use activeTracerHorizontalAdvectionEdgeFlux
+             ! Call fct routine for thickness first, and use layerThicknessEdgeFlux
              ! returned by that call as normalThicknessFlux for call to tracer fct
              call li_tracer_advection_fct_tend(&
                   tend(nTracers:,:,:), advectedTracers(nTracers:,:,:), layerThicknessOld * 0.0_RKIND + 1.0_RKIND, &
                   layerNormalVelocity, 0.0_RKIND * normalVelocity, dt,    &
-                  1, activeTracerHorizontalAdvectionEdgeFlux(nTracers:,:,:), computeBudgets=.false.)
+                  1, layerThicknessEdgeFlux, computeBudgets=.false.)
              ! layerThickness is last tracer. However, for some reason
              ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
              ! This does conserve mass:
              layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
 
              if (trim(config_tracer_advection) .eq. 'fct') then
-                ! Call fct for tracers, using activeTracerHorizontalAdvectionEdgeFlux
+                ! Call fct for tracers, using layerThicknessEdgeFlux
                 ! from fct thickness advection as normalThicknessFlux
                 call li_tracer_advection_fct_tend(&
                      tend(1:nTracers-1,:,:), advectedTracers(1:nTracers-1,:,:), layerThicknessOld, &
-                     activeTracerHorizontalAdvectionEdgeFlux(nTracers,:,:), 0.0_RKIND * normalVelocity, dt,    &
+                     layerThicknessEdgeFlux, 0.0_RKIND * normalVelocity, dt,    &
                      nTracers-1, computeBudgets=.false.)
              elseif (trim(config_tracer_advection) .eq. 'none') then
                 ! do nothing
@@ -714,8 +714,7 @@ module li_advection
                      advCoefs3rd, &
                      advMaskHighOrder, &
                      advMask2ndOrder, &
-                     tend, &
-                     activeTracerHorizontalAdvectionEdgeFlux)
+                     tend)
       endif
 
       ! clean up

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -369,6 +369,7 @@ module li_advection
 
       ! save old copycellMask for determining cells changing from grounded to floating and vice versa
       cellMaskTemporaryField % array(:) = cellMask(:)
+      layerThicknessEdgeFlux(:,:) = 0.0_RKIND
 
       !-----------------------------------------------------------------
       ! Horizontal transport of thickness and tracers
@@ -414,7 +415,6 @@ module li_advection
              (trim(config_tracer_advection) .eq. 'fct' ) ) then
             allocate(tend(nTracers,nVertLevels,nCells+1))
             tend(:,:,:) = 0.0_RKIND
-            layerThicknessEdgeFlux(:,:) = 0.0_RKIND
          endif
 
          ! Transport thickness and tracers
@@ -648,8 +648,8 @@ module li_advection
                   enddo
                else
                   do k = 1, nVertLevels
-                     thicknessFluxEdge = layerNormalVelocity(k,iEdge) * dvEdge(iEdge) * layerThicknessEdge(k,iEdge)
-                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * thicknessFluxEdge / dvEdge(iEdge)
+                     layerThicknessEdgeFlux(k,iEdge) = layerNormalVelocity(k,iEdge) * layerThicknessEdge(k,iEdge)
+                     fluxAcrossGroundingLine(iEdge) = fluxAcrossGroundingLine(iEdge) + GLfluxSign * layerThicknessEdgeFlux(k,iEdge)
                   enddo
                endif
                ! assign to grounded cell in fluxAcrossGroundingLineOnCells

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -65,7 +65,7 @@ module li_tracer_advection_fct
                                         tend, tracers, layerThickness, &
                                         normalThicknessFlux, w, dt,    &
                                         nTracers, &
-                                        activeTracerHorizontalAdvectionEdgeFlux, &
+                                        layerThicknessEdgeFlux, &
                                         computeBudgets)!{{{
       use li_mesh
       !-----------------------------------------------------------------
@@ -74,8 +74,8 @@ module li_tracer_advection_fct
 
       real (kind=RKIND), dimension(:,:,:), intent(inout) :: &
          tend    !< [inout] Tracer tendency to which advection added
-      real (kind=RKIND), dimension(:,:,:), intent(inout), optional :: &
-         activeTracerHorizontalAdvectionEdgeFlux  !< [inout] used to compute higher order normalThicknessFlux
+      real (kind=RKIND), dimension(:,:), intent(inout), optional :: &
+         layerThicknessEdgeFlux  !< [inout] used to compute higher order normalThicknessFlux
       !-----------------------------------------------------------------
       ! Input parameters
       !-----------------------------------------------------------------
@@ -462,18 +462,19 @@ module li_tracer_advection_fct
 #endif
         ! Compute budget and monotonicity diagnostics if needed
 
-        ! Use activeTracerHorizontalAdvectionEdgeFlux from the call to fct for thickness
+        ! Use layerThicknessEdgeFlux from the call to fct for thickness
         ! advection as the higher-order normalThicknessFlux for fct tracer advection.
-        if (present(activeTracerHorizontalAdvectionEdgeFlux)) then
+        if (present(layerThicknessEdgeFlux)) then
             do iEdge = 1,nEdges
             do k = 1, nVertLevels
                ! Save u*h*T flux on edge for analysis. This variable will be
                ! divided by h at the end of the time step.
+               ! average normal velocities from layer interfaces to layer midpoints
                if (dvEdge(iEdge) > 0.0_RKIND) then
-                  activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = &
+                  layerThicknessEdgeFlux(k,iEdge) = &
                       (lowOrderFlx(k,iEdge) + highOrderFlx(k,iEdge))/dvEdge(iEdge)
                else
-                  activeTracerHorizontalAdvectionEdgeFlux(iTracer,k,iEdge) = 0.0_RKIND
+                  layerThicknessEdgeFlux(k,iEdge) = 0.0_RKIND
                endif
             enddo
             enddo


### PR DESCRIPTION
When using higher-order thickness advection, calculate higher-order flux across grounding line.