### PR TITLE
Fix small conservation error when using fct thickness and tracer advection

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -74,6 +74,7 @@ module li_advection
 !-----------------------------------------------------------------------
 
    subroutine li_advection_thickness_tracers(&
+        domain,                 &
         dt,                     &
         meshPool,               &
         velocityPool,           &
@@ -107,6 +108,7 @@ module li_advection
       ! input/output variables
       !
       !-----------------------------------------------------------------
+      type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
 
       type (mpas_pool_type), intent(inout) :: &
            velocityPool           !< Input/output: velocity information
@@ -493,6 +495,10 @@ module li_advection
              ! this: layerThickness(:,:) = advectedTracers(nTracers,:,:) does not conserve mass!
              ! This does conserve mass:
              layerThickness(:,:) = layerThickness(:,:) + tend(nTracers,:,:) * dt
+
+             call mpas_timer_start("halo updates")
+             call mpas_dmpar_field_halo_exch(domain, 'layerThicknessEdgeFlux')
+             call mpas_timer_stop("halo updates")
 
              if (trim(config_tracer_advection) .eq. 'fct') then
                 ! Call fct for tracers, using layerThicknessEdgeFlux

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe.F
@@ -715,6 +715,7 @@ module li_time_integration_fe
             endif
 
             call li_advection_thickness_tracers(&
+                 domain,                 &
                  deltat,                 &
                  meshPool,               &
                  velocityPool,           &
@@ -733,6 +734,7 @@ module li_time_integration_fe
             endif
 
             call li_advection_thickness_tracers(&
+                 domain,                 &
                  deltat,                 &
                  meshPool,               &
                  velocityPool,           &


### PR DESCRIPTION
Add a halo update on `layerThicknessEdgeFlux` to fix a small tracer conservation error when using fct thickness and tracer advection. That error was documented in this comment in PR #70 : https://github.com/MALI-Dev/E3SM/pull/70#issuecomment-1664471184.