### PR TITLE
Fix dissipation when solver fails

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -616,8 +616,12 @@ contains
 
 
           ! Now interpolate from vertices to cell centers
-          call li_interpolate_vertex_to_cell_2d(meshPool, dissipationVertexField % array, heatDissipation)
-          heatDissipation = heatDissipation / (config_ice_density * cp_ice)
+          if (albanyVelocityError == 0) then
+             ! the dissipationVertexField can have garbage if the solver didn't converge,
+             ! so keep previous timestep's field if nonconvergence
+             call li_interpolate_vertex_to_cell_2d(meshPool, dissipationVertexField % array, heatDissipation)
+             heatDissipation = heatDissipation / (config_ice_density * cp_ice)
+          endif
           call mpas_deallocate_scratch_field(dissipationVertexField, .true.)
 
           call li_interpolate_vertex_to_cell_1d(meshPool, drivingStressVert, drivingStress)


### PR DESCRIPTION
When the velocity solver fails, the internal dissipation field it returns can have large artifacts in it that lead to unphysical melt rates being applied.  This merge skips updating the heatDissipation field when the solver fails so that the previous timestep's value is retained.