### PR TITLE
Add restart option when the SLM is coupled to MALI

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -145,13 +145,9 @@
 		            description="Selection of the method for bedrock uplift calculation."
 		            possible_values="'none', 'data', 'sealevelmodel'"
         />
-        <nml_option name="config_slm_coupling_interval" type="character" default_value="0002-00-00_00:00:00" units="time"
-            description="Time interval at which the sea-level model is called by MALI. The interval has to be an even multiple of the option 'config_adaptive_timestep_force_interval"
-            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'"
-		/>
-	<nml_option name="config_slm_timestep_restart" type="integer" default_value="0" units="unitless"
-	    description="number of timesteps the sea-level model moved forward since the start of simulation."
-		possible_values="Any integer value calculated from dividing the difference between simulation start time and restart time by MALI-SLM coupling interval. This poses the restriction on the restart time to be a integer multiple of MALI-SLM coupling interval."
+        <nml_option name="config_slm_coupling_interval" type="integer" default_value="2" units="years"
+            description="Time interval at which the sea-level model is called by MALI. Only integer years are currently supported. The user must set 'dt1' in namelist.sealevel to match this value.  Note that the user needs to set config_adaptive_timestep_force_interval to divide evenly into config_slm_coupling_interval.  Also, restart file output_interval needs to be a multiple of config_slm_coupling_interval."
+            possible_values="Any positive integer"
 		/>
         <nml_option name="config_MALI_to_SLM_weights_file" type="character" default_value="mpas_to_grid.nc" units="unitless"
             description="File containing the interpolation weights for regridding from MPAS mesh to the Gaussian grid used by the Sea Level Model."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -149,6 +149,10 @@
             description="Time interval at which the sea-level model is called by MALI. The interval has to be an even multiple of the option 'config_adaptive_timestep_force_interval"
             possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'"
 		/>
+	<nml_option name="config_slm_timestep_restart" type="integer" default_value="0" units="unitless"
+	    description="number of timesteps the sea-level model moved forward since the start of simulation."
+		possible_values="Any integer value calculated from dividing the difference between simulation start time and restart time by MALI-SLM coupling interval. This poses the restriction on the restart time to be a integer multiple of MALI-SLM coupling interval."
+		/>
         <nml_option name="config_MALI_to_SLM_weights_file" type="character" default_value="mpas_to_grid.nc" units="unitless"
             description="File containing the interpolation weights for regridding from MPAS mesh to the Gaussian grid used by the Sea Level Model."
             possible_values="Any file name string"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -1018,7 +1018,8 @@ contains
       ! First, check consistency in coupling interval set up in MALI and SLM
       call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
       if (config_slm_coupling_interval == slm_dt1) then
-         call mpas_log_write("The coupling interval in MALI ($i yr) and SLM ($i yr) are consistent - check passes")
+         call mpas_log_write("The coupling interval in MALI ($i yr) and SLM ($i yr) are consistent - check passes", &
+                 intArgs=(/config_slm_coupling_interval, slm_dt1/))
       else
          call mpas_log_write("The coupling interval in MALI ($i yr) and SLM ($i yr) are inconsistent", MPAS_LOG_ERR, &
                  intArgs=(/config_slm_coupling_interval, slm_dt1/))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -407,6 +407,10 @@ contains
       integer :: itersl, dtime ! SLM variable
       real    :: starttime     ! SLM variable
       integer, dimension(:), pointer :: cellMask  ! integer bitmask for cells
+      integer, pointer :: config_slm_coupling_interval
+      type (MPAS_TimeInterval_type) :: slm_coupling_interval
+      character (len=StrKIND), pointer :: simulationStartTime
+      type (MPAS_Time_type) :: simulationStartTime_timeType
 
       ! MPI variables
       integer, dimension(:), pointer :: indexToCellID
@@ -415,12 +419,30 @@ contains
       err = 0
       err_tmp = 0
 
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+
+      ! Set up the alarm for the coupling time interval
+      call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+      call mpas_set_timeInterval(slm_coupling_interval, YY=config_slm_coupling_interval, ierr=err_tmp)
+      err = ior(err,err_tmp)
+      call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
+      call mpas_set_time(simulationStartTime_timeType, dateTimeString=simulationStartTime, ierr=err_tmp)
+      err = ior(err,err_tmp)
+      call mpas_add_clock_alarm(domain%clock, 'slmCouplingInterval', alarmTime=simulationStartTime_timeType, &
+           alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
+      err = ior(err,err_tmp)
+      if (mpas_is_alarm_ringing(domain%clock, 'slmCouplingInterval', ierr=err_tmp)) then
+         err = ior(err, err_tmp)
+         call mpas_reset_clock_alarm(domain%clock, 'slmCouplingInterval', ierr=err_tmp)
+         err = ior(err, err_tmp)
+      endif
+
       ! initialize interpolation
       call interpolate_init(domain, err_tmp)
       err = ior(err, err_tmp)
 
       ! Set needed variables for using MPI
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCellsAll)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsOwned)
       call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID)
@@ -448,7 +470,7 @@ contains
          call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
 
          ! First, check consistency in coupling interval set up in MALI and SLM
-         call check_SLM_coupling_interval(dtime, meshPool, domain % streamManager, err_tmp)
+         call check_SLM_coupling_interval(dtime, meshPool, err_tmp)
          err = ior(err, err_tmp)
          if (err /= 0) then
             call mpas_log_write("Error occurred in check_SLM_coupling_interval.", MPAS_LOG_ERR)
@@ -985,7 +1007,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine check_SLM_coupling_interval(slm_dt1, meshPool, streamManager, err)
+   subroutine check_SLM_coupling_interval(slm_dt1, meshPool, err)
 
       use mpas_timekeeping
       use mpas_stream_manager
@@ -993,18 +1015,16 @@ contains
 
       integer, intent (in) :: slm_dt1
       type (mpas_pool_type), intent(in) :: meshPool  !< mesh information
-      type (MPAS_streamManager_type), intent(inout) :: streamManager
       integer, intent(out) :: err
 
       ! local variables
       integer, pointer :: config_slm_coupling_interval
       logical, pointer :: config_adaptive_timestep
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval, config_dt
-      type (MPAS_TimeInterval_Type) :: coupling_interval, force_interval, dt_interval, restart_interval, zero_interval
+      type (MPAS_TimeInterval_Type) :: coupling_interval, force_interval, dt_interval, zero_interval
       type (MPAS_Time_Type) :: start_time
       character (len=StrKIND), pointer :: simulationStartTime
       integer :: YYYY, MM, DD, H, M, S  ! time components
-      type (MPAS_stream_list_type), pointer :: stream_cursor
       integer (kind=I8KIND) :: n_intervals
       type (MPAS_TimeInterval_type) :: remainder
       integer :: err_tmp
@@ -1066,26 +1086,9 @@ contains
          endif
       endif
 
-      ! Now check that restart interval is an even multiple of coupling interval
-      stream_cursor => streamManager % streams % head
-      do while (associated(stream_cursor))
-         if ( trim(stream_cursor % name) == 'restart' .and. (stream_cursor % active_stream) ) then
-            call mpas_log_write("Checking restart interval against SLM coulping interval")
-            restart_interval = MPAS_stream_mgr_get_stream_interval(streamManager, 'restart', MPAS_STREAM_OUTPUT, ierr=err_tmp)
-            err = ior(err, err_tmp)
-            call mpas_interval_division(start_time, restart_interval, coupling_interval, n_intervals, remainder)
-            if (remainder .EQ. zero_interval) then
-               call mpas_log_write("config_slm_coupling_interval divides into restart interval $i times " // &
-                 "with no remainder - check passes", intArgs=(/int(n_intervals)/))
-            else
-               call mpas_log_write("config_slm_coupling_interval divides into restart interval $i times " // &
-                 "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
-               err = ior(err, 1)
-            endif
-         endif
+      ! No need to compare restart interval and coupling interval because restarts with SLM are supported for
+      ! any restart interval now
 
-         stream_cursor => stream_cursor % next
-      enddo
       call mpas_log_write("")
 
    !--------------------------------------------------------------------
@@ -1118,7 +1121,7 @@ contains
       ! local vars
       integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND), pointer :: xtime, simulationStartTime
-      type (MPAS_TimeInterval_Type) :: coupling_interval, zero_interval
+      type (MPAS_TimeInterval_Type) :: coupling_interval
       type (MPAS_Time_Type) :: start_time, curr_time
       integer (kind=I8KIND) :: n_intervals
       type (MPAS_TimeInterval_type) :: remainder
@@ -1141,17 +1144,9 @@ contains
       err = ior(err, err_tmp)
 
       call mpas_interval_division(start_time, curr_time - start_time, coupling_interval, n_intervals, remainder)
-      call mpas_set_timeInterval(zero_interval, dt = 0.0_RKIND)
-      if (remainder .EQ. zero_interval) then
-         call mpas_log_write("SLM Restart check: config_slm_coupling_interval divides into elapsed time $i times " // &
-              "with no remainder - check passes", intArgs=(/int(n_intervals)/))
-         slmTimeStep = int(n_intervals)
-      else
-         call mpas_log_write("SLM Restart check: config_slm_coupling_interval divides into elapsed time $i times " // &
-              "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
-         err = ior(err, 1)
-         slmTimeStep = -999
-      endif
+      slmTimeStep = int(n_intervals)
+      call mpas_log_write("SLM Restart check: Using SLM time level $i because config_slm_coupling_interval divides into " // &
+              "elapsed time that many times ", intArgs=(/int(slmTimeStep)/))
       call mpas_log_write("")
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -448,7 +448,7 @@ contains
          call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
 
          ! First, check consistency in coupling interval set up in MALI and SLM
-         call check_SLM_coupling_interval(dtime, domain % streamManager, err_tmp)
+         call check_SLM_coupling_interval(dtime, meshPool, domain % streamManager, err_tmp)
          err = ior(err, err_tmp)
          if (err /= 0) then
             call mpas_log_write("Error occurred in check_SLM_coupling_interval.", MPAS_LOG_ERR)
@@ -985,23 +985,27 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine check_SLM_coupling_interval(slm_dt1, streamManager, err)
+   subroutine check_SLM_coupling_interval(slm_dt1, meshPool, streamManager, err)
 
       use mpas_timekeeping
       use mpas_stream_manager
       use mpas_derived_types, only : MPAS_STREAM_PROPERTY_RECORD_INTV
 
       integer, intent (in) :: slm_dt1
+      type (mpas_pool_type), intent(in) :: meshPool  !< mesh information
       type (MPAS_streamManager_type), intent(inout) :: streamManager
       integer, intent(out) :: err
 
       ! local variables
       integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval
-      type (MPAS_Time_Type) :: force_interval, restart_interval
-      character(len=StrKIND) :: restart_interval_str
+      type (MPAS_TimeInterval_Type) :: coupling_interval, force_interval, restart_interval, zero_interval
+      type (MPAS_Time_Type) :: start_time
+      character (len=StrKIND), pointer :: simulationStartTime
       integer :: YYYY, MM, DD, H, M, S  ! time components
       type (MPAS_stream_list_type), pointer :: stream_cursor
+      integer (kind=I8KIND) :: n_intervals
+      type (MPAS_TimeInterval_type) :: remainder
       integer :: err_tmp
 
       err = 0
@@ -1015,28 +1019,26 @@ contains
          err = ior(err, 1)
       endif
 
+      ! define zero interval for comparing against below
+      call mpas_set_timeInterval(zero_interval, dt = 0.0_RKIND)
+      ! get start time as a reference time
+      call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
+      call mpas_set_time(start_time, dateTimeString=simulationStartTime)
+      ! define SLM coupling interval as a timeInterval type
+      call mpas_set_timeInterval(coupling_interval, YY=config_slm_coupling_interval, MM=0, DD=0, H=0, M=0, S=0, ierr=err_tmp)
+      err = ior(err, err_tmp)
+
       ! Check that config_adaptive_timestep_force_interval divides evenly into config_slm_coupling_interval
       call mpas_pool_get_config(liConfigs, "config_adaptive_timestep_force_interval", config_adaptive_timestep_force_interval)
-      ! Note: Using mpas_set_time instead of mpas_set_time_interval, even though this is an interval
-      ! This is because mpas_get_time_interval requires a reference time, which is not relevant
-      ! to these checks, and mpas_get_time allows us to get the component pieces that we want to check.
-      call mpas_set_time(force_interval, dateTimeString=config_adaptive_timestep_force_interval, ierr=err_tmp)
+      call mpas_set_timeInterval(force_interval, timeString=config_adaptive_timestep_force_interval, ierr=err_tmp)
       err = ior(err, err_tmp)
-      call mpas_get_time(force_interval, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
-      if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
-         call mpas_log_write("config_adaptive_timestep_force_interval currently not supported " // &
-              "to have nonzero values for months, days, hours, minutes, or seconds when sea-level model " // &
-              "is coupled.  config_adaptive_timestep_force_interval=" //trim(config_adaptive_timestep_force_interval), MPAS_LOG_ERR)
-         call mpas_log_write("  MM=$i, DD=$i, H=$i, M=$i, S=$i", intArgs=(/MM, DD, H, M, S/))
-         ! Note: the actual requirement is that adapt dt force interval divides evenly into coupling interval
-         ! but that is tricky to check, and wanting anything but even years for that option is a rare use case.
-         err = ior(err, 1)
-      endif
-      ! Next check the number of years divides evenly into SLM coupling interval
-      if (mod(config_slm_coupling_interval, YYYY) /= 0) then
-         call mpas_log_write("config_adaptive_timestep_force_interval does not divide evenly into config_slm_coupling_interval" // &
-              "config_adaptive_timestep_force_interval=" // trim(config_adaptive_timestep_force_interval) // &
-              "; config_slm_coupling_interval=$i", MPAS_LOG_ERR, intArgs=(/config_slm_coupling_interval/))
+      call mpas_interval_division(start_time, coupling_interval, force_interval, n_intervals, remainder)
+      if (remainder .EQ. zero_interval) then
+         call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
+                 "with no remainder - check passes", intArgs=(/int(n_intervals)/))
+      else
+         call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
+                 "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
          err = ior(err, 1)
       endif
 
@@ -1045,27 +1047,16 @@ contains
       do while (associated(stream_cursor))
          if ( trim(stream_cursor % name) == 'restart' .and. (stream_cursor % active_stream) ) then
             call mpas_log_write("Checking restart interval against SLM coulping interval")
-            call MPAS_stream_mgr_get_property(streamManager, 'restart', MPAS_STREAM_PROPERTY_RECORD_INTV, &
-                 restart_interval_str, ierr=err_tmp)
+            restart_interval = MPAS_stream_mgr_get_stream_interval(streamManager, 'restart', MPAS_STREAM_OUTPUT, ierr=err_tmp)
             err = ior(err, err_tmp)
-
-            call mpas_log_write('restart interval is: ' //trim(restart_interval_str))
-
-            call mpas_set_time(restart_interval, dateTimeString=restart_interval_str, ierr=err_tmp)
-            err = ior(err, err_tmp)
-            call mpas_get_time(restart_interval, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
-            if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
-               call mpas_log_write("If Sea Level Model is active, restart output_interval cannot include " // &
-                    "nonzero months, days, hours, minutes or seconds.  restart output_interval=" // &
-                    trim(restart_interval_str), MPAS_LOG_ERR)
-               err = ior(err, 1)
+            call mpas_interval_division(start_time, restart_interval, coupling_interval, n_intervals, remainder)
+            if (remainder .EQ. zero_interval) then
+               call mpas_log_write("config_slm_coupling_interval divides into restart interval $i times " // &
+                 "with no remainder - check passes", intArgs=(/int(n_intervals)/))
+            else
+               call mpas_log_write("config_slm_coupling_interval divides into restart interval $i times " // &
+                 "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
             endif
-
-            if (mod(YYYY, config_slm_coupling_interval) /= 0) then
-               call mpas_log_write("restart output_interval must be a multiple of config_slm_coupling_interval", MPAS_LOG_ERR)
-               err = ior(err, 1)
-            endif
-
          endif
 
          stream_cursor => stream_cursor % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -501,10 +501,13 @@ contains
 
          call find_slm_restart_timestep(meshPool, slmTimeStep, err_tmp)
          err = ior(err, err_tmp)
-         if (err == 0) then
-            call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
-            call slmodel_solve(slmTimeStep, domain)
-         endif
+
+         ! Note: no need to call slmodel_solve on init of a restart.
+         ! If this time level happens to be a coupling interval, SLM would have been solved already
+         ! in the previous run that generated the restart file.
+         ! While it would not hurt (other than unneeded execution time) to call SLM again if the
+         ! restart time level happens to be a coupling interval, if the restart time is in between
+         ! coupling intervals calling SLM here will make things out of sync.
 
       else
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -1125,6 +1125,7 @@ contains
       type (MPAS_Time_Type) :: start_time, curr_time
       integer (kind=I8KIND) :: n_intervals
       type (MPAS_TimeInterval_type) :: remainder
+      character (len=StrKIND) :: remainder_string
       integer :: err_tmp
 
       err = 0
@@ -1135,7 +1136,6 @@ contains
       call mpas_set_timeInterval(coupling_interval, YY=config_slm_coupling_interval, MM=0, DD=0, H=0, M=0, S=0, ierr=err_tmp)
       err = ior(err, err_tmp)
 
-
       call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
       call mpas_pool_get_array(meshPool, 'xtime', xtime)
       call mpas_set_time(start_time, dateTimeString=simulationStartTime, ierr=err_tmp)
@@ -1145,8 +1145,12 @@ contains
 
       call mpas_interval_division(start_time, curr_time - start_time, coupling_interval, n_intervals, remainder)
       slmTimeStep = int(n_intervals)
-      call mpas_log_write("SLM Restart check: Using SLM time level $i because config_slm_coupling_interval divides into " // &
+      call mpas_get_timeInterval(remainder, start_time, timeString=remainder_string, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_log_write("SLM Restart: Using SLM time level $i because config_slm_coupling_interval divides into " // &
               "elapsed time that many times ", intArgs=(/int(slmTimeStep)/))
+      call mpas_log_write("  That calculation implies it has been " // trim(remainder_string) // " since last SLM coupling. " // &
+              "If that interval seems wrong, there may be an error in your configuration.")
       call mpas_log_write("")
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -1116,17 +1116,20 @@ contains
       ! local vars
       integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND), pointer :: xtime, simulationStartTime
-      character (len=StrKIND) :: elapsed_time_str
+      type (MPAS_TimeInterval_Type) :: coupling_interval, zero_interval
       type (MPAS_Time_Type) :: start_time, curr_time
-      type (MPAS_Time_Type) :: elapsed_time ! should be a time interval but not possible to get years that way
-      integer :: YYYY, MM, DD, H, M, S  ! time components
+      integer (kind=I8KIND) :: n_intervals
+      type (MPAS_TimeInterval_type) :: remainder
       integer :: err_tmp
 
       err = 0
-
-      slmTimeStep = -999  ! initialize to bad number
+      err_tmp = 0
 
       call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
+      ! define SLM coupling interval as a timeInterval type
+      call mpas_set_timeInterval(coupling_interval, YY=config_slm_coupling_interval, MM=0, DD=0, H=0, M=0, S=0, ierr=err_tmp)
+      err = ior(err, err_tmp)
+
 
       call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
       call mpas_pool_get_array(meshPool, 'xtime', xtime)
@@ -1134,30 +1137,20 @@ contains
       err = ior(err, err_tmp)
       call mpas_set_time(curr_time, dateTimeString=xtime, ierr=err_tmp)
       err = ior(err, err_tmp)
-      call mpas_get_timeInterval(curr_time - start_time, start_time, timeString=elapsed_time_str, ierr=err_tmp)
-      err = ior(err, err_tmp)
 
-      ! convert elapsed time string to its units. Using the intermediate string format because mpas_get_timeInterval doesn't return
-      ! years, and figuring out years from days depends on the calendar
-      call mpas_set_time(elapsed_time, dateTimeString=elapsed_time_str, ierr=err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_get_time(elapsed_time, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
-
-      ! make sure the elapsed time is an even year
-      if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
-         call mpas_log_write("Elapsed time since simulationStartTime include nonzero months, days, hours, minutes, " // &
-                 "or seconds.", MPAS_LOG_ERR)
-         err = ior(err, 1)
-      endif
-
-      if (mod(YYYY, config_slm_coupling_interval) == 0) then
-         ! We can restart cleanly
-         slmTimeStep = YYYY / config_slm_coupling_interval
+      call mpas_interval_division(start_time, curr_time - start_time, coupling_interval, n_intervals, remainder)
+      call mpas_set_timeInterval(zero_interval, dt = 0.0_RKIND)
+      if (remainder .EQ. zero_interval) then
+         call mpas_log_write("SLM Restart check: config_slm_coupling_interval divides into elapsed time $i times " // &
+              "with no remainder - check passes", intArgs=(/int(n_intervals)/))
+         slmTimeStep = int(n_intervals)
       else
-         call mpas_log_write("Elapsed years since simulationStartTime is not evenly divisible by config_slm_coupling_interval." // &
-                 " Unable to restart Sea Level Model cleanly.", MPAS_LOG_ERR)
+         call mpas_log_write("SLM Restart check: config_slm_coupling_interval divides into elapsed time $i times " // &
+              "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
          err = ior(err, 1)
+         slmTimeStep = -999
       endif
+      call mpas_log_write("")
 
    !--------------------------------------------------------------------
    end subroutine find_slm_restart_timestep

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -998,8 +998,9 @@ contains
 
       ! local variables
       integer, pointer :: config_slm_coupling_interval
-      character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval
-      type (MPAS_TimeInterval_Type) :: coupling_interval, force_interval, restart_interval, zero_interval
+      logical, pointer :: config_adaptive_timestep
+      character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval, config_dt
+      type (MPAS_TimeInterval_Type) :: coupling_interval, force_interval, dt_interval, restart_interval, zero_interval
       type (MPAS_Time_Type) :: start_time
       character (len=StrKIND), pointer :: simulationStartTime
       integer :: YYYY, MM, DD, H, M, S  ! time components
@@ -1011,10 +1012,15 @@ contains
       err = 0
       err_tmp = 0
 
+      call mpas_log_write("")
+      call mpas_log_write("-- Checking consistency of config_slm_coupling_interval and other settings --")
+
       ! First, check consistency in coupling interval set up in MALI and SLM
       call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
-      if (config_slm_coupling_interval /= slm_dt1) then
-         call mpas_log_write("The coupling interval in MALI ($i) and SLM ($i) are inconsistent", MPAS_LOG_ERR, &
+      if (config_slm_coupling_interval == slm_dt1) then
+         call mpas_log_write("The coupling interval in MALI ($i yr) and SLM ($i yr) are consistent - check passes")
+      else
+         call mpas_log_write("The coupling interval in MALI ($i yr) and SLM ($i yr) are inconsistent", MPAS_LOG_ERR, &
                  intArgs=(/config_slm_coupling_interval, slm_dt1/))
          err = ior(err, 1)
       endif
@@ -1028,18 +1034,35 @@ contains
       call mpas_set_timeInterval(coupling_interval, YY=config_slm_coupling_interval, MM=0, DD=0, H=0, M=0, S=0, ierr=err_tmp)
       err = ior(err, err_tmp)
 
-      ! Check that config_adaptive_timestep_force_interval divides evenly into config_slm_coupling_interval
-      call mpas_pool_get_config(liConfigs, "config_adaptive_timestep_force_interval", config_adaptive_timestep_force_interval)
-      call mpas_set_timeInterval(force_interval, timeString=config_adaptive_timestep_force_interval, ierr=err_tmp)
-      err = ior(err, err_tmp)
-      call mpas_interval_division(start_time, coupling_interval, force_interval, n_intervals, remainder)
-      if (remainder .EQ. zero_interval) then
-         call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
+      call mpas_pool_get_config(liConfigs, "config_adaptive_timestep", config_adaptive_timestep)
+      if (config_adaptive_timestep) then
+         ! for adaptive dt, check that config_adaptive_timestep_force_interval divides evenly into config_slm_coupling_interval
+         call mpas_pool_get_config(liConfigs, "config_adaptive_timestep_force_interval", config_adaptive_timestep_force_interval)
+         call mpas_set_timeInterval(force_interval, timeString=config_adaptive_timestep_force_interval, ierr=err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_interval_division(start_time, coupling_interval, force_interval, n_intervals, remainder)
+         if (remainder .EQ. zero_interval) then
+            call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
                  "with no remainder - check passes", intArgs=(/int(n_intervals)/))
-      else
-         call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
+         else
+            call mpas_log_write("config_adaptive_timestep_force_interval divides into config_slm_coupling_interval $i times " // &
                  "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
-         err = ior(err, 1)
+            err = ior(err, 1)
+         endif
+      else
+        ! For fixed dt, check that dt divides evenly into config_slm_coupling_interval
+         call mpas_pool_get_config(liConfigs, "config_dt", config_dt)
+         call mpas_set_timeInterval(dt_interval, timeString=config_dt, ierr=err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_interval_division(start_time, coupling_interval, dt_interval, n_intervals, remainder)
+         if (remainder .EQ. zero_interval) then
+            call mpas_log_write("config_dt divides into config_slm_coupling_interval $i times " // &
+                 "with no remainder - check passes", intArgs=(/int(n_intervals)/))
+         else
+            call mpas_log_write("config_dt divides into config_slm_coupling_interval $i times " // &
+                 "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
+            err = ior(err, 1)
+         endif
       endif
 
       ! Now check that restart interval is an even multiple of coupling interval
@@ -1061,6 +1084,7 @@ contains
 
          stream_cursor => stream_cursor % next
       enddo
+      call mpas_log_write("")
 
    !--------------------------------------------------------------------
    end subroutine check_SLM_coupling_interval

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -388,20 +388,14 @@ contains
 
 #ifdef USE_SEALEVELMODEL
       logical, pointer :: config_do_restart
-      integer, pointer :: config_slm_timestep_restart
-      character (len=StrKIND), pointer :: config_slm_coupling_interval
-      character (len=StrKIND), pointer :: xtime, simulationStartTime
       type (mpas_pool_type), pointer :: meshPool     !< mesh information
       type (mpas_pool_type), pointer :: geometryPool
-      type (MPAS_Time_Type) :: currTime !< current time as time type
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       real (kind=RKIND), dimension(:), allocatable :: meshMask
       real (kind=RKIND), dimension(nglv,2*nglv) :: ismIceload, ismBedtopo, ismMask
       real (kind=RKIND), dimension(nglv*2*nglv) :: thicknessSLgrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: bedtopoSLgrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: maskSLgrid1D
-      integer :: slm_coupling_interval, slmRestartYear, slmTimeStep_restart
-      integer :: currYear, simulationStartYear
       integer :: err_tmp
       integer :: unit_num_slm  ! SLM variable
       integer :: itersl, dtime ! SLM variable
@@ -445,6 +439,15 @@ contains
          unit_num_slm = domain % logInfo % outputLog % unitNum
          call sl_set_unit_num(unit_num_slm)
 
+         call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
+
+         ! First, check consistency in coupling interval set up in MALI and SLM
+         call check_SLM_coupling_interval(dtime, domain % streamManager, err_tmp)
+         err = ior(err, err_tmp)
+         if (err /= 0) then
+            return
+         endif
+
          ! Set Displacement variable for GATHERV command
          nCellsGlobal = sum(nCellsPerProc)
          allocate(indexToCellIDGathered(nCellsGlobal))
@@ -467,37 +470,11 @@ contains
       ! check if the run is a restart or not
       call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
       if (config_do_restart) then
-         ! find the right slmTimeStep
-         call mpas_pool_get_config(liConfigs,'config_slm_coupling_interval', config_slm_coupling_interval)
-         read(config_slm_coupling_interval(1:4),*) slm_coupling_interval
-         call mpas_pool_get_config(liConfigs,'config_slm_timestep_restart', config_slm_timestep_restart)
-         slmTimeStep = config_slm_timestep_restart
 
-         ! check if the timestep is setup properly
-         ! get the simulation start time
-         call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
-         read(simulationStartTime(1:4),*) simulationStartYear
-
-         ! get the current (restart) time
-         call mpas_pool_get_array(meshPool, 'xtime', xtime)
-         read(xtime(1:4),*) currYear
-
-         ! take the difference and divide by the coupling interval
-         slmTimeStep_restart = ( currYear - simulationStartYear ) / slm_coupling_interval
-
-         ! if the result is not equal to the defined slmTimeStep, raise an error.
-         if (slmTimeStep /= slmTimeStep_restart) then
-            slmRestartYear = ( slmTimeStep * slm_coupling_interval ) + simulationStartYear
-            call mpas_log_write("Restart year from SLM restart timestep and MALI restart time &
-                 are inconsistent", MPAS_LOG_ERR)
-            call mpas_log_write("Problem: Restart year based on `config_slm_timestep_restart` &
-                 is $i, but MALI restart year is set to $i.", &
-                 intArgs=(/slmRestartYear, currYear/))
-            err = ior(err,1)
-         else
-            call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
-            call slmodel_solve(slmTimeStep, domain)
-         endif
+         call find_slm_restart_timestep(meshPool, slmTimeStep, err_tmp)
+         err = ior(err, err_tmp)
+         call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
+         call slmodel_solve(slmTimeStep, domain)
 
       else
 
@@ -534,16 +511,6 @@ contains
 
          if (curProc.eq.0) then
 
-            ! First, check consistency in coupling interval set up in MALI and SLM
-            err = 0
-            call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
-            read(config_slm_coupling_interval(1:4),*) slm_coupling_interval
-            call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
-            if (slm_coupling_interval .NE. dtime) then
-               call mpas_log_write("The coupling interval in MALI and SLM settings are inconsistent", &
-                    MPAS_LOG_ERR)
-               err = ior(err,1)
-            endif
             ! Rearrange data into CellID order
             do iCell = 1,nCellsGlobal
                globalArrayThickness(indexToCellIDGathered(iCell)) = gatheredArrayThickness(iCell)
@@ -992,6 +959,177 @@ contains
    !--------------------------------------------------------------------
    end subroutine check
 
+
+!***********************************************************************
+!
+!  routine check_SLM_coupling_interval
+!
+!> \brief   Perform various checks on the SLM coupling interval setting
+!> \author  Matt Hoffman
+!> \date    Feb 2024
+!> \details
+!>  This routine checks that the SLM coupling interval is an even multiple
+!>  of the adaptive timestep force inverval and divides evenly into the
+!>  restart interval.  It also checks that the coupling interval in the MALI
+!>  matches the value in the SLM namelist.
+!
+!-----------------------------------------------------------------------
+
+   subroutine check_SLM_coupling_interval(slm_dt1, streamManager, err)
+
+      use mpas_timekeeping
+      use mpas_stream_manager
+      use mpas_derived_types, only : MPAS_STREAM_PROPERTY_RECORD_INTV
+
+      integer, intent (in) :: slm_dt1
+      type (MPAS_streamManager_type), intent(inout) :: streamManager
+      integer, intent(out) :: err
+
+      ! local variables
+      integer, pointer :: config_slm_coupling_interval
+      character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval
+      type (MPAS_Time_Type) :: force_interval, restart_interval
+      character(len=StrKIND) :: restart_interval_str
+      integer :: YYYY, MM, DD, H, M, S  ! time components
+      type (MPAS_stream_list_type), pointer :: stream_cursor
+      integer :: err_tmp
+
+      err = 0
+
+      ! First, check consistency in coupling interval set up in MALI and SLM
+      call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
+      if (config_slm_coupling_interval /= slm_dt1) then
+         call mpas_log_write("The coupling interval in MALI and SLM settings are inconsistent", MPAS_LOG_ERR)
+         err = ior(err,1)
+      endif
+
+      ! Check that config_adaptive_timestep_force_interval divides evenly into config_slm_coupling_interval
+      call mpas_pool_get_config(liConfigs, "config_adaptive_timestep_force_interval", config_adaptive_timestep_force_interval)
+      ! Note: Using mpas_set_time instead of mpas_set_time_interval, even though this is an interval
+      ! This is because mpas_get_time_interval requires a reference time, which is not relevant
+      ! to these checks, and mpas_get_time allows us to get the component pieces that we want to check.
+      call mpas_set_time(force_interval, dateTimeString=config_adaptive_timestep_force_interval, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_get_time(force_interval, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
+      if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
+         call mpas_log_write("config_adaptive_timestep_force_interval currently not supported " // &
+              "to have nonzero values for months, days, hours, minutes, or seconds when sea-level model " // &
+              "is coupled.  config_adaptive_timestep_force_interval=" //trim(config_adaptive_timestep_force_interval), MPAS_LOG_ERR)
+         ! Note: the actual requirement is that adapt dt force interval divides evenly into coupling interval
+         ! but that is tricky to check, and wanting anything but even years for that option is a rare use case.
+         err = ior(err, 1)
+      endif
+      ! Next check the number of years divides evenly into SLM coupling interval
+      if (mod(config_slm_coupling_interval, YYYY) /= 0) then
+         call mpas_log_write("config_adaptive_timestep_force_interval does not divide evenly into config_slm_coupling_interval" // &
+              "config_adaptive_timestep_force_interval=" // trim(config_adaptive_timestep_force_interval) // &
+              "; config_slm_coupling_interval=$i", MPAS_LOG_ERR, intArgs=(/config_slm_coupling_interval/))
+         err = ior(err, 1)
+      endif
+
+      ! Now check that restart interval is an even multiple of coupling interval
+      stream_cursor => streamManager % streams % head
+      do while (associated(stream_cursor))
+         if ( trim(stream_cursor % name) == 'restart' .and. (stream_cursor % valid) ) then
+            call MPAS_stream_mgr_get_property(streamManager, 'restart', MPAS_STREAM_PROPERTY_RECORD_INTV, &
+                 restart_interval_str, ierr=err_tmp)
+            err = ior(err, err_tmp)
+
+            call mpas_log_write('restart interval is: ' //trim(restart_interval_str))
+
+            call mpas_set_time(restart_interval, dateTimeString=restart_interval_str, ierr=err_tmp)
+            err = ior(err, err_tmp)
+            call mpas_get_time(restart_interval, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
+            if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
+               call mpas_log_write("If Sea Level Model is active, restart output_interval cannot include " // &
+                    "nonzero months, days, hours, minutes or seconds.  restart output_interval=" // &
+                    trim(restart_interval_str), MPAS_LOG_ERR)
+            endif
+            err = ior(err, 1)
+
+            if (mod(YYYY, config_slm_coupling_interval) /= 0) then
+               call mpas_log_write("restart output_interval must be a multiple of config_slm_coupling_interval", MPAS_LOG_ERR)
+               err = ior(err, 1)
+            endif
+
+         endif
+      enddo
+
+   !--------------------------------------------------------------------
+   end subroutine check_SLM_coupling_interval
+
+
+!***********************************************************************
+!
+!  routine find_slm_restart_timestep
+!
+!> \brief   Perform various checks on the SLM coupling interval setting
+!> \author  Matt Hoffman
+!> \date    Feb 2024
+!> \details
+!>  This routine checks that the SLM coupling interval is an even multiple
+!>  of the adaptive timestep force inverval and divides evenly into the
+!>  restart interval.  It also checks that the coupling interval in the MALI
+!>  matches the value in the SLM namelist.
+!
+!-----------------------------------------------------------------------
+
+   subroutine find_slm_restart_timestep(meshPool, slmTimeStep, err)
+
+      use mpas_timekeeping
+
+      type (mpas_pool_type), intent(in) :: meshPool  !< mesh information
+      integer, intent(out) :: slmTimeStep
+      integer, intent(out) :: err
+
+      ! local vars
+      integer, pointer :: config_slm_coupling_interval
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
+      character (len=StrKIND) :: elapsed_time_str
+      type (MPAS_Time_Type) :: start_time, curr_time
+      type (MPAS_Time_Type) :: elapsed_time ! should be a time interval but not possible to get years that way
+      integer :: YYYY, MM, DD, H, M, S  ! time components
+      integer :: err_tmp
+
+      err = 0
+
+      slmTimeStep = -999  ! initialize to bad number
+
+      call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
+
+      call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
+      call mpas_pool_get_array(meshPool, 'xtime', xtime)
+      call mpas_set_time(start_time, dateTimeString=simulationStartTime, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_set_time(curr_time, dateTimeString=xtime, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_get_timeInterval(curr_time - start_time, start_time, timeString=elapsed_time_str, ierr=err_tmp)
+      err = ior(err, err_tmp)
+
+      ! convert elapsed time string to its units. Using the intermediate string format because mpas_get_timeInterval doesn't return
+      ! years, and figuring out years from days depends on the calendar
+      call mpas_set_time(elapsed_time, dateTimeString=elapsed_time_str, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_get_time(elapsed_time, YYYY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S)
+
+      ! make sure the elapsed time is an even year
+      if ((MM /= 0) .or. (DD /= 0) .or. (H /= 0) .or. (M /= 0) .or. (S /= 0)) then
+         call mpas_log_write("Elapsed time since simulationStartTime include nonzero months, days, hours, minutes, " // &
+                 "or seconds.", MPAS_LOG_ERR)
+         err = ior(err, 1)
+      endif
+
+      if (mod(YYYY, config_slm_coupling_interval) == 0) then
+         ! We can restart cleanly
+         slmTimeStep = YYYY / config_slm_coupling_interval
+      else
+         call mpas_log_write("Elapsed years since simulationStartTime is not evenly divisible by config_slm_coupling_interval." // &
+                 " Unable to restart Sea Level Model cleanly.", MPAS_LOG_ERR)
+         err = ior(err, 1)
+      endif
+
+   !--------------------------------------------------------------------
+   end subroutine find_slm_restart_timestep
 
 !***********************************************************************
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -115,6 +115,7 @@ contains
       !-----------------------------------------------------------------
 
       character (len=StrKIND), pointer :: config_uplift_method
+      integer :: err_tmp
 
       ! No init is needed.
       err = 0
@@ -122,7 +123,12 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_uplift_method', config_uplift_method)
       if (trim(config_uplift_method)=='sealevelmodel') then
          ! initialize the 1D sea-level model if fresh start
-         call slmodel_init(domain, err)
+         call slmodel_init(domain, err_tmp)
+         err = ior(err, err_tmp)
+
+         if (err /= 0) then
+            call mpas_log_write('Error in li_bedtopo_init', MPAS_LOG_ERR)
+         endif
       endif
 
    !--------------------------------------------------------------------
@@ -445,7 +451,7 @@ contains
          call check_SLM_coupling_interval(dtime, domain % streamManager, err_tmp)
          err = ior(err, err_tmp)
          if (err /= 0) then
-            return
+            call mpas_log_write("Error occurred in check_SLM_coupling_interval.", MPAS_LOG_ERR)
          endif
 
          ! Set Displacement variable for GATHERV command
@@ -473,8 +479,10 @@ contains
 
          call find_slm_restart_timestep(meshPool, slmTimeStep, err_tmp)
          err = ior(err, err_tmp)
-         call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
-         call slmodel_solve(slmTimeStep, domain)
+         if (err == 0) then
+            call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
+            call slmodel_solve(slmTimeStep, domain)
+         endif
 
       else
 
@@ -532,11 +540,13 @@ contains
             slmTimeStep = 0
 
             ! series of calling SLM routines
-            call sl_call_readnl
-            call sl_solver_checkpoint(itersl, dtime)
-            call sl_timewindow(slmTimeStep)
-            call sl_solver_init(itersl, starttime, ismIceload, ismBedtopo, ismMask)
-            call sl_deallocate_array
+            if (err == 0) then
+               call sl_call_readnl
+               call sl_solver_checkpoint(itersl, dtime)
+               call sl_timewindow(slmTimeStep)
+               call sl_solver_init(itersl, starttime, ismIceload, ismBedtopo, ismMask)
+               call sl_deallocate_array
+            endif
 
          endif
          deallocate(globalArrayThickness)
@@ -995,12 +1005,14 @@ contains
       integer :: err_tmp
 
       err = 0
+      err_tmp = 0
 
       ! First, check consistency in coupling interval set up in MALI and SLM
       call mpas_pool_get_config(liConfigs, "config_slm_coupling_interval", config_slm_coupling_interval)
       if (config_slm_coupling_interval /= slm_dt1) then
-         call mpas_log_write("The coupling interval in MALI and SLM settings are inconsistent", MPAS_LOG_ERR)
-         err = ior(err,1)
+         call mpas_log_write("The coupling interval in MALI ($i) and SLM ($i) are inconsistent", MPAS_LOG_ERR, &
+                 intArgs=(/config_slm_coupling_interval, slm_dt1/))
+         err = ior(err, 1)
       endif
 
       ! Check that config_adaptive_timestep_force_interval divides evenly into config_slm_coupling_interval
@@ -1015,6 +1027,7 @@ contains
          call mpas_log_write("config_adaptive_timestep_force_interval currently not supported " // &
               "to have nonzero values for months, days, hours, minutes, or seconds when sea-level model " // &
               "is coupled.  config_adaptive_timestep_force_interval=" //trim(config_adaptive_timestep_force_interval), MPAS_LOG_ERR)
+         call mpas_log_write("  MM=$i, DD=$i, H=$i, M=$i, S=$i", intArgs=(/MM, DD, H, M, S/))
          ! Note: the actual requirement is that adapt dt force interval divides evenly into coupling interval
          ! but that is tricky to check, and wanting anything but even years for that option is a rare use case.
          err = ior(err, 1)
@@ -1030,7 +1043,8 @@ contains
       ! Now check that restart interval is an even multiple of coupling interval
       stream_cursor => streamManager % streams % head
       do while (associated(stream_cursor))
-         if ( trim(stream_cursor % name) == 'restart' .and. (stream_cursor % valid) ) then
+         if ( trim(stream_cursor % name) == 'restart' .and. (stream_cursor % active_stream) ) then
+            call mpas_log_write("Checking restart interval against SLM coulping interval")
             call MPAS_stream_mgr_get_property(streamManager, 'restart', MPAS_STREAM_PROPERTY_RECORD_INTV, &
                  restart_interval_str, ierr=err_tmp)
             err = ior(err, err_tmp)
@@ -1044,8 +1058,8 @@ contains
                call mpas_log_write("If Sea Level Model is active, restart output_interval cannot include " // &
                     "nonzero months, days, hours, minutes or seconds.  restart output_interval=" // &
                     trim(restart_interval_str), MPAS_LOG_ERR)
+               err = ior(err, 1)
             endif
-            err = ior(err, 1)
 
             if (mod(YYYY, config_slm_coupling_interval) /= 0) then
                call mpas_log_write("restart output_interval must be a multiple of config_slm_coupling_interval", MPAS_LOG_ERR)
@@ -1053,6 +1067,8 @@ contains
             endif
 
          endif
+
+         stream_cursor => stream_cursor % next
       enddo
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -1080,6 +1080,7 @@ contains
             else
                call mpas_log_write("config_slm_coupling_interval divides into restart interval $i times " // &
                  "with nonzero remainder", MPAS_LOG_ERR, intArgs=(/int(n_intervals)/))
+               err = ior(err, 1)
             endif
          endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_bedtopo.F
@@ -121,7 +121,7 @@ contains
 
       call mpas_pool_get_config(liConfigs, 'config_uplift_method', config_uplift_method)
       if (trim(config_uplift_method)=='sealevelmodel') then
-         ! initialize the 1D sea-level model
+         ! initialize the 1D sea-level model if fresh start
          call slmodel_init(domain, err)
       endif
 
@@ -362,6 +362,7 @@ contains
    subroutine slmodel_init(domain, err)
 
 #ifdef USE_SEALEVELMODEL
+      use mpas_timekeeping
       use sl_model_mod                    !< this is part of the SLM code
       use sl_io_mod                       !< this is part of the SLM code
       use user_specs_mod, only: nglv      !< this is part of the SLM code
@@ -386,16 +387,21 @@ contains
       !-----------------------------------------------------------------
 
 #ifdef USE_SEALEVELMODEL
+      logical, pointer :: config_do_restart
+      integer, pointer :: config_slm_timestep_restart
       character (len=StrKIND), pointer :: config_slm_coupling_interval
+      character (len=StrKIND), pointer :: xtime, simulationStartTime
       type (mpas_pool_type), pointer :: meshPool     !< mesh information
       type (mpas_pool_type), pointer :: geometryPool
+      type (MPAS_Time_Type) :: currTime !< current time as time type
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       real (kind=RKIND), dimension(:), allocatable :: meshMask
       real (kind=RKIND), dimension(nglv,2*nglv) :: ismIceload, ismBedtopo, ismMask
       real (kind=RKIND), dimension(nglv*2*nglv) :: thicknessSLgrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: bedtopoSLgrid1D
       real (kind=RKIND), dimension(nglv*2*nglv) :: maskSLgrid1D
-      integer :: slm_coupling_interval
+      integer :: slm_coupling_interval, slmRestartYear, slmTimeStep_restart
+      integer :: currYear, simulationStartYear
       integer :: err_tmp
       integer :: unit_num_slm  ! SLM variable
       integer :: itersl, dtime ! SLM variable
@@ -431,11 +437,15 @@ contains
 
       ! Gather nCellsOwned
       call MPI_GATHER( nCellsOwned, 1, MPI_INTEGER, nCellsPerProc, 1, MPI_INTEGER, &
-                       0, domain % dminfo % comm, err_tmp)
+      0, domain % dminfo % comm, err_tmp)
       err = ior(err, err_tmp)
 
-      ! Set Displacement variable for GATHERV command
       if (curProc.eq.0) then
+         ! First, set SLM unit number to the MALI output log file unit
+         unit_num_slm = domain % logInfo % outputLog % unitNum
+         call sl_set_unit_num(unit_num_slm)
+
+         ! Set Displacement variable for GATHERV command
          nCellsGlobal = sum(nCellsPerProc)
          allocate(indexToCellIDGathered(nCellsGlobal))
          nCellsDisplacement(1) = 0
@@ -451,89 +461,124 @@ contains
 
       ! Gather indexToCellID
       call MPI_GATHERV( indexToCellID, nCellsOwned, MPI_INTEGER, indexToCellIDGathered, &
-              nCellsPerProc, nCellsDisplacement, MPI_INTEGER, 0, domain % dminfo % comm, err_tmp)
+      nCellsPerProc, nCellsDisplacement, MPI_INTEGER, 0, domain % dminfo % comm, err_tmp)
       err = ior(err, err_tmp)
 
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-
-      if (curProc.eq.0) then
-         allocate(globalArrayThickness(nCellsGlobal), gatheredArrayThickness(nCellsGlobal))
-         allocate(globalArrayBedTopography(nCellsGlobal), gatheredArrayBedTopography(nCellsGlobal))
-         allocate(meshMask(nCellsGlobal))
-         ismIceload(:,:) = 0.0
-         ismBedtopo(:,:) = 0.0
-         ismMask(:,:) = 0.0
-         bedtopoSLgrid1D(:) = 0.0
-         thicknessSLgrid1D(:) = 0.0
-         maskSLgrid1D(:) = 0.0
-      else
-         ! Intel requires these be allocated even though they are not meaningful on the non-destination procs
-         allocate(globalArrayThickness(1), gatheredArrayThickness(1))
-         allocate(globalArrayBedTopography(1), gatheredArrayBedTopography(1))
-         allocate(meshMask(1))
-      endif
-
-      ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
-      call MPI_GATHERV((thickness*real(li_mask_is_grounded_ice_int(cellMask),RKIND)), &
-             nCellsOwned, MPI_DOUBLE, gatheredArrayThickness, nCellsPerProc, &
-             nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err_tmp)
-      err = ior(err, err_tmp)
-      call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArrayBedTopography, nCellsPerProc, &
-                       nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err_tmp)
-      err = ior(err, err_tmp)
-
-      if (curProc.eq.0) then
-
-         ! First, check consistency in coupling interval set up in MALI and SLM
-         err = 0
-         call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+      ! check if the run is a restart or not
+      call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
+      if (config_do_restart) then
+         ! find the right slmTimeStep
+         call mpas_pool_get_config(liConfigs,'config_slm_coupling_interval', config_slm_coupling_interval)
          read(config_slm_coupling_interval(1:4),*) slm_coupling_interval
-         call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
-         if (slm_coupling_interval .NE. dtime) then
-            call mpas_log_write("The coupling interval in MALI and SLM settings are inconsistent", &
-                 MPAS_LOG_ERR)
+         call mpas_pool_get_config(liConfigs,'config_slm_timestep_restart', config_slm_timestep_restart)
+         slmTimeStep = config_slm_timestep_restart
+
+         ! check if the timestep is setup properly
+         ! get the simulation start time
+         call mpas_pool_get_array(meshPool, 'simulationStartTime', simulationStartTime)
+         read(simulationStartTime(1:4),*) simulationStartYear
+
+         ! get the current (restart) time
+         call mpas_pool_get_array(meshPool, 'xtime', xtime)
+         read(xtime(1:4),*) currYear
+
+         ! take the difference and divide by the coupling interval
+         slmTimeStep_restart = ( currYear - simulationStartYear ) / slm_coupling_interval
+
+         ! if the result is not equal to the defined slmTimeStep, raise an error.
+         if (slmTimeStep /= slmTimeStep_restart) then
+            slmRestartYear = ( slmTimeStep * slm_coupling_interval ) + simulationStartYear
+            call mpas_log_write("Restart year from SLM restart timestep and MALI restart time &
+                 are inconsistent", MPAS_LOG_ERR)
+            call mpas_log_write("Problem: Restart year based on `config_slm_timestep_restart` &
+                 is $i, but MALI restart year is set to $i.", &
+                 intArgs=(/slmRestartYear, currYear/))
             err = ior(err,1)
+         else
+            call mpas_log_write("Calling the SLM. SLM timestep $i", intArgs=(/slmTimeStep/))
+            call slmodel_solve(slmTimeStep, domain)
          endif
-         ! Rearrange data into CellID order
-         do iCell = 1,nCellsGlobal
-            globalArrayThickness(indexToCellIDGathered(iCell)) = gatheredArrayThickness(iCell)
-            globalArrayBedTopography(indexToCellIDGathered(iCell)) = gatheredArrayBedTopography(iCell)
-            meshMask(indexToCellIDGathered(iCell)) = 1
-         enddo
 
-         ! interpolate thickness, bedTopograpy, mesh mask to the Gaussian grid
-         call interpolate(toColValues, toRowValues, toSvalues, globalArrayThickness, thicknessSLgrid1D)
-         call interpolate(toColValues, toRowValues, toSvalues, globalArrayBedTopography, bedtopoSLgrid1D)
-         call interpolate(toColValues, toRowValues, toSvalues, meshMask, maskSLgrid1D)
+      else
 
-         ! reformat the interpolated data
-         ismIceload = reshape(thicknessSLgrid1D, [nglv,2*nglv])
-         ismBedtopo = reshape(bedtopoSLgrid1D, [nglv,2*nglv])
-         ismMask = reshape(maskSLgrid1D, [nglv,2*nglv])
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+         call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
-         ! initialize coupling time step number. initial time is 0
-         slmTimeStep = 0
+         if (curProc.eq.0) then
+            allocate(globalArrayThickness(nCellsGlobal), gatheredArrayThickness(nCellsGlobal))
+            allocate(globalArrayBedTopography(nCellsGlobal), gatheredArrayBedTopography(nCellsGlobal))
+            allocate(meshMask(nCellsGlobal))
+            ismIceload(:,:) = 0.0
+            ismBedtopo(:,:) = 0.0
+            ismMask(:,:) = 0.0
+            bedtopoSLgrid1D(:) = 0.0
+            thicknessSLgrid1D(:) = 0.0
+            maskSLgrid1D(:) = 0.0
+         else
+            ! Intel requires these be allocated even though they are not meaningful on the non-destination procs
+            allocate(globalArrayThickness(1), gatheredArrayThickness(1))
+            allocate(globalArrayBedTopography(1), gatheredArrayBedTopography(1))
+            allocate(meshMask(1))
+         endif
 
-         ! set SLM unit number to the MALI output log file unit
-         unit_num_slm = domain % logInfo % outputLog % unitNum
+         ! Gather only the nCellsOwned from thickness and bedtopo (does not include Halos)
+         call MPI_GATHERV((thickness*real(li_mask_is_grounded_ice_int(cellMask),RKIND)), &
+                nCellsOwned, MPI_DOUBLE, gatheredArrayThickness, nCellsPerProc, &
+                nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err_tmp)
+         err = ior(err, err_tmp)
+         call MPI_GATHERV(bedTopography, nCellsOwned, MPI_DOUBLE, gatheredArrayBedTopography, nCellsPerProc, &
+                          nCellsDisplacement, MPI_DOUBLE, 0, domain % dminfo % comm, err_tmp)
+         err = ior(err, err_tmp)
 
-         ! series of calling SLM routines
-         call sl_set_unit_num(unit_num_slm)
-         call sl_call_readnl
-         call sl_solver_checkpoint(itersl, dtime)
-         call sl_timewindow(slmTimeStep)
-         call sl_solver_init(itersl, starttime, ismIceload, ismBedtopo, ismMask)
-         call sl_deallocate_array
+         if (curProc.eq.0) then
 
-      endif
-      deallocate(globalArrayThickness)
-      deallocate(gatheredArrayThickness)
-      deallocate(globalArrayBedTopography)
-      deallocate(gatheredArrayBedTopography)
-      deallocate(meshMask)
+            ! First, check consistency in coupling interval set up in MALI and SLM
+            err = 0
+            call mpas_pool_get_config(liConfigs, 'config_slm_coupling_interval', config_slm_coupling_interval)
+            read(config_slm_coupling_interval(1:4),*) slm_coupling_interval
+            call sl_drive_readnl(itersl, dtime, starttime) !SLM subroutine
+            if (slm_coupling_interval .NE. dtime) then
+               call mpas_log_write("The coupling interval in MALI and SLM settings are inconsistent", &
+                    MPAS_LOG_ERR)
+               err = ior(err,1)
+            endif
+            ! Rearrange data into CellID order
+            do iCell = 1,nCellsGlobal
+               globalArrayThickness(indexToCellIDGathered(iCell)) = gatheredArrayThickness(iCell)
+               globalArrayBedTopography(indexToCellIDGathered(iCell)) = gatheredArrayBedTopography(iCell)
+               meshMask(indexToCellIDGathered(iCell)) = 1
+            enddo
+
+            ! interpolate thickness, bedTopograpy, mesh mask to the Gaussian grid
+            call interpolate(toColValues, toRowValues, toSvalues, globalArrayThickness, thicknessSLgrid1D)
+            call interpolate(toColValues, toRowValues, toSvalues, globalArrayBedTopography, bedtopoSLgrid1D)
+            call interpolate(toColValues, toRowValues, toSvalues, meshMask, maskSLgrid1D)
+
+            ! reformat the interpolated data
+            ismIceload = reshape(thicknessSLgrid1D, [nglv,2*nglv])
+            ismBedtopo = reshape(bedtopoSLgrid1D, [nglv,2*nglv])
+            ismMask = reshape(maskSLgrid1D, [nglv,2*nglv])
+
+            ! initialize coupling time step number. initial time is 0
+            slmTimeStep = 0
+
+            ! series of calling SLM routines
+            call sl_call_readnl
+            call sl_solver_checkpoint(itersl, dtime)
+            call sl_timewindow(slmTimeStep)
+            call sl_solver_init(itersl, starttime, ismIceload, ismBedtopo, ismMask)
+            call sl_deallocate_array
+
+         endif
+         deallocate(globalArrayThickness)
+         deallocate(gatheredArrayThickness)
+         deallocate(globalArrayBedTopography)
+         deallocate(gatheredArrayBedTopography)
+         deallocate(meshMask)
+
+      endif ! endif restart or not
 
 # else
       call mpas_log_write("The sea-level model needs to be included in the compilation with 'SLM=true'", &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -1105,13 +1105,11 @@ module li_core
       type (MPAS_Time_Type) :: startTime, stopTime, alarmStartTime
       type (MPAS_TimeInterval_type) :: runDuration, timeStep, alarmTimeStep
       type (MPAS_TimeInterval_type) :: adaptDtForceInterval
-      type (MPAS_TimeInterval_type) :: slm_coupling_interval
       character (len=StrKIND), pointer :: config_start_time, config_run_duration, config_stop_time, &
          config_output_interval, config_restart_interval ! MPAS standard configs
       character (len=StrKIND), pointer :: config_dt  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_restart_timestamp_name
-      character (len=StrKIND), pointer :: config_uplift_method
       integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND) :: restartTimeStamp !< string to be read from file
       integer, pointer :: config_year_digits
@@ -1131,7 +1129,6 @@ module li_core
       call mpas_pool_get_config(configs, 'config_stop_time', config_stop_time)
       call mpas_pool_get_config(configs, 'config_restart_timestamp_name', config_restart_timestamp_name)
       call mpas_pool_get_config(configs, 'config_adaptive_timestep_force_interval', config_adaptive_timestep_force_interval)
-      call mpas_pool_get_config(configs, 'config_uplift_method', config_uplift_method)
       call mpas_pool_get_config(configs, 'config_slm_coupling_interval', config_slm_coupling_interval)
 
 
@@ -1195,20 +1192,6 @@ module li_core
          ierr = ior(ierr, err_tmp)
       endif
       ierr = ior(ierr, err_tmp)
-
-      ! Set up the coupling time interval if MALI is coupled to sea-level model
-      if (trim(config_uplift_method) == "sealevelmodel") then
-         call mpas_set_timeInterval(slm_coupling_interval, YY=config_slm_coupling_interval, ierr=err_tmp)
-         ierr = ior(ierr,err_tmp)
-         call mpas_add_clock_alarm(core_clock, 'slmCouplingInterval', alarmTime=startTime, &
-              alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
-         ierr = ior(ierr,err_tmp)
-         if (mpas_is_alarm_ringing(core_clock, 'slmCouplingInterval', ierr=err_tmp)) then
-            ierr = ior(ierr, err_tmp)
-            call mpas_reset_clock_alarm(core_clock, 'slmCouplingInterval', ierr=err_tmp)
-            ierr = ior(ierr, err_tmp)
-         endif
-      endif
 
       ! === error check
       if (ierr /= 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -338,8 +338,8 @@ module li_core
       ! ===
       call li_velocity_external_write_albany_mesh(domain)
 
-      call mpas_dmpar_max_int(domain % dminfo, err, globalErr)  ! Find out if any blocks got an error
-      if (globalErr > 0) then
+      call mpas_dmpar_max_int(domain % dminfo, abs(err), globalErr)  ! Find out if any blocks got an error
+      if (globalErr /= 0) then
           call mpas_log_write("An error has occurred in li_core_init. Aborting...", MPAS_LOG_CRIT)
       endif
 
@@ -1111,7 +1111,8 @@ module li_core
       character (len=StrKIND), pointer :: config_dt  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_restart_timestamp_name
-      character (len=StrKIND), pointer :: config_uplift_method, config_slm_coupling_interval
+      character (len=StrKIND), pointer :: config_uplift_method
+      integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND) :: restartTimeStamp !< string to be read from file
       integer, pointer :: config_year_digits
       integer :: err_tmp
@@ -1197,7 +1198,7 @@ module li_core
 
       ! Set up the coupling time interval if MALI is coupled to sea-level model
       if (trim(config_uplift_method) == "sealevelmodel") then
-         call mpas_set_timeInterval(slm_coupling_interval, timeString=config_slm_coupling_interval, ierr=err_tmp)
+         call mpas_set_timeInterval(slm_coupling_interval, YY=config_slm_coupling_interval, ierr=err_tmp)
          ierr = ior(ierr,err_tmp)
          call mpas_add_clock_alarm(core_clock, 'slmCouplingInterval', alarmTime=startTime, &
               alarmTimeInterval=slm_coupling_interval, ierr=err_tmp)
@@ -1210,7 +1211,7 @@ module li_core
       endif
 
       ! === error check
-      if (ierr > 0) then
+      if (ierr /= 0) then
           call mpas_log_write("An error has occurred in li_simulation_clock_init.", MPAS_LOG_ERR)
       endif
 


### PR DESCRIPTION
Previously, when the regional sea-level prediction capability was added to MALI (https://github.com/MALI-Dev/E3SM/pull/21), the restart config option for the sea-level model was not added. This led the sea-level model to get initialized to Timestep zero when coupled MALI-SLM simulations are being restarted, forgetting about the ice loading changes and associated viscoelastic solid earth deformation that happened in the timesteps prior to current model time. This PR fixes the problem by allowing the sea-level model to resume where it was left off. Note in parallel to this PR, the version of the SLM needs to incorporate the changes made in the following accompanying PR (https://github.com/MALI-Dev/1DSeaLevelModel_FWTW/pull/9)

**Testing results (on Chicoma)**
Test directory: `/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512`

This test utilizes the `compass/landice/slm/circicesheet` test group (hollyhan:hollyhan/compass/landice/slm_circ_icesheet) in setting a coupled MALI-SLM simulation on MALI 20km rectangular grid with cylindrical ice sheet retreating 2km radius per year and SLM SH512 resolution. 

The following config options can be used to setup the circular ice sheet test case on chicoma:
```
# Config options for slm circ_icesheet test case
[circ_icesheet]

# The size of the domain in meters in the x and y directions for the planar mesh
lx = 6000000.0
ly = 6000000.0

# list of MALI mesh resolutions in kilometers delimited by ',' without space
# i.e. The distance between adjacent cell centers.
mali_res = 20

# Ice shape type ('cylinder', and for dome, 'dome-halfar' or 'dome-cism')
# r0 and h0: initial radius and height of the cylinder ice in meters
ice_type = cylinder
r0 = 2000000.0
h0 = 3000.0

# 'True' if manually want to set bedTopography elevation
# bed topography elevation in meters (provide a positive/negative float value
# for grounded above land/marine-based ice)
set_topo_elev = True
topo_elev = -1500.0

# Whether to center the circular ice in the center of the cell that is closest to the
# center of the domain
put_origin_on_a_cell = False

# Config options for surface mass balance forcing
[smb_forcing]

# Start, end and interval years for SMB forcing
start_year = 2015
end_year = 2116
dt_year = 1

# Direction in which SMB is applied ('horizontal' or 'vertical')
# and amount of ice to melt
direction = horizontal
# Change in radius in meters; used when 'direction == horizontal'
drdt = -2000.0
# Change in height in meters;sed when 'direction == vertical'
dhdt = -20.0

# config options for the sea-level model
[slm]
# True if MALI-SLM are coupled
coupling = True

# List of the number of Gauss-Legendre points in latitude
# delimited by ',' without space
slm_nglv = 512

# Max spherical harmonics degree and order
# i.e. SLM resolution of the SLM
slm_res = 512

# mapping method between the MALI and SLM grids
mapping_method_mali_to_slm = conserve
mapping_method_slm_to_mali = bilinear

# ratio of MALI-SLM coupling interval and MALI output interval in integer years
time_stride = 1

# config options related to visualization
[circ_icesheet_viz]

# Area (m^2) of the global ocean for calculating ice sheet contribution to
# sea level. Only used when MALI-SLM coupling is False
Aocn_const = 4.5007E+14

# Area (m^2) of the global ocean excluding the marine-based ice region
# only used when MALI-SLM coupling is False
AocnBeta_const = 4.50007E+14

# whether to save image files
save_images = True

# whether to hide figures (typically when save_images = True)
hide_figs = True
```
Version of SLM used: [SHA 286336ddd1ea884f9c397729511853e9f6fd276a added on top of the head of `origin/main` (SHA 42478dd3c3eefaeeb71d45dc7c8db7f42795519b)]
Temporal resolution of the SMB forcing applied to MALI: 1 yr
Coupling interval between MALI and the SLM: 5 yrs
Simulation start/end year: 2015/2045
Coupled simulation length: 40 yrs
Total number of SLM step in full simulation: 8 (40 yrs divided by 5 yrs)

**Test simulations setup**
**Simulation 1: Cold-start simulations 
**Simulation 1-1:Benchmark run where MALI runs from a cold start**
Version of MALI used: [SHA 859158a6fb6e4c7d1f8a0840651673ffeef9d427]
(`/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_coldStart/folder_maliHead_3079c717b3/OUTPUT_SLM`)
Plot showing the changes in gravitational potential over 40 simulation years:
![image](https://github.com/MALI-Dev/E3SM/assets/33441196/557449f0-beb2-4975-bb7a-bde4967432c8)

**Simulation 1-2: Cold start with the head of this PR [SHA 35bed8a9e6]**
(`/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_coldStart/folder_maliHead_35bed8a9e6/OUTPUT_SLM`)
Difference in deltaG field (change in gravity potential over 40 years): Calculated by subtracting the result from the benchmark simulation (Simulation 1-1) from the result from this simulation (Sim. 1-2).
![image](https://github.com/MALI-Dev/E3SM/assets/33441196/05c2fe97-0c56-4fc4-a3b5-a7d7b96dd49b)

**Simulation 2: Coupled simulation restarts from simulation year 30** (`/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_reStart`)

        Simulation 2-1. The namelist option `config_slm_timestep_restart` and the MALI restart year are CORRECTLY set such that the SLM timestep at the restart year match the MALI restart year (note that this creates a constraint on MALI restart year to the years that SLM is called):
                        -	MALI restart year = 2045
                        -	Config_slm_timestep_restart = 6 (SLM restart year = 2015 (start year) +  5 yr(couping interval) * 6 (timestep) = 2045)
           Changes in the gravitational equipotential field between 2015 and 2045 (file `G8.nc` in `/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_reStart/OUTPUT_SLM_slmRestartYear2045_maliRestartYear2045/G8.nc`):
![image](https://github.com/MALI-Dev/E3SM/assets/33441196/beb3b6ef-9174-455d-9bb4-48ebbd73ff77)
          Difference in the fields above to the same field calculated by the benchmark simulation (Simulation #1-1) shows zero difference:
![image](https://github.com/MALI-Dev/E3SM/assets/33441196/745c5523-75bd-4dec-9ca6-b2f4f462eb13)
(The difference file is located here:`/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_reStart/OUTPUT_SLM_slmRestartYear2045_maliRestartYear2045/diff_G8_to_originDevelop.nc`


        Simulation 2-2. The namelist option `config_slm_timestep_restart` and the MALI restart year are INCORRECTLY set to reflect the same year. 
                        -	MALI restart year = 2045
                        -	config_slm_timestep_restart = 5 (SLM restart year = 2015 (start year) +  5 yr(couping interval) * 5 (timestep) = 2040)
                       
          In this case, an error is raised for the inconsistency in restart year in MALI and the SLM. 
          `log.landice.0000.err` file shows, 
```
----------------------------------------------------------------------
Beginning MPAS-landice Error Log File for task       0 of     128
    Opened at 2024/01/13 17:18:19
----------------------------------------------------------------------

ERROR: Restart year from SLM restart timestep and MALI restart time are inconsistent
CRITICAL ERROR: An error has occurred in li_core_init. Aborting...
Logging complete.  Closing file at 2024/01/13 17:18:19
```
and `log.landice.0000.out` file dies with the following message:
```
 This is a restart: read stream 'restart'.
 Looking for recurring input streams (forcing) that should be forced to be read at the initial time.
   * Forced an initial read of input stream 'smb' from time: 2045-01-01_00:00:00
 Finished processing recurring input streams at initial time.
 Using none velocity solver.
ERROR: Restart year from SLM restart timestep and MALI restart time are inconsistent
 Problem: Restart year based on `config_slm_timestep_restart` is 2040, but MALI restart year is set to 2045.
CRITICAL ERROR: An error has occurred in li_core_init. Aborting...

 -----------------------------------------
 Total log messages printed:
    Output messages =                  324
    Warning messages =                   0
    Error messages =                     1
    Critical error messages =            1
 -----------------------------------------
 Logging complete.  Closing file at 2024/01/13 17:18:19
```
The log files can be found here: `/lustre/scratch4/turquoise/hollyhan/testPR_restart_coupled_simulations/landice/slm/circular_icesheet_test/mali20km_slm512/run_model_restartPR_reStart/output_logfiles_slmRestartYear2040_maliRestartYear2045`




