### PR TITLE
Updates to SGH model to enhance channel stability

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1099,10 +1099,10 @@ is the value of that variable from the *previous* time level!
                 />
 		<!-- Variables only needed by SIA solver -->
 		<var name="baryCellsOnVertex" type="integer" dimensions="R3 nVertices" units="unitless"
-			 description="Cell center indices to use for interpolating from cell centers to vertex locations.  Note these are local indices!" packages="SIAvelocity"
+			 description="Cell center indices to use for interpolating from cell centers to vertex locations.  Note these are local indices!" packages="SIAvelocity;hydro"
 		/>
 		<var name="baryWeightsOnVertex" type="real" dimensions="R3 nVertices" units="unitless"
-			 description="Weights to interpolate from cell centers to vertex locations.  Each weight is used with the corresponding cell center index indentified by baryCellsOnVertex." packages="SIAvelocity"
+			 description="Weights to interpolate from cell centers to vertex locations.  Each weight is used with the corresponding cell center index indentified by baryCellsOnVertex." packages="SIAvelocity;hydro"
 		/>
 		<!-- Variables only needed by HO solver -->
 		<var name="wachspressWeightVertex" type="real" dimensions="maxEdges nCells" units="unitless"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -24,7 +24,7 @@
 		            description="Selection of the method for calculating the tangent component of slope at edges.
 'from_vertex_barycentric' interpolates scalar values from cell centers to vertices using the barycentric interpolation routine in operators (mpas_cells_to_points_using_baryweights) and then calculates the slope between vertices.  It works for obtuse triangles, but will not work correctly across the edges of periodic meshes.
 'from_vertex_barycentric_kiteareas' interpolates scalar values from cell centers to vertices using barycentric interpolation based on kiterea values and then calculates the slope between vertices.  It will work across the edges of periodic meshes, but will not work correctly for obtuse triangles.
-'from_normal_slope' uses the vector operator mpas_tangential_vector_1d to calculate the tangent slopes from the normal slopes on the edges of the adjacent cells.  It will work for any mesh configuration, but is the least accurate method."
+'from_normal_slope' uses the vector operator mpas_tangential_vector_1d to calculate the tangent slopes from the normal slopes on the edges of the adjacent cells.  It will work for any mesh configuration. 'from_normal_slope' uses a larger stencil, so may therefore produce a smoother 'gradMagPhiEdge' field. Detailed testing yielded nearly identical results between 'from_normal_slope' and 'from_vertex_barycentric' methods, but 'from_normal_slope' seemed to produce slightly more stable results at the grounding line."
 		            possible_values="'from_vertex_barycentric', 'from_vertex_barycentric_kiteareas', 'from_normal_slope'"
 		/>
 		<nml_option name="config_SGH_pressure_calc" type="character" default_value="cavity" units="unitless"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -77,7 +77,13 @@
 		            description="notional englacial porosity"
 		            possible_values="positive real number"
 		/>
-                <!-- channel options -->
+		
+		<nml_option name="config_SGH_use_iceThicknessHydro" type="logical" default_value=".true." units="unitless"
+			    description="alter ice thickness along boundaries to avoid local maxima/minima in upperSurface. This can circumvent instabilities from forming along the boundaries of the hydro model that arise from unrealistic surface anomalies left over from building the domain. This option has no significant effect on the behavior of the model but makes it more stable."
+		            possible_values=".true. or .false."
+		/>
+	
+	        <!-- channel options -->
                 <nml_option name="config_SGH_chnl_active" type="logical" default_value=".false." units="unitless"
 		            description="activate channels in subglacial hydrology model"
 		            possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -148,6 +148,8 @@
                 <!-- state vars -->
 		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
 			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
+		<var name="upperSurfaceHydro" type="real" dimensions="nCells Time" units="m"
+			description="upper surface used by the hydrology model if config_SGH_use_iceThicknessHydro = .true." />
 		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -140,7 +140,9 @@
 	<!-- Variables related to subglacial hydrology -->
         <var_struct name="hydro" time_levs="1" packages="hydro">
                 <!-- state vars -->
-                <var name="waterThickness" type="real" dimensions="nCells Time" units="m"
+		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
+			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
+		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system from previous time step" />

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -125,6 +125,10 @@
 		            possible_values="'file', 'thermal', 'basal_heat'"
 		/>
 
+		  <nml_option name="config_SGH_iter_smooth_waterPressureSlopeNormal" type="integer" default_value="1" units="none"
+					 description="number of iterations to smooth waterPressure over when calculating waterPressureSlopeNormal. Used only to keep channelPressureFreeze stable and will not affect other aspects of the model that rely on waterPressure." 	
+					 possible_values="positive integer or zero"
+		/>
 	</nml_record>
 
 <!-- ======================================================================= -->
@@ -162,7 +166,9 @@
                      description="water layer thickness in subglacial till from previous time step" />
                 <var name="waterPressure" type="real" dimensions="nCells Time" units="Pa"
                      description="pressure in subglacial hydrology system" />
-                <var name="waterPressureOld" type="real" dimensions="nCells Time" units="Pa"
+					 <var name="waterPressureSmooth" type="real" dimensions="nCells Time" units="Pa"
+								description="smoothed water pressure used only for calculation of channelPressureFreeze" />
+					 <var name="waterPressureOld" type="real" dimensions="nCells Time" units="Pa"
                      description="pressure in subglacial hydrology system from previous time step" />
                 <var name="waterPressureTendency" type="real" dimensions="nCells Time" units="Pa s^{-1}"
                      description="tendency in pressure in subglacial hydrology system" />
@@ -240,7 +246,9 @@
                      description="time step length limited by pressure equation scheme in subglacial hydrology system" />
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
                      description="time step used for evolving subglacial hydrology system" />
-                <!-- channel variables -->
+					 <var name="pressureField" type="real" dimensions="nCells Time" units="Pa"
+							description="Dummy variable used for smoothing waterPressureSlopeNormal" />
+				  <!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -251,6 +251,8 @@
                      description="divergence due to channel flow in subglacial hydrology system" />
                 <var name="channelAreaChangeCell" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="change in channel area within each cell, averaged over cell area" />
+                <var name="channelMeltInputCell" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
 

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -196,14 +196,20 @@
                      description="hydropotential in subglacial hydrology system without water thickness contribution" />
                 <var name="hydropotentialBaseVertex" type="real" dimensions="nVertices Time" units="Pa"
                      description="hydropotential without water thickness contribution on vertices.  Only used for some choices of config_SGH_tangent_slope_calculation." />
+                <var name="hydropotentialVertex" type="real" dimensions="nVertices Time" units="Pa"
+                     description="hydropotential on vertices.  Only used for some choices of config_SGH_tangent_slope_calculation." />
                 <var name="hydropotentialBaseSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of hydropotentialBase" />
                 <var name="hydropotentialSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of hydropotential" />
                 <var name="hydropotentialBaseSlopeTangent" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="tangent component of gradient of hydropotentialBase" />
-             <var name="gradMagPhiEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                <var name="hydropotentialSlopeTangent" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                     description="tangent component of gradient of hydropotential" />
+                <var name="gradMagPhiBaseEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="magnitude of the gradient of hydropotentialBase, on Edges" />
+                <var name="gradMagPhiEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                     description="magnitude of the gradient of hydropotential, on Edges" />
                 <var name="waterPressureSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of waterPressure in subglacial hydrology system" />
                 <var name="divergence" type="real" dimensions="nCells Time" units="m s^{-1}"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -176,7 +176,9 @@
                      description="mask indicating how to handle fluxes on each edge: 0=calculate based on hydropotential gradient; 1=allow outflow based on hydropotential gradient, but no inflow (NOT YET IMPLEMENTED); 2=zero flux" />
                 <var name="hydroMarineMarginMask" type="integer" dimensions="nEdges Time" units="none"
                      description="mask indicating the marine boundary of the active subglacial hydrology domain" />
-                <var name="waterFluxAdvec" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
+		<var name="hydroTerrestrialMarginMask" type="integer" dimensions="nEdges Time" units="none"
+	 	     description="mask indicating the terrestrial boundary of the active subglacial hydrology domain" />
+		<var name="waterFluxAdvec" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
                      description="advective water flux in subglacial hydrology system" />
                 <var name="waterFluxDiffu" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
                      description="diffusive water flux in subglacial hydrology system" />

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -244,7 +244,7 @@
                 <var name="closingRate" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="rate of ice creep closure in subglacial hydrology system" />
                 <var name="zeroOrderSum" type="real" dimensions="nCells Time" units="m s^{-1}"
-                        description="sum of zero order terms in subglacial hydrology system" />
+                     description="sum of zero order terms in subglacial hydrology system" />
                 <var name="deltatSGHadvec" type="real" dimensions="Time" units="s"
                      description="advective CFL limited time step length in subglacial hydrology system" />
                 <var name="deltatSGHdiffu" type="real" dimensions="Time" units="s"
@@ -291,11 +291,7 @@
                 <var name="channelMeltInputCell" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
-                        description="diffusivity in channel in subglacial hydrology system" />
-                <var name="diffMassConserveRate" type="real" dimensions="nCells Time" units="m s^{-1}"
-                        description="difference between cavity opening/closing and mass conservation definitions of waterThickness change (Eqs. 48 and 54 in Hoffman 2018, respectively)." />
-                <var name="distributeMassCell" type="real" dimensions="nCells Time" units="m s^{-1}"
-                        description="water evenly distributed/removed to/from channel edges on each cell in order to compensate for diffMassConserveRate and thus conserve mass." />
+                     description="diffusivity in channel in subglacial hydrology system" />
 		  </var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -120,15 +120,22 @@
                             description="calculate time-varying forcing specified by SHMIP experiments C or D"
 		            possible_values="'none', 'C1'-'C4', 'D1'-'D5'"
 		/>
-        <nml_option name="config_SGH_basal_melt" type="character" default_value="file" units="none"
+      <nml_option name="config_SGH_basal_melt" type="character" default_value="file" units="none"
                             description="source for the basalMeltInput term.  'file' takes whatever field was input and performs no calculation.  'thermal' uses the groundedBasalMassBal field calculated by the thermal model.  'basal_heat' calculates a melt rate assuming the entirety of the basal heat flux (basalFrictionFlux+basalHeatFlux) goes to melting ice at the bed.  This is calculated in the SGH module and is independent of any calculations in the thermal model."
 		            possible_values="'file', 'thermal', 'basal_heat'"
 		/>
-
-		  <nml_option name="config_SGH_iter_smooth_waterPressureSlopeNormal" type="integer" default_value="1" units="none"
+		<nml_option name="config_SGH_iter_smooth_waterPressureSlopeNormal" type="integer" default_value="1" units="none"
 					 description="number of iterations to smooth waterPressure over when calculating waterPressureSlopeNormal. Used only to keep channelPressureFreeze stable and will not affect other aspects of the model that rely on waterPressure." 	
 					 possible_values="positive integer or zero"
+	   />
+		<nml_option name="config_SGH_inhibit_chnls_on_lakes" type="character" default_value="none" units="none"
+			description="Option to inhibit growth of channels over subglacial lakes. 'lakeDepth' zeros out channelDischarge if subglacial lake depth is greater than config_SGH_max_chnl_lake_depth. 'flotation' zeros out channelDischarge when above flotation."
+			possible_values="'none', 'lakeDepth', 'flotation'"
 		/>
+      <nml_option name="config_SGH_max_chnl_lake_depth" type="real" default_value="0.0" units="m"
+                        description="if config_SGH_inhibit_chnls_on_lakes = 'lakeDepth': Maximum depth of subglacial lake before channelDischarge is turned off. "
+                        possible_values="positive real number"
+      />		  
 	</nml_record>
 
 <!-- ======================================================================= -->
@@ -247,7 +254,11 @@
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
                      description="time step used for evolving subglacial hydrology system" />
 					 <var name="pressureField" type="real" dimensions="nCells Time" units="Pa"
-							description="Dummy variable used for smoothing waterPressureSlopeNormal" />
+						   description="Dummy variable used for smoothing waterPressureSlopeNormal" />
+                <var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
+		               description="total discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell" />	
+	     	       <var name="totalGroundingLineDischargeEdge" type="real" dimensions="Time nEdges" units="m^{3} s^{-1}"
+		               description="total discharge across grounding line edge" />
 				  <!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
@@ -281,9 +292,7 @@
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
-		<var name="channelDebugMask" type="real" dimensions="nEdges Time" units="none"
-		     description="1 is hydropotentialSlopeNormal and hydropotentialBaseSlopeNormal forced to 1 Pa/m to prevent inflow at the grounding line" />
-	</var_struct>
+		  </var_struct>
 
 <!-- ======================================================================= -->
 

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -273,7 +273,8 @@
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
-
+		<var name="channelDebugMask" type="real" dimensions="nEdges Time" units="none"
+		     description="1 if waterFluxMask = 2, 2 if not grounded ice or on the hydroMarineMargin, 3 if waterFlux < 1e-10, 4 if channelEffectivePressure is greater than 50% overburden" />
 	</var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -274,7 +274,7 @@
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
 		<var name="channelDebugMask" type="real" dimensions="nEdges Time" units="none"
-		     description="1 if waterFluxMask = 2, 2 if not grounded ice or on the hydroMarineMargin, 3 if waterFlux < 1e-10, 4 if channelEffectivePressure is greater than 50% overburden" />
+		     description="1 is hydropotentialSlopeNormal and hydropotentialBaseSlopeNormal forced to 1 Pa/m to prevent inflow at the grounding line" />
 	</var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -244,7 +244,7 @@
                 <var name="closingRate" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="rate of ice creep closure in subglacial hydrology system" />
                 <var name="zeroOrderSum" type="real" dimensions="nCells Time" units="m s^{-1}"
-                     description="sum of zero order terms in subglacial hydrology system" />
+                        description="sum of zero order terms in subglacial hydrology system" />
                 <var name="deltatSGHadvec" type="real" dimensions="Time" units="s"
                      description="advective CFL limited time step length in subglacial hydrology system" />
                 <var name="deltatSGHdiffu" type="real" dimensions="Time" units="s"
@@ -291,7 +291,11 @@
                 <var name="channelMeltInputCell" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
-                     description="diffusivity in channel in subglacial hydrology system" />
+                        description="diffusivity in channel in subglacial hydrology system" />
+                <var name="diffMassConserveRate" type="real" dimensions="nCells Time" units="m s^{-1}"
+                        description="difference between cavity opening/closing and mass conservation definitions of waterThickness change (Eqs. 48 and 54 in Hoffman 2018, respectively)." />
+                <var name="distributeMassCell" type="real" dimensions="nCells Time" units="m s^{-1}"
+                        description="water evenly distributed/removed to/from channel edges on each cell in order to compensate for diffMassConserveRate and thus conserve mass." />
 		  </var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -183,6 +183,7 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  basalSpeed
       real (kind=RKIND), dimension(:), pointer ::  fluxAcrossGroundingLine
       real (kind=RKIND), dimension(:), pointer ::  groundedToFloatingThickness
+      
       real (kind=RKIND), dimension(:), pointer ::  waterThickness
       real (kind=RKIND), dimension(:), pointer ::  basalMeltInput
       real (kind=RKIND), dimension(:), pointer ::  externalWaterInput
@@ -202,6 +203,7 @@ contains
       real (kind=RKIND), pointer :: rhoi ! config_ice_density
       real (kind=RKIND), pointer :: rhow ! config_ocean_density
       real (kind=RKIND), pointer :: bedBumpMax ! config_SGH_bed_roughness_max
+      logical, pointer :: config_SGH
 
       ! Local counters
       integer :: k, iCell, iEdge, nCellsGrounded
@@ -316,6 +318,7 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhow)
       call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', bedBumpMax)
+      call mpas_pool_get_config(liConfigs, 'config_SGH', config_SGH)
 
       ! loop over blocks
       block => domain % blocklist
@@ -349,16 +352,17 @@ contains
          call mpas_pool_get_array(velocityPool, 'surfaceSpeed', surfaceSpeed)
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
          call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
-         call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
-         call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
-         call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
-         call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
-         call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
-         call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
-         call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
-         call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
-         call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
-
+         if (config_SGH) then
+            call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
+            call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
+            call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
+            call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+            call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+            call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+            call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
+            call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+            call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+         endif
 
          ! loop over cells
          do iCell = 1,nCellsSolve
@@ -426,58 +430,61 @@ contains
                * rhoi / (deltat / scyr)  ! convert from m to kg/yr
 
             !! Subglacial Hydrology Calculations
+            if (config_SGH) then
 
-            ! Subglacial Water Volume
-            blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
+               ! Subglacial Water Volume
+               blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
 
-            ! Basal melt input
-            blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
+               ! Basal melt input
+               blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
 
-            ! External water input
-            blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
+               ! External water input
+               blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
 
-            ! Lake Volume
-            if (waterThickness(iCell) > bedBumpMax) then
-                blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+               ! Lake Volume
+               if (waterThickness(iCell) > bedBumpMax) then
+                  blockSumLakeVolume = blockSumLakeVolume + (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+               endif
+                 
+               ! Lake Area
+               if (waterThickness(iCell) > bedBumpMax) then
+                   blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
+               endif
+
+               ! Area-weighted flotation fraction for grounded ice
+               if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                   blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
+               endif
             endif
-           
-            ! Lake Area
-            if (waterThickness(iCell) > bedBumpMax) then
-                blockSumLakeArea = blockSumLakeArea + areaCell(iCell)
-            endif
 
-            ! Area-weighted flotation fraction for grounded ice
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then
-                blockSumFlotationFraction = blockSumFlotationFraction + ( waterPressure(iCell) / rhow / gravity / thickness(iCell) ) * areaCell(iCell)
-            endif
-           
 
          end do ! end loop over cells
 
-         ! Loop over edges
-         do iEdge = 1, nEdgesSolve
+         if (config_SGH) then
+            ! Loop over edges
+            do iEdge = 1, nEdgesSolve
 
-            ! Flux across GL, units = kg/yr
-            blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
-                      * scyr * rhoi ! convert from m^2/s to kg/yr
+               ! Flux across GL, units = kg/yr
+               blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
+                         * scyr * rhoi ! convert from m^2/s to kg/yr
 
-            ! Channel Melt
-            blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
+               ! Channel Melt
+               blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
 
-            ! Meltwater Flux across the grounding line
-            blockSumGLMeltFlux = blockSumGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+               ! Meltwater Flux across the grounding line
+               blockSumGLMeltFlux = blockSumGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
 
-            ! Meltwater Flux across terrestrial margins
-            blockSumTerrestrialMeltFlux = blockSumTerrestrialMeltFlux + abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+               ! Meltwater Flux across terrestrial margins
+               blockSumTerrestrialMeltFlux = blockSumTerrestrialMeltFlux + abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
 
-            ! Meltwater Discharge in channels across grounding line
-            blockSumChannelGLMeltFlux = blockSumChannelGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+               ! Meltwater Discharge in channels across grounding line
+               blockSumChannelGLMeltFlux = blockSumChannelGLMeltFlux + abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
 
-            ! Meltwater discharge in channels across terrestrial margin
-            blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+               ! Meltwater discharge in channels across terrestrial margin
+               blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
 
-         end do ! end loop over edges
-
+            end do ! end loop over edges
+         endif
          block => block % next
       end do    ! end loop over blocks
 
@@ -522,20 +529,24 @@ contains
       sums(13) = blockSumCalvingFlux
       sums(14) = blockSumFaceMeltingFlux
       sums(15) = blockSumVAF
-      sums(16) = blockGLflux
-      sums(17) = blockGLMigrationflux
-      sums(18) = blockSumSubglacialWaterVolume
-      sums(19) = blockSumBasalMeltInput
-      sums(20) = blockSumExternalWaterInput
-      sums(21) = blockSumChannelMelt
-      sums(22) = blockSumLakeVolume
-      sums(23) = blockSumLakeArea
-      sums(24) = blockSumGLMeltFlux
-      sums(25) = blockSumTerrestrialMeltFlux
-      sums(26) = blockSumChannelGLMeltFlux
-      sums(27) = blockSumChannelTerrestrialMeltFlux
-      sums(28) = blockSumFlotationFraction
-      nVars = 28
+      if (config_SGH) then
+         sums(16) = blockGLflux
+         sums(17) = blockGLMigrationflux
+         sums(18) = blockSumSubglacialWaterVolume
+         sums(19) = blockSumBasalMeltInput
+         sums(20) = blockSumExternalWaterInput
+         sums(21) = blockSumChannelMelt
+         sums(22) = blockSumLakeVolume
+         sums(23) = blockSumLakeArea
+         sums(24) = blockSumGLMeltFlux
+         sums(25) = blockSumTerrestrialMeltFlux
+         sums(26) = blockSumChannelGLMeltFlux
+         sums(27) = blockSumChannelTerrestrialMeltFlux
+         sums(28) = blockSumFlotationFraction
+         nVars = 28
+      else
+        nVars = 15
+      endif
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -562,20 +573,22 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'avgSubshelfMelt', avgSubshelfMelt)
          call mpas_pool_get_array(globalStatsAMPool, 'totalCalvingFlux', totalCalvingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
-         call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
-         call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
+         if (config_SGH) then
+            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelMelt', totalChannelMelt)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeVolume', totalLakeVolume)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalLakeArea', totalLakeArea)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalGLMeltFlux',totalGLMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalTerrestrialMeltFlux', totalTerrestrialMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelGLMeltFlux',totalChannelGLMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalChannelTerrestrialMeltFlux', totalChannelTerrestrialMeltFlux)
+            call mpas_pool_get_array(globalStatsAMPool, 'totalFlotationFraction', totalFlotationFraction)
+            call mpas_pool_get_array(globalStatsAMPool, 'avgFlotationFraction', avgFlotationFraction)
+         endif
 
          totalIceArea = reductions(1)
          totalIceVolume = reductions(2)
@@ -592,20 +605,21 @@ contains
          totalCalvingFlux = reductions(13)
          totalFaceMeltingFlux = reductions(14)
          volumeAboveFloatation = reductions(15)
-         groundingLineFlux = reductions(16)
-         groundingLineMigrationFlux = reductions(17)
-         totalSubglacialWaterVolume = reductions(18)
-         totalBasalMeltInput = reductions(19)
-         totalExternalWaterInput = reductions(20)
-         totalChannelMelt = reductions(21)
-         totalLakevolume = reductions(22)
-         totalLakeArea = reductions(23)
-         totalGLMeltFlux = reductions(24)
-         totalTerrestrialMeltFlux = reductions(25)
-         totalChannelGLMeltFlux = reductions(26)
-         totalChannelTerrestrialMeltFlux = reductions(27)
-         totalFlotationFraction = reductions(28)
-
+         if (config_SGH) then
+            groundingLineFlux = reductions(16)
+            groundingLineMigrationFlux = reductions(17)
+            totalSubglacialWaterVolume = reductions(18)
+            totalBasalMeltInput = reductions(19)
+            totalExternalWaterInput = reductions(20)
+            totalChannelMelt = reductions(21)
+            totalLakevolume = reductions(22)
+            totalLakeArea = reductions(23)
+            totalGLMeltFlux = reductions(24)
+            totalTerrestrialMeltFlux = reductions(25)
+            totalChannelGLMeltFlux = reductions(26)
+            totalChannelTerrestrialMeltFlux = reductions(27)
+            totalFlotationFraction = reductions(28)
+         endif
 
          if (totalIceArea > 0.0_RKIND) then
             iceThicknessMean = totalIceVolume / totalIceArea
@@ -626,11 +640,12 @@ contains
          else
             avgSubshelfMelt = 0.0_RKIND
          endif
-
-         if (groundedIceArea > 0.0_RKIND) then
-            avgFlotationFraction = totalFlotationFraction / groundedIceArea
-         else
-            avgFlotationFraction = 0.0_RKIND
+         if (config_SGH) then
+            if (groundedIceArea > 0.0_RKIND) then
+                avgFlotationFraction = totalFlotationFraction / groundedIceArea
+            else
+                avgFlotationFraction = 0.0_RKIND
+            endif
          endif
 
          block => block % next

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -436,7 +436,8 @@ contains
                blockSumSubglacialWaterVolume = blockSumSubglacialWaterVolume + waterThickness(iCell) * areaCell(iCell)
 
                ! Basal melt input
-               blockSumBasalMeltInput = blockSumBasalMeltInput + basalMeltInput(iCell) * areaCell(iCell)
+               blockSumBasalMeltInput = blockSumBasalMeltInput + real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * &
+                                        basalMeltInput(iCell) * areaCell(iCell)
 
                ! External water input
                blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -1011,6 +1011,10 @@ module li_core
       err = ior(err, err_tmp)
       call mpas_timer_stop("initialize velocity")
 
+      ! SIA and hydro need these weights initialized for some options
+      call li_init_barycentric_weights_vertex(block, err_tmp)
+      err = ior(err, err_tmp)
+
       ! Higher-order velo solvers needs vertex-to-cell interp routine initialized
       if ( (trim(config_velocity_solver) == 'L1L2') .or.    &
            (trim(config_velocity_solver) == 'FO') .or.      &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
@@ -154,53 +154,9 @@ contains
       ! local variables
       !
       !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: scratchPool
-      integer :: iCell, iLevel, i, iVertex, err_tmp
-      integer, pointer :: nVertices
-      character (len=StrKIND), pointer :: config_sia_tangent_slope_calculation
-      integer, dimension(:,:), pointer :: baryCellsOnVertex
-      real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
-      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
-      type (field1dInteger), pointer :: vertexIndicesField
 
       ! No block init needed.
       err = 0
-      err_tmp = 0
-
-      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-      call mpas_pool_get_array(meshPool, 'baryCellsOnVertex', baryCellsOnVertex)
-      call mpas_pool_get_array(meshPool, 'baryWeightsOnVertex', baryWeightsOnVertex)
-      call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
-      call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
-      call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
-      call mpas_pool_get_config(liConfigs, 'config_sia_tangent_slope_calculation', config_sia_tangent_slope_calculation)
-      call mpas_pool_get_field(scratchPool, 'vertexIndices', vertexIndicesField)
-      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-
-      ! The SIA solver may need to setup these weights for calculating upperSurfaceVertex
-      if (trim(config_sia_tangent_slope_calculation) == 'from_vertex_barycentric') then
-         call mpas_allocate_scratch_field(vertexIndicesField, .true.)
-         do iVertex = 1, nVertices
-            vertexIndicesField % array(iVertex) = iVertex
-         enddo
-         call mpas_calculate_barycentric_weights_for_points(meshPool, &
-                xVertex(1:nVertices), yVertex(1:nVertices), zVertex(1:nVertices), &
-                vertexIndicesField % array(1:nVertices), &
-                baryCellsOnVertex(:, 1:nVertices), baryWeightsOnVertex(:, 1:nVertices), err_tmp)
-         ! TODO: Until framework can handle periodic meshs gracefully, this will return an error
-         ! for periodic meshes.  This error means that the velocity solver will be very wrong across
-         ! the periodicity, but it will be fine everywhere else.  For now, just print a warning but
-         ! don't make this a fatal error.
-         !err = ior(err, err_tmp)
-         if (err_tmp > 0) then
-            call mpas_log_write("The 'from_vertex_barycentric' option for 'config_sia_tangent_slope_calculation' " &
-                 // "does NOT work across the periodicity in periodic meshes.  However, it does work within the interior " &
-                 // "of the mesh.", MPAS_LOG_WARN)
-         endif
-         call mpas_deallocate_scratch_field(vertexIndicesField, .true.)
-      endif
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -720,6 +720,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBase
       real (kind=RKIND), dimension(:), pointer :: hydropotential
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialVertex
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdge
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
@@ -728,6 +729,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: waterPressureSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseSlopeTangent
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeTangent
+      real (kind=RKIND), dimension(:), pointer :: gradMagPhiBaseEdge
       real (kind=RKIND), dimension(:), pointer :: gradMagPhiEdge
       real (kind=RKIND), dimension(:), pointer :: effectiveConducEdge
       real (kind=RKIND), dimension(:), pointer :: diffusivity
@@ -802,6 +805,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
+      call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
+      call mpas_pool_get_array(hydroPool, 'gradMagPhiBaseEdge', gradMagPhiBaseEdge)
       call mpas_pool_get_array(hydroPool, 'gradMagPhiEdge', gradMagPhiEdge)
       call mpas_pool_get_array(hydroPool, 'effectiveConducEdge', effectiveConducEdge)
       call mpas_pool_get_array(hydroPool, 'diffusivity', diffusivity)
@@ -890,10 +895,13 @@ module li_subglacial_hydro
          endif
       end do
 
-      ! Calculate tangent slope of hydropotentialBase - three possible methods to consider
+      ! Calculate tangent slope of hydropotential and hydropotentialBase - three possible methods to consider
 
       ! Calculate hydropotentialBaseVertex if needed
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseVertex', hydropotentialBaseVertex)
+         ! < this array could be protected by logic if desired
+      ! caluculate hydropotentialVertex if needed
+      call mpas_pool_get_array(hydroPool, 'hydropotentialVertex', hydropotentialVertex)
          ! < this array could be protected by logic if desired
       select case (trim(config_SGH_tangent_slope_calculation))
       case ('from_vertex_barycentric')
@@ -902,8 +910,11 @@ module li_subglacial_hydro
          call mpas_cells_to_points_using_baryweights(meshPool, baryCellsOnVertex(:, 1:nVertices), &
               baryWeightsOnVertex(:, 1:nVertices), hydropotentialBase, hydropotentialBaseVertex(1:nVertices), err_tmp)
               err = ior(err, err_tmp)
+         call mpas_cells_to_points_using_baryweights(meshPool, baryCellsOnVertex(:, 1:nVertices), &
+              baryWeightsOnVertex(:, 1:nVertices), hydropotential, hydropotentialVertex(1:nVertices), err_tmp)
       case ('from_vertex_barycentric_kiteareas')
          call li_cells_to_vertices_1dfield_using_kiteAreas(meshPool, hydropotentialBase, hydropotentialBaseVertex)
+         call li_cells_to_vertices_1dfield_using_kiteAreas(meshPool, hydropotential, hydropotentialVertex)
       end select
 
       ! Now perform tangent slope calculation based on method chosen
@@ -920,8 +931,11 @@ module li_subglacial_hydro
             if ( li_mask_is_ice(edgeMask(iEdge)) ) then
                hydropotentialBaseSlopeTangent(iEdge) = ( hydropotentialBaseVertex(verticesOnEdge(1,iEdge)) -  &
                      hydropotentialBaseVertex(verticesOnEdge(2,iEdge)) ) / dvEdge(iEdge)
+               hydropotentialSlopeTangent(iEdge) = ( hydropotentialVertex(verticesOnEdge(1,iEdge)) -  &
+                     hydropotentialVertex(verticesOnEdge(2,iEdge)) ) / dvEdge(iEdge)
             else
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
             ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
             do i = 1, 2
@@ -930,17 +944,23 @@ module li_subglacial_hydro
                   iCell = cellsOnVertex(j, iVertex)
                   if (iCell == nCells + 1) then
                      hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+                     hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
                   endif
                enddo
             enddo
          end do  ! edges
       case ('from_normal_slope')
+         ! Do first with hydropotentialBase
          call mpas_tangential_vector_1d(hydropotentialBaseSlopeNormal, meshPool, &
-                  includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         ! Repeat for full hydropotential
+         call mpas_tangential_vector_1d(hydropotentialSlopeNormal, meshPool, &
+         includeHalo=.false., tangentialVector=hydropotentialSlopeTangent)
          ! ensure that edges that don't have ice on at least one side have tangent slope set to zero
          do iEdge = 1, nEdges
             if ( .not. li_mask_is_ice(edgeMask(iEdge)) ) then
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
          end do  ! edges
       case default
@@ -949,8 +969,12 @@ module li_subglacial_hydro
       end select
 
       ! calculate magnitude of gradient of Phi
-      gradMagPhiEdge = sqrt(hydropotentialBaseSlopeNormal**2 + hydropotentialBaseSlopeTangent**2)
-
+      gradMagPhiEdge = sqrt(hydropotentialSlopeNormal**2 + hydropotentialSlopeTangent**2)
+      
+      ! calculate magnitude of gradient of hydropotentialBase
+      gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 +&
+      hydropotentialBaseSlopeTangent**2)
+      
       ! calculate effective conductivity on edges
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
@@ -959,12 +983,12 @@ module li_subglacial_hydro
                              conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
                              (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
             effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-               (gradMagPhiEdge(iEdge)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+               (gradMagPhiBaseEdge(iEdge)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
          end do
       else
          ! Just use a single conductivity coeff.
          effectiveConducEdge(:) = conduc_coeff * waterThicknessEdge(:)**(alpha-1.0_RKIND) *&
-            (gradMagPhiEdge(:)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+            (gradMagPhiBaseEdge(:)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
       endif
 
       ! calculate diffusivity on edges

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -998,6 +998,7 @@ module li_subglacial_hydro
          ! we also don't want to assume it's the ocean water column height, because that would imply
          ! a diffusive flux inward, which is undesirable. So disabling diffusion at the GL.
          if (hydroMarineMarginMask(iEdge) == 1) then
+            diffusivity(iEdge) = 0.0_RKIND
             waterFluxDiffu(iEdge) = 0.0_RKIND
          else
             waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
@@ -1139,31 +1140,43 @@ module li_subglacial_hydro
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'indexToEdgeID', indexToEdgeID)
 
-         ! Calculate advective CFL-limited time step
-         dtSGHadvecBlock = 0.5_RKIND * minval(dcEdge(1:nEdgesSolve) / (abs(waterVelocity(1:nEdgesSolve)) &
-            + 1.0e-12_RKIND))  ! regularize
+         dtSGHadvecBlock = bigNumber
+         dtSGHdiffuBlock = bigNumber
+         dtSGHpressureBlock = bigNumber
+         dtSGHadvecChanBlock = bigNumber
+         dtSGHdiffuChanBlock = bigNumber
+
+         do iEdge = 1, nEdgesSolve
+            ! Calculate advective CFL-limited time step
+            if (abs(waterVelocity(iEdge)) > 0.0) then
+               dtSGHadvecBlock = min(dtSGHadvecBlock, 0.5_RKIND * dcEdge(iEdge) / abs(waterVelocity(iEdge)))
+            endif
+
+            if (diffusivity(iEdge) > 0.0) then
+               ! Calculate diffusive CFL-limited time step
+               dtSGHdiffuBlock = min(dtSGHdiffuBlock, 0.25_RKIND * dcEdge(iEdge)**2 / diffusivity(iEdge))
+               ! Calculate pressure limited time step
+               dtSGHpressureBlock = min(dtSGHpressureBlock, 1.0_RKIND * porosity * dcEdge(iEdge)**2 &
+                      / (2.0_RKIND * diffusivity(iEdge)))
+            endif
+
+            if (config_SGH_chnl_active) then
+               if (abs(channelVelocity(iEdge)) > 0.0) then
+                  ! Calculate channel advection limited time step
+                  dtSGHadvecChanBlock = min(dtSGHadvecChanBlock, 0.5_RKIND * dcEdge(iEdge) / (abs(channelVelocity(iEdge))))
+               endif
+               ! Calculate channel diffusion limited time step
+               if (channelDiffusivity(iEdge) > 0.0) then
+                  dtSGHdiffuChanBlock = min(dtSGHdiffuChanBlock, 0.25_RKIND * dcEdge(iEdge)**2 / channelDiffusivity(iEdge))
+               endif
+            endif
+         enddo
+
          dtSGHadvecProc = min(dtSGHadvecProc, dtSGHadvecBlock)
-
-         ! Calculate diffusive CFL-limited time step
-         dtSGHdiffuBlock = 0.25_RKIND * minval(dcEdge(1:nEdgesSolve)**2 / (diffusivity(1:nEdgesSolve) + 1.0e-12_RKIND))
          dtSGHdiffuProc = min(dtSGHdiffuProc, dtSGHdiffuBlock)
-
-         ! Calculate pressure limited time step
-         dtSGHpressureBlock = 1.0_RKIND * minval(porosity * dcEdge(1:nEdgesSolve)**2 &
-                   / (2.0_RKIND * diffusivity(1:nEdgesSolve) + 1.0e-12_RKIND))
          dtSGHpressureProc = min(dtSGHpressureProc, dtSGHpressureBlock)
-
-         if (config_SGH_chnl_active) then
-            ! Calculate channel advection limited time step
-            dtSGHadvecChanBlock = 0.5_RKIND * minval(dcEdge(1:nEdgesSolve) / (abs(channelVelocity(1:nEdgesSolve)) &
-               + 1.0e-12_RKIND))
-            ! regularize
-            dtSGHadvecChanProc = min(dtSGHadvecChanProc, dtSGHadvecChanBlock)
-            ! Calculate channel diffusion limited time step
-            dtSGHdiffuChanBlock = 0.25_RKIND * minval(dcEdge(1:nEdgesSolve)**2 / (channelDiffusivity(1:nEdgesSolve) + &
-               1.0e-12_RKIND))
-            dtSGHdiffuChanProc = min(dtSGHdiffuChanProc, dtSGHdiffuChanBlock)
-         endif
+         dtSGHadvecChanProc = min(dtSGHadvecChanProc, dtSGHadvecChanBlock)
+         dtSGHdiffuChanProc = min(dtSGHdiffuChanProc, dtSGHdiffuChanBlock)
 
          ! Master deltat is needed below, so grab it in this block loop
          call mpas_pool_get_array(meshPool, 'deltat', deltat)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -889,6 +889,16 @@ module li_subglacial_hydro
          endif ! GL edge or grounded margin
       end do
 
+      ! zero gradients at boundaries of the mesh
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+         if ((cell1 == nCells+1) .or. (cell2 == nCells+1)) then
+            hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
+            hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
+            waterPressureSlopeNormal(iEdge) = 0.0_RKIND
+         endif
+      end do
 
       ! Calculate tangent slope of hydropotentialBase - three possible methods to consider
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -744,6 +744,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:,:), pointer :: verticesOnEdge
+      integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
       real (kind=RKIND), pointer :: alpha, beta
@@ -758,6 +759,7 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer, pointer :: nVertices
       integer :: iEdge, cell1, cell2
+      integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
@@ -917,11 +919,14 @@ module li_subglacial_hydro
       end select
 
       ! Now perform tangent slope calculation based on method chosen
+      ! For the two vertex based methods, edges with vertices on the boundary of the mesh will have invalid values
+      ! For the normal slope method, any edges on cells that are at the edge of the mesh will have
+      ! contaminated values.
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
+      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
       select case (trim(config_SGH_tangent_slope_calculation))
       case ('from_vertex_barycentric', 'from_vertex_barycentric_kiteareas')
-         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-         call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
          do iEdge = 1, nEdges
             ! Only calculate slope for edges that have ice on at least one side.
             if ( li_mask_is_ice(edgeMask(iEdge)) ) then
@@ -930,10 +935,26 @@ module li_subglacial_hydro
             else
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
             endif
+            ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
+            do i = 1, 2
+               iVertex = verticesOnEdge(i, iEdge)
+               do j = 1, 3
+                  iCell = cellsOnVertex(j, iVertex)
+                  if (iCell == nCells + 1) then
+                     hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+                  endif
+               enddo
+            enddo
          end do  ! edges
       case ('from_normal_slope')
          call mpas_tangential_vector_1d(hydropotentialBaseSlopeNormal, meshPool, &
                   includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         ! ensure that edges that don't have ice on at least one side have tangent slope set to zero
+         do iEdge = 1, nEdges
+            if ( .not. li_mask_is_ice(edgeMask(iEdge)) ) then
+               hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+            endif
+         end do  ! edges
       case default
          call mpas_log_write('Invalid value for config_SGH_tangent_slope_calculation.', MPAS_LOG_ERR)
          err = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -259,6 +259,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThicknessTendency
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
+      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: areaCell
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
@@ -534,6 +535,7 @@ module li_subglacial_hydro
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'divergenceChannel')
          call mpas_dmpar_field_halo_exch(domain, 'channelAreaChangeCell')
+         call mpas_dmpar_field_halo_exch(domain, 'channelMeltInputCell')
          call mpas_dmpar_field_halo_exch(domain, 'channelArea')
          call mpas_timer_stop("halo updates")
       endif
@@ -570,12 +572,16 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'divergence', divergence)
          call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
          call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+         call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
          waterThicknessOld = waterThickness
-         waterThickness = waterThicknessOld + deltatSGH * ( (basalMeltInput + externalWaterInput) / rho_water - divergence  &
+         waterThickness = waterThicknessOld + deltatSGH * ( &
+             (basalMeltInput + externalWaterInput) / rho_water &
+             + channelMeltInputCell &
+             - divergence  &
              - divergenceChannel - channelAreaChangeCell  &
-             - (Wtill - WtillOld) / deltatSGH)
+             - (Wtill - WtillOld) / deltatSGH )
          waterThickness = waterThickness * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations
          waterThickness = max(0.0_RKIND, waterThickness)
          divergence = divergence * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations for more convenient viz
@@ -1777,6 +1783,7 @@ module li_subglacial_hydro
       end where
       channelChangeRate = channelOpeningRate - channelClosingRate
 
+
    !--------------------------------------------------------------------
    end subroutine update_channel
 
@@ -1816,9 +1823,11 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelDischarge
+      real (kind=RKIND), dimension(:), pointer :: channelMelt, channelPressureFreeze
       real (kind=RKIND), dimension(:), pointer :: channelChangeRate
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
+      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
       real (kind=RKIND), pointer :: deltatSGH
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -1834,9 +1843,12 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+      call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+      call mpas_pool_get_array(hydroPool, 'channelPressureFreeze', channelPressureFreeze)
       call mpas_pool_get_array(hydroPool, 'channelChangeRate', channelChangeRate)
       call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
       call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+      call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -1848,6 +1860,7 @@ module li_subglacial_hydro
       ! Calculate flux divergence on cells and channel area change on cells
       divergenceChannel(:) = 0.0_RKIND  ! zero div before accumulating
       channelAreaChangeCell(:) = 0.0_RKIND  ! zero before accumulating
+      channelMeltInputCell(:) = 0.0_RKIND  ! zero before accumulating
       ! loop over locally owned cells
       do iCell = 1, nCellsSolve
          ! TODO: could limit to grounded cells only
@@ -1858,10 +1871,12 @@ module li_subglacial_hydro
             divergenceChannel(iCell) = divergenceChannel(iCell) - channelDischarge(iEdge) * edgeSignOnCell(iEdgeOnCell, iCell)
             channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND
                ! < only half of channel is in this cell
+            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water
          end do ! edges
       end do ! cells
       divergenceChannel(1:nCellsSolve) = divergenceChannel(1:nCellsSolve) / areaCell(1:nCellsSolve)
       channelAreaChangeCell(1:nCellsSolve) = channelAreaChangeCell(1:nCellsSolve) / areaCell(1:nCellsSolve)
+      channelMeltInputCell(1:nCellsSolve) = channelMeltInputCell(1:nCellsSolve) / areaCell(1:nCellsSolve)
 
       ! Now update channel area
       channelArea = channelChangeRate * deltatSGH + channelArea

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -833,12 +833,29 @@ module li_subglacial_hydro
          waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
       end do
 
+      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
+      do iEdge = 1, nEdges
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
+             (hydroMarineMarginMask(iEdge)==1)) then
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            else ! cell1 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            endif ! which cell is icefree
+         endif ! if edge of grounded ice
+      end do
+
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
       ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
       ! but that is unrealistic.
-      ! So for all boundaries of the hydro system, the hydropotential at the margin should be determined by the geometry
-      ! at the edge of the cell in a 1-sided sense
+      ! So for all boundaries of the hydro system where outflow is occuring,
+      ! the hydropotential at the margin should be determined by the geometry
+      ! at the edge of the cell in a 1-sided sense.
       do iEdge = 1, nEdges
          if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
              (hydroMarineMarginMask(iEdge)==1)) then
@@ -860,35 +877,6 @@ module li_subglacial_hydro
                     max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
             endif ! which cell is icefree
          endif ! if edge of grounded ice
-      end do
-
-      ! Disallow flow from ocean to glacier, or land to glacier,
-      ! which can occur under some circumstances
-      ! For ocean this is invalid because ocean water has a different density!
-      ! For land this would only happen if there is a supply of water, which is not currently handled.
-      ! Do this by simply zeroing the hydropotential gradient in those cases.
-      ! (Do this step only after the other hydropotential special cases are treated above.)
-      do iEdge = 1, nEdges
-         ! Find edges along GL or margin to check for 'backwards' flow
-         if ((hydroMarineMarginMask(iEdge)==1) .or. &
-             li_mask_is_margin(edgeMask(iEdge)) ) then
-            ! Now check if flow is backwards
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            if (hydropotentialBaseSlopeNormal(iEdge) > 0.0_RKIND) then
-               ! flow is from cell2 to cell1
-               if (.not. li_mask_is_grounded_ice(cellMask(cell2))) then
-                  hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
-                  hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
-               endif
-            elseif (hydropotentialBaseSlopeNormal(iEdge) < 0.0_RKIND) then
-               ! flow is from cell1 to cell2
-               if (.not. li_mask_is_grounded_ice(cellMask(cell1))) then
-                  hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
-                  hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
-               endif
-            endif
-         endif ! GL edge or grounded margin
       end do
 
       ! zero gradients at boundaries of the mesh

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -963,11 +963,15 @@ module li_subglacial_hydro
          waterFluxAdvec(iEdge) = waterVelocity(iEdge) * waterThicknessEdgeUpwind(iEdge)
 
          ! diffusive flux
-         ! Note: At the GL, the water thickness for one cell will be 0, meaning a large gradient.  However, the
-         ! diffusivity uses a one sided water thickness.  It's unclear what really happens to lakes at the GL/margin.
-         waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
+         ! Note: Water thickness at the GL is undefined.  I don't think we want to assume it's 0, and
+         ! we also don't want to assume it's the ocean water column height, because that would imply
+         ! a diffusive flux inward, which is undesirable. So disabling diffusion at the GL.
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            waterFluxDiffu(iEdge) = 0.0_RKIND
+         else
+            waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
                / dcEdge(iEdge)
-         !endif
+         endif
       end do
       where (waterFluxMask == 2)
          waterFluxAdvec = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1652,7 +1652,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelVelocity
       real (kind=RKIND), dimension(:), pointer :: gradMagPhiEdge
       real (kind=RKIND), dimension(:), pointer :: waterFlux
-      real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseSlopeNormal
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: waterPressureSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: channelOpeningRate
       real (kind=RKIND), dimension(:), pointer :: channelClosingRate
@@ -1698,7 +1698,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
       call mpas_pool_get_array(hydroPool, 'channelVelocity', channelVelocity)
       call mpas_pool_get_array(hydroPool, 'gradMagPhiEdge', gradMagPhiEdge)
-      call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeNormal', hydropotentialBaseSlopeNormal)
+      call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeNormal', hydropotentialSlopeNormal)
       call mpas_pool_get_array(hydroPool, 'waterPressureSlopeNormal', waterPressureSlopeNormal)
       call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
       call mpas_pool_get_array(hydroPool, 'channelOpeningRate', channelOpeningRate)
@@ -1720,7 +1720,7 @@ module li_subglacial_hydro
          channelDischarge(:) = 0.0_RKIND
       elsewhere
          channelDischarge = -1.0_RKIND * Kc * channelArea**alpha_c * gradMagPhiEdge**(beta_c - 2.0_RKIND) * &
-            hydropotentialBaseSlopeNormal
+            hydropotentialSlopeNormal
       end where
 
       where (waterFluxMask == 2)
@@ -1752,8 +1752,8 @@ module li_subglacial_hydro
             Kc * channelArea**(alpha_c - 1.0_RKIND) * gradMagPhiEdge**(beta_c - 2.0_RKIND))
       end where
 
-      channelMelt = (abs(channelDischarge * hydropotentialBaseSlopeNormal) &  ! channel dissipation
-                  +  abs(waterFlux * hydropotentialBaseSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
+      channelMelt = (abs(channelDischarge * hydropotentialSlopeNormal) &  ! channel dissipation
+                  +  abs(waterFlux * hydropotentialSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
                   ) / latent_heat_ice
       channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
          (channelDischarge + waterFlux * config_SGH_incipient_channel_width) &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2197,6 +2197,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
       integer, pointer :: nEdgesSolve
@@ -2213,6 +2214,7 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+         call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
 
@@ -2230,6 +2232,20 @@ module li_subglacial_hydro
                      (li_mask_is_floating_ice(cellMask(cell1)) .or. &
                      ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
                hydroMarineMarginMask(iEdge) = 1
+            endif
+         enddo
+
+         hydroTerrestrialMarginMask(:) = 0
+         do iEdge = 1, nEdgesSolve
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            !Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
+               .and. (bedTopography(cell2) > config_sea_level)) then
+               hydroTerrestrialMarginMask(iEdge) = 1
+            elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
+               .and. (bedTopography(cell1) > config_sea_level)) then
+               hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -105,6 +105,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: tillMax
       real (kind=RKIND), pointer :: rhoi, rhoo
@@ -172,8 +173,12 @@ module li_subglacial_hydro
 
          call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
+         call calc_iceThicknessHydro(block, err_tmp) !adjust ice thickness along boundaries
+         err = ior(err,err_tmp)
+
          waterPressure = max(0.0_RKIND, waterPressure)
-         waterPressure = min(waterPressure, rhoi * gravity * thickness)
+         waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
          ! set pressure correctly under floating ice and open ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -314,6 +319,9 @@ module li_subglacial_hydro
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
          call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+
+         call calc_iceThicknessHydro(block, err_tmp)
+         err = ior(err, err_tmp)
 
          call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
          err = ior(err, err_tmp)
@@ -1436,6 +1444,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro      
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -1502,6 +1511,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
 
       openingRate(:) = bedRough * basalSpeed(:) * (bedRoughMax - waterThickness(:))
       !openingRate(:) = bedRough * basalSpeed(:) * (bedRoughMax - waterThickness(:)) + &
@@ -1522,7 +1532,7 @@ module li_subglacial_hydro
       case ('cavity')
 
          where (li_mask_is_floating_ice(cellMask))
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere (.not. li_mask_is_ice(cellMask))
             waterPressure = 0.0_RKIND
          elsewhere
@@ -1532,11 +1542,11 @@ module li_subglacial_hydro
 
       case ('overburden')
          where (li_mask_is_floating_ice(cellMask))
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere (.not. li_mask_is_ice(cellMask))
             waterPressure = 0.0_RKIND
          elsewhere
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          end where
 
       case default
@@ -1545,7 +1555,7 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
-      waterPressure = min(waterPressure, rhoi * gravity * thickness)
+      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
 
       do iCell = 1, nCells
         if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
@@ -1594,7 +1604,6 @@ module li_subglacial_hydro
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -1619,6 +1628,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: hydropotential
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: config_sea_level
 
@@ -1639,9 +1649,10 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
-      effectivePressure = rhoi * gravity * thickness - waterPressure
+      effectivePressure = rhoi * gravity * iceThicknessHydro - waterPressure
          ! < this should evalute to 0 for floating ice if Pw set correctly there.
       where (.not. li_mask_is_grounded_ice(cellmask))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
@@ -2125,6 +2136,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), pointer :: rhoi, rhoo
 
       ! Calculate N assuming perfect ocean connection
@@ -2139,7 +2151,9 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-         effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+         
+         effectivePressure = rhoi * gravity * iceThicknessHydro - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
          effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
 
          block => block % next
@@ -2206,7 +2220,8 @@ module li_subglacial_hydro
          do iEdge = 1, nEdgesSolve
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
-            ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            ! We are looking for edges with 1 cell grounded ice and the
+            ! other cell floating ice or open ocean
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
                  ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
@@ -2227,5 +2242,91 @@ module li_subglacial_hydro
 
    !--------------------------------------------------------------------
    end subroutine calc_hydro_mask
+   
+
+!***********************************************************************
+!
+!  routine calc_iceThicknessHydro
+!
+!> \brief   Calculate version of ice thickness used by hydrology model
+!> \author  Alex Hager
+!> \date    7 June 2023
+!> \details
+!>  This routine calculates a modified ice thickness that is altered at
+!   the domain boundaries to avoid local minima in hydropotential
+!-----------------------------------------------------------------------
+   subroutine calc_iceThicknessHydro(block, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: block    !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      ! Pools pointers
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: hydroPool
+      type (mpas_pool_type), pointer :: meshPool
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: upperSurface
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nCells
+      integer :: iCell
+      integer :: jCell
+      real (kind=RKIND) :: minNeighborHeight
+      real (kind=RKIND), parameter :: bigValue = 1.0_RKIND
+      integer, dimension(:), pointer :: nEdgesOnCell
+      err = 0
+
+      ! Get pools things
+      call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+      call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      
+      iceThicknessHydro = thickness
+
+      do iCell = 1, nCells
+         if ((li_mask_is_boundary(cellMask(iCell))) .and. (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+           minNeighborHeight = bigValue !allocate
+
+            do jCell = 1, nEdgesOnCell(iCell)
+               if ( .not. li_mask_is_boundary(cellMask(cellsOnCell(jCell,iCell)))) then
+                       minNeighborHeight = min(minNeighborHeight, upperSurface(cellsOnCell(jCell,iCell)))
+               endif            
+            end do
+            
+            !only adjust surface elevation if cell is local minimum
+            if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+               iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+            endif
+
+         endif
+      enddo
+
+!-------------------------------------------------------------------------      
+      end subroutine calc_iceThicknessHydro
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1650,7 +1650,7 @@ module li_subglacial_hydro
       effectivePressure = max(0.0_RKIND, effectivePressure)
 
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
-      where (.not. (li_mask_is_grounded_ice(cellMask))) 
+      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < 0.0_RKIND)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
       end where      
       !disallow negative hydropotentialBase

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -863,11 +863,31 @@ module li_subglacial_hydro
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               !set to arbitrarily small value, not zero.
+               hydropotentialBaseSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               
+               !Just in case values are between 0 and 1.0e-15
+               if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
+                  (hydropotentialBaseSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+
+                  hydropotentialBaseSlopeNormal(iEdge) = 1.0e-15_RKIND
+               endif
+               if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
+                  (hydropotentialSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+
+                  hydropotentialSlopeNormal(iEdge) = 1.0e-15_RKIND
+               endif
+            
             else ! cell1 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               hydropotentialBaseSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+            
+               if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
+                  (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
+
+                  hydropotentialSlopeNormal(iEdge) = -1.0e-15_RKIND
+               endif
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
@@ -1852,11 +1872,9 @@ module li_subglacial_hydro
       !channelDischarge.
 
       !TODO: Make a function of sheet dissipation threshold?
-      where ((abs(waterFlux) <= 1e-15_RKIND) .and. (hydroMarineMarginMask == 0))
+      where (abs(waterFlux) < 1e-15_RKIND)
         channelDischarge = 0.0_RKIND
         channelArea = 0.0_RKIND
-      elsewhere ((abs(waterFlux) <= 1e-15_RKIND) .and. (hydroMarineMarginMask == 1))
-        channelDischarge = 0.0_RKIND
       end where
 
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -882,6 +882,24 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
+      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
+      do iEdge = 1, nEdges
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge)))) then
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+
+            else ! cell1 is the cell outside the hydro domain
+
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+
+            endif ! which cell is icefree
+         endif ! if edge of grounded ice
+      end do
+
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1551,23 +1551,6 @@ module li_subglacial_hydro
 
       waterPressure = max(0.0_RKIND, waterPressure)
       
-      do iCell = 1, nCells
-        onMarineMargin = .false.
-        do iEdge = 1, nEdgesOnCell(iCell)
-           if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
-              onMarineMargin = .true.
-              exit
-           endif
-        enddo
-        if (onMarineMargin) then
-           ! At marine margin, don't let water pressure fall below ocean pressure
-           ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
-           if (waterPressure(iCell) < rho_water * gravity * (config_sea_level - bedTopography(iCell))) then
-               waterPressure(iCell) = rho_water * gravity * (config_sea_level - bedTopography(iCell))
-           endif
-        endif
-      enddo
-
       waterPressureTendency = (waterPressure - waterPressureOld) / deltatSGH
 
       call calc_pressure_diag_vars(block, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2316,8 +2316,11 @@ module li_subglacial_hydro
       integer :: numCellsChanged
       integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
+      real (kind=RKIND) :: maxNeighborHeight
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
+      real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
+      logical, pointer :: config_SGH_use_iceThicknessHydro
       err = 0
 
       ! Get pools things
@@ -2333,37 +2336,50 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      
-      iceThicknessHydro = thickness
-      numCellsChanged = 0
+      call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
+      iceThicknessHydro = thickness 
 
-      do iCell = 1, nCells
-         if ((li_mask_is_boundary(cellMask(iCell))) .and. &
-                 (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+      !iceThicknessHydro is equivalent to thickness if
+      !config_SGH_use_iceThicknessHydro is false. Default is to alter
+      !ice thickness along boundaries. 
+
+      if (config_SGH_use_iceThicknessHydro) then
+      
+         numCellsChanged = 0
+
+         do iCell = 1, nCells
+            if ((li_mask_is_boundary(cellMask(iCell))) .and. &
+                    (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
            
-            minNeighborHeight = bigValue !allocate
+               minNeighborHeight = bigValue !allocate
+               maxNeighborHeight = bigNegativeValue
 
-            do jCell = 1, nEdgesOnCell(iCell)
-               iNeighbor = cellsOnCell(jCell,iCell)
-               if ( .not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
-                   (iNeighbor < nCells + 1)) then
-                    minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-               endif            
-            end do
+               do jCell = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jCell,iCell)
+                  if (.not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
+                     (iNeighbor < nCells + 1)) then
+                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
+                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
+                  endif        
+               end do
             
-            !only adjust surface elevation if cell is local minimum
-            if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
-               call mpas_log_write("Changed ice thickness of cell $i", intArgs=(/iCell/))
-               numCellsChanged = numCellsChanged + 1
-               iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+               !only adjust surface elevation if cell is local minimum or
+               !maximum
+               if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+                  numCellsChanged = numCellsChanged + 1
+                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+               elseif ((upperSurface(iCell) > maxNeighborHeight) .and. &
+                      (maxNeighborHeight > bigNegativeValue)) then
+                  numCellsChanged = numCellsChanged + 1
+                  iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+               endif
+
             endif
+         enddo
 
-         endif
-      enddo
-
-      call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
-      call mpas_log_write("Minimum Neighbor Height: $r", realArgs=(/minNeighborHeight/))
-      
+         call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
+      endif
+   
    end subroutine calc_iceThicknessHydro
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -860,7 +860,8 @@ module li_subglacial_hydro
       ! The hydropotential at the terrestrial margin should be determined by the geometry
       ! at the edge of the cell in a 1-sided sense.
       do iEdge = 1, nEdges
-         if (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) then
+         if (li_mask_is_margin(edgeMask(iEdge)) .and. (li_mask_is_grounded_ice(edgeMask(iEdge))) &
+                 .and. (hydroMarineMarginMask(iEdge) .ne. 1)) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2444,6 +2444,11 @@ module li_subglacial_hydro
 
                endif
 
+               !avoid negatives, default to original thickness
+               if (iceThicknessHydro(iCell) < 0.0_RKIND) then
+                  iceThicknessHydro(iCell) = thickness(iCell)
+               endif
+            
             endif
          enddo
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -274,6 +274,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellX
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellY
+      real (kind=RKIND), dimension(:), pointer :: openingRate
+      real (kind=RKIND), dimension(:), pointer :: closingRate
       real (kind=RKIND), dimension(:), allocatable :: cellJunk
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -590,15 +592,23 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
          call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
          call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
+         call mpas_pool_get_array(hydroPool, 'closingRate', closingRate)
+         call mpas_pool_get_array(hydroPool, 'openingRate', openingRate)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
          waterThicknessOld = waterThickness
-         waterThickness = waterThicknessOld + deltatSGH * ( &
-             (basalMeltInput + externalWaterInput) / rho_water &
-             + channelMeltInputCell &
-             - divergence  &
-             - divergenceChannel - channelAreaChangeCell  &
-             - (Wtill - WtillOld) / deltatSGH )
+         
+         if (config_SGH_chnl_active) then
+            waterThickness = waterThicknessOld + deltatSGH * ( &
+                  openingRate - closingRate)
+         else
+            waterThickness = waterThicknessOld + deltatSGH * ( &
+                (basalMeltInput + externalWaterInput) / rho_water &
+                + channelMeltInputCell &
+                - divergence  &
+                - divergenceChannel - channelAreaChangeCell  &
+                - (Wtill - WtillOld) / deltatSGH )
+         endif
          waterThickness = waterThickness * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations
          waterThickness = max(0.0_RKIND, waterThickness)
          divergence = divergence * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations for more convenient viz
@@ -1817,10 +1827,26 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: openingRate
+      real (kind=RKIND), dimension(:), pointer :: closingRate
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
       real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: dcEdge
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: distributeMassCell
+      real (kind=RKIND), dimension(:), pointer :: diffMassConserveRate
+      real (kind=RKIND), dimension(:), pointer :: basalMeltInput
+      real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
+      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
+      real (kind=RKIND), pointer :: deltatSGH
+      real (kind=RKIND), dimension(:), pointer :: divergence
+      real (kind=RKIND), dimension(:), pointer :: divergenceChannel
+      real (kind=RKIND), dimension(:), pointer :: externalWaterInput
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, dimension(:,:), pointer ::  edgesOnCell
+      real (kind=RKIND), dimension(:), pointer :: tillWaterThickness
+      real (kind=RKIND), dimension(:), pointer :: tillWaterThicknessOld
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
@@ -1834,8 +1860,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: xEdge
       real (kind=RKIND), dimension(:), pointer :: yEdge
       integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nEdgesSolve, nEdges
-      integer :: iEdge, cell1, cell2
+      integer, pointer :: nEdgesSolve, nEdges, nCells
+      integer :: iEdge, cell1, cell2, edgeID, iCell
 
       err = 0
 
@@ -1861,6 +1887,7 @@ module li_subglacial_hydro
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
@@ -1885,6 +1912,21 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+      call mpas_pool_get_array(hydroPool, 'openingRate', openingRate)
+      call mpas_pool_get_array(hydroPool, 'closingRate', closingRate)
+      call mpas_pool_get_array(hydroPool, 'diffMassConserveRate', diffMassConserveRate)
+      call mpas_pool_get_array(hydroPool, 'distributeMassCell', distributeMassCell)
+      call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
+      call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+      call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
+      call mpas_pool_get_array(hydroPool, 'divergence', divergence)
+      call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
+      call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
+      call mpas_pool_get_array(hydroPool, 'tillWaterThickness', tillWaterThickness)
+      call mpas_pool_get_array(hydroPool, 'tillWaterThicknessOld', tillWaterThicknessOld)
+      call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(meshPool, 'xCell', xCell)
@@ -1892,6 +1934,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
       call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
@@ -1998,12 +2041,33 @@ module li_subglacial_hydro
       end do
       channelClosingRate(:) = creep_coeff * channelArea(:) * flowParamAChannel(:) * channelEffectivePressure(:)**3
 
+      !There are two ways to calculate waterThickness, one using conservation of mass and one using cavity opening/closing, 
+      !but these do not always agree. We want waterThickness to be a product of cavity opening/closing, meaning we need
+      !to use channels as an alternate way to restore mass conservation. This is done by calculating the difference between the two
+      !different waterThickness methods and adjusting channelChangeRate to make up the difference.
+
+      diffMassConserveRate = (openingRate - closingRate) - &
+             ( (basalMeltInput + externalWaterInput) / rho_water &
+             + channelMeltInputCell &
+             - divergence  &
+             - divergenceChannel - channelAreaChangeCell  &
+             - (tillWaterThickness - tillWaterThicknessOld) / deltatSGH )
+
+      !Evenly distributed remaining mass across all channels flowing into cell and add to channelChangeRate
+      do iCell = 1, nCells
+         distributeMassCell(iCell) = diffMassConserveRate(iCell) / nEdgesOnCell(iCell)
+           do iEdge = 1, nEdgesOnCell(iCell)
+               edgeID = edgesOnCell(iEdge,iCell) 
+               channelChangeRate(edgeID) = channelOpeningRate(edgeID) - channelClosingRate(edgeID) + distributeMassCell(iCell) * dcEdge(edgeID) * 0.5_RKIND
+         end do
+      end do
+
       where (waterFluxMask == 2)
          channelOpeningRate = 0.0_RKIND
          channelClosingRate = 0.0_RKIND
+         channelChangeRate = 0.0_RKIND
       end where
-      channelChangeRate = channelOpeningRate - channelClosingRate
-
+      
       !calculate total grounding line discharges
       totalGroundingLineDischargeCell(:) = 0.0_RKIND
       totalGroundingLineDischargeEdge(:) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2355,19 +2355,19 @@ module li_subglacial_hydro
          do iCell = 1, nCells
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
 
-               maxNeighborHeight = bigValue !allocate
-               minNeighborHeight = bigNegativeValue
+               maxNeighborHeight = bigNegativeValue !allocate
+               minNeighborHeight = bigValue
                
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
 
-                  if (jCell == 1) then
-                          totNeighborHeight = upperSurface(iNeighbor)
-                          numCells = 1
-                  endif 
-
                   if (iNeighbor < nCells + 1) then
 
+                      if (jCell == 1) then
+                              totNeighborHeight = upperSurface(iNeighbor)
+                              numCells = 1
+                      endif 
+                      
                       minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
                       maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -889,13 +889,25 @@ module li_subglacial_hydro
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+                    if (hydroMarineMarginMask(iEdge) == 1) then
+                            if (hydropotentialBaseSlopeNormal(iEdge) > -1.0_RKIND) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
+                            endif
+                            if (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND) then
+                                 hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
+                            endif
+                    endif
 
             else ! cell1 is the cell outside the hydro domain
 
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+                    if (hydroMarineMarginMask(iEdge) == 1) then
+                            if (hydropotentialBaseSlopeNormal(iEdge) < 1.0_RKIND) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = 1.0_RKIND
+                            endif
+                            if (hydropotentialSlopeNormal(iEdge) < 1.0_RKIND) then
+                                 hydropotentialSlopeNormal(iEdge) = 1.0_RKIND
+                            endif
+                    endif
 
             endif ! which cell is icefree
          endif ! if edge of grounded ice

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2313,10 +2313,12 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer :: iCell
       integer :: jCell
-      integer :: numCellsChanged
       integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: maxNeighborHeight
+      real (kind=RKIND) :: meanNeighborHeight
+      real (kind=RKIND) :: totNeighborHeight
+      real (kind=RKIND) :: numCells
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -2344,42 +2346,67 @@ module li_subglacial_hydro
       !ice thickness along boundaries. 
 
       if (config_SGH_use_iceThicknessHydro) then
-      
-         numCellsChanged = 0
 
          do iCell = 1, nCells
-            if ((li_mask_is_boundary(cellMask(iCell))) .and. &
-                    (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
-           
-               minNeighborHeight = bigValue !allocate
-               maxNeighborHeight = bigNegativeValue
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
+               !Smooth by making each cell equal to the mean of its
+               !neighbors.
 
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
-                  if (.not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
-                     (iNeighbor < nCells + 1)) then
-                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
-                  endif        
+                  if (iNeighbor < nCells + 1) then
+                          if (jCell == 1) then
+                             totNeighborHeight = upperSurface(iNeighbor)
+                             numCells = 1
+                          else
+                             totNeighborHeight = totNeighborHeight +  upperSurface(iNeighbor)
+                             numCells = numCells + 1
+                          endif
+                  endif
+
+                     meanNeighborHeight = totNeighborHeight / numCells
                end do
-            
+
+               iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+               !Above averaging is not sequential with respect to flow
+               !direction, so cells can still be local minima or maxima
+               !after smoothing. Find and correct cells where this is the case
+
+               minNeighborHeight = bigValue !allocate
+               maxNeighborHeight = bigNegativeValue
+               
+               do jCell = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jCell,iCell)
+                  if (iNeighbor < nCells + 1) then
+
+                      minNeighborHeight = min(minNeighborHeight, iceThicknessHydro(iNeighbor) + &
+                      bedTopography(iNeighbor))
+
+                      maxNeighborHeight = max(maxNeighborHeight, iceThicknessHydro(iNeighbor) + &
+                      bedTopography(iNeighbor))
+
+                  endif
+               end do
+
                !only adjust surface elevation if cell is local minimum or
                !maximum
-               if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
-                  numCellsChanged = numCellsChanged + 1
-                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
-               elseif ((upperSurface(iCell) > maxNeighborHeight) .and. &
-                      (maxNeighborHeight > bigNegativeValue)) then
-                  numCellsChanged = numCellsChanged + 1
+               if (((iceThicknessHydro(iCell) + bedTopography(iCell)) < minNeighborHeight) &
+                       .and. (minNeighborHeight < bigValue)) then
+
+                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)
+
+               elseif (((iceThicknessHydro(iCell) + bedTopography(iCell)) > maxNeighborHeight) &
+                       .and. (maxNeighborHeight > bigNegativeValue)) then
+
                   iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+
                endif
 
             endif
          enddo
 
-         call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
-      endif
-   
+      endif 
    end subroutine calc_iceThicknessHydro
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1745,6 +1745,9 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
+      real (kind=RKIND) :: channelOverburden
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
@@ -1753,6 +1756,7 @@ module li_subglacial_hydro
       integer, pointer :: nVertLevels
 
       integer, pointer :: nEdgesSolve
+      integer, pointer :: nEdges
       integer :: iEdge, cell1, cell2
 
 
@@ -1775,6 +1779,7 @@ module li_subglacial_hydro
 
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
@@ -1797,7 +1802,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
       ! Calculate terms needed for opening (melt) rate
 
       where(gradMagPhiEdge < 0.01_RKIND)
@@ -1807,6 +1813,23 @@ module li_subglacial_hydro
             hydropotentialSlopeNormal
       end where
 
+      !Debugging
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         channelOverburden = ((thickness(cell1)+thickness(cell2)) / 2) * rhoi * gravity
+         if (waterFluxMask(iEdge) == 2) then
+            channelDebugMask(iEdge) = 1
+         elseif (.not. ((li_mask_is_grounded_ice(edgeMask(iEdge))) .or. (hydroMarineMarginMask(iEdge)==1))) then
+            channelDebugMask(iEdge) = 2
+         elseif (abs(waterFlux(iEdge)) <= 1e-15_RKIND)  then
+            channelDebugMask(iEdge) = 3
+      !   elseif ((channelEffectivePressure(iEdge) / channelOverburden) > 0.5_RKIND) then
+       !     channelDebugMask(iEdge) = 4
+         endif
+      enddo
+      
       where (waterFluxMask == 2)
          channelDischarge = 0.0_RKIND
          channelArea = 0.0_RKIND
@@ -1815,15 +1838,25 @@ module li_subglacial_hydro
       ! Note: an edge with only one grounded cell neighbor is called floating, so this logic retains channel vars
       ! on those edges to allow channel discharge across GL
       where (.not. ( (li_mask_is_grounded_ice(edgeMask)) .or. (hydroMarineMarginMask==1) ) )
-         channelArea = 0.0_RKIND
          channelDischarge = 0.0_RKIND
+         channelArea = 0.0_RKIND
       end where
 
-      ! Disable channels from forming if there is no sheet flux
-      ! TODO: Make a function of sheet dissipation threshold?
-      where (abs(waterFlux) <= 1e-10_RKIND)
-         channelArea = 0.0_RKIND
-         channelDischarge = 0.0_RKIND
+      !Disable channels if no sheet flux.
+      !This tends to only be an issue at steep hydropotential gradients
+      !with thin ice and at the grounding line. In the first case, we
+      !want to keep channels from forming at all, so make both channelArea
+      !and channelDischarge zero. At the grounding line, we want the
+      !channel to be able to reestablish its original position once the
+      !condition is no longer being met, so only zero out
+      !channelDischarge.
+
+      !TODO: Make a function of sheet dissipation threshold?
+      where ((abs(waterFlux) <= 1e-15_RKIND) .and. (hydroMarineMarginMask == 0))
+        channelDischarge = 0.0_RKIND
+        channelArea = 0.0_RKIND
+      elsewhere ((abs(waterFlux) <= 1e-15_RKIND) .and. (hydroMarineMarginMask == 1))
+        channelDischarge = 0.0_RKIND
       end where
 
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -194,6 +194,11 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      !update halo for iceThicknessHydro
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_timer_stop("halo updates")
+      
       ! === error check
       if (err > 0) then
           call mpas_log_write("An error has occurred in li_SGH_init.", MPAS_LOG_ERR)
@@ -329,6 +334,11 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      !update halo for iceThicknessHydro
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_timer_stop("halo updates")
+      
       ! initialize while loop
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)  ! can get from any block
       call mpas_pool_get_array(meshPool, 'deltat', masterDeltat)
@@ -2303,8 +2313,10 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer :: iCell
       integer :: jCell
+      integer :: numCellsChanged
+      integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
-      real (kind=RKIND), parameter :: bigValue = 1.0_RKIND
+      real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
       err = 0
 
@@ -2323,26 +2335,35 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       
       iceThicknessHydro = thickness
+      numCellsChanged = 0
 
       do iCell = 1, nCells
-         if ((li_mask_is_boundary(cellMask(iCell))) .and. (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
-           minNeighborHeight = bigValue !allocate
+         if ((li_mask_is_boundary(cellMask(iCell))) .and. &
+                 (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+           
+            minNeighborHeight = bigValue !allocate
 
             do jCell = 1, nEdgesOnCell(iCell)
-               if ( .not. li_mask_is_boundary(cellMask(cellsOnCell(jCell,iCell)))) then
-                       minNeighborHeight = min(minNeighborHeight, upperSurface(cellsOnCell(jCell,iCell)))
+               iNeighbor = cellsOnCell(jCell,iCell)
+               if ( .not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
+                   (iNeighbor < nCells + 1)) then
+                    minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
                endif            
             end do
             
             !only adjust surface elevation if cell is local minimum
             if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+               call mpas_log_write("Changed ice thickness of cell $i", intArgs=(/iCell/))
+               numCellsChanged = numCellsChanged + 1
                iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
             endif
 
          endif
       enddo
 
-!-------------------------------------------------------------------------      
-      end subroutine calc_iceThicknessHydro
+      call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
+      call mpas_log_write("Minimum Neighbor Height: $r", realArgs=(/minNeighborHeight/))
+      
+   end subroutine calc_iceThicknessHydro
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2272,10 +2272,10 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             !Look for edges with 1 cell on grounding ice and the other cell on land without ice
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
-               .and. (bedTopography(cell2) > config_sea_level)) then
+               .and. (bedTopography(cell2) >= config_sea_level)) then
                hydroTerrestrialMarginMask(iEdge) = 1
             elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
-               .and. (bedTopography(cell1) > config_sea_level)) then
+               .and. (bedTopography(cell1) >= config_sea_level)) then
                hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1846,7 +1846,7 @@ module li_subglacial_hydro
                   +  abs(waterFlux * hydropotentialSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
                   ) / latent_heat_ice
       channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
-         (channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
+         abs(channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
          * waterPressureSlopeNormal / latent_heat_ice
 
       if (config_SGH_include_pressure_melt) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1845,7 +1845,7 @@ module li_subglacial_hydro
       channelMelt = (abs(channelDischarge * hydropotentialSlopeNormal) &  ! channel dissipation
                   +  abs(waterFlux * hydropotentialSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
                   ) / latent_heat_ice
-      channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
+      channelPressureFreeze = iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
          abs(channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
          * waterPressureSlopeNormal / latent_heat_ice
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2309,6 +2309,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
       integer, dimension(:,:), pointer :: cellsOnCell
       integer, dimension(:), pointer :: cellMask
@@ -2316,8 +2317,8 @@ module li_subglacial_hydro
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
-      real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: maxNeighborHeight
+      real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: meanNeighborHeight
       real (kind=RKIND) :: totNeighborHeight
       real (kind=RKIND) :: numCells
@@ -2336,6 +2337,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+      call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -2345,70 +2347,58 @@ module li_subglacial_hydro
 
       !iceThicknessHydro is equivalent to thickness if
       !config_SGH_use_iceThicknessHydro is false. Default is to alter
-      !ice thickness along boundaries. 
+      !ice thickness
 
       if (config_SGH_use_iceThicknessHydro) then
 
          do iCell = 1, nCells
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
-               !Smooth by making each cell equal to the mean of its
-               !neighbors.
 
-               do jCell = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(jCell,iCell)
-                  if (iNeighbor < nCells + 1) then
-                          if (jCell == 1) then
-                             totNeighborHeight = upperSurface(iNeighbor)
-                             numCells = 1
-                          else
-                             totNeighborHeight = totNeighborHeight +  upperSurface(iNeighbor)
-                             numCells = numCells + 1
-                          endif
-                  endif
-
-                     meanNeighborHeight = totNeighborHeight / numCells
-               end do
-
-               iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
-
-               !Above averaging is not sequential with respect to flow
-               !direction, so cells can still be local minima or maxima
-               !after smoothing. Find and correct cells where this is the case
-
-               minNeighborHeight = bigValue !allocate
-               maxNeighborHeight = bigNegativeValue
+               maxNeighborHeight = bigValue !allocate
+               minNeighborHeight = bigNegativeValue
                
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
+
+                  if (jCell == 1) then
+                          totNeighborHeight = upperSurface(iNeighbor)
+                          numCells = 1
+                  endif 
+
                   if (iNeighbor < nCells + 1) then
 
-                      minNeighborHeight = min(minNeighborHeight, iceThicknessHydro(iNeighbor) + &
-                      bedTopography(iNeighbor))
+                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
-                      maxNeighborHeight = max(maxNeighborHeight, iceThicknessHydro(iNeighbor) + &
-                      bedTopography(iNeighbor))
+                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
 
+                      totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
+                      numCells = numCells + 1
                   endif
                end do
 
+               meanNeighborHeight = totNeighborHeight / numCells
+
                !only adjust surface elevation if cell is local minimum or
                !maximum
-               if (((iceThicknessHydro(iCell) + bedTopography(iCell)) < minNeighborHeight) &
+               if ((upperSurface(iCell) < minNeighborHeight) &
                        .and. (minNeighborHeight < bigValue)) then
 
-                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)
+                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
 
-               elseif (((iceThicknessHydro(iCell) + bedTopography(iCell)) > maxNeighborHeight) &
+               elseif ((upperSurface(iCell) > maxNeighborHeight) &
                        .and. (maxNeighborHeight > bigNegativeValue)) then
 
-                  iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
 
                endif
 
             endif
          enddo
 
-      endif 
+      endif
+
+      upperSurfaceHydro = iceThicknessHydro + bedTopography
+
    end subroutine calc_iceThicknessHydro
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2113,10 +2113,11 @@ module li_subglacial_hydro
             iEdge = edgesOnCell(iEdgeOnCell, iCell)
             ! add on advective & diffusive fluxes
             divergenceChannel(iCell) = divergenceChannel(iCell) - channelDischarge(iEdge) * edgeSignOnCell(iEdgeOnCell, iCell)
-            channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND
+            channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND + channelAreaChangeCell(iCell)
                ! < only half of channel is in this cell
-            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water
+            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water + channelMeltInputCell(iCell)
          end do ! edges
+
       end do ! cells
       divergenceChannel(1:nCellsSolve) = divergenceChannel(1:nCellsSolve) / areaCell(1:nCellsSolve)
       channelAreaChangeCell(1:nCellsSolve) = channelAreaChangeCell(1:nCellsSolve) / areaCell(1:nCellsSolve)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -884,7 +884,8 @@ module li_subglacial_hydro
 
       ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
       do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge)))) then
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) & 
+            .or. (hydroMarineMarginMask(iEdge) == 1)) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
@@ -1655,16 +1656,11 @@ module li_subglacial_hydro
       where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < 0.0_RKIND)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
       end where      
-      !disallow negative hydropotentialBase
-      hydropotentialBase = max(0.0_RKIND, hydropotentialBase)
 
       ! hydropotential with water thickness
       hydropotential = hydropotentialBase + rho_water * gravity * waterThickness
 
-      !Disallow negative hydropotential
-      hydropotential = max(0.0_RKIND, hydropotential)
-
-   !--------------------------------------------------------------------
+ !--------------------------------------------------------------------
    end subroutine calc_pressure_diag_vars
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -881,25 +881,6 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
-      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
-      do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1)) then
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-               
-            else ! cell1 is the cell outside the hydro domain
-            
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-              
-            endif ! which cell is icefree
-         endif ! if edge of grounded ice
-      end do
-      
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
@@ -1672,9 +1653,14 @@ module li_subglacial_hydro
       where (.not. (li_mask_is_grounded_ice(cellMask))) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
       end where      
+      !disallow negative hydropotentialBase
+      hydropotentialBase = max(0.0_RKIND, hydropotentialBase)
 
       ! hydropotential with water thickness
       hydropotential = hydropotentialBase + rho_water * gravity * waterThickness
+
+      !Disallow negative hydropotential
+      hydropotential = max(0.0_RKIND, hydropotential)
 
    !--------------------------------------------------------------------
    end subroutine calc_pressure_diag_vars

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1566,7 +1566,7 @@ module li_subglacial_hydro
 
       waterPressure = max(0.0_RKIND, waterPressure)
       waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
-
+      
       do iCell = 1, nCells
         if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
              ((.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) ) then
@@ -1667,7 +1667,7 @@ module li_subglacial_hydro
       where (.not. li_mask_is_grounded_ice(cellmask))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
       end where
-
+      
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
       ! This is still correct under ice shelves/open ocean because waterPressure has been set appropriately there already.
       ! Note this leads to a nonuniform hydropotential at sea level that is a function of the ocean depth.
@@ -2348,7 +2348,7 @@ module li_subglacial_hydro
       if (config_SGH_use_iceThicknessHydro) then
 
          do iCell = 1, nCells
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
+            if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
                !Smooth by making each cell equal to the mean of its
                !neighbors.
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -739,6 +739,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
       real (kind=RKIND), dimension(:), pointer :: hydropotentialVertex
       real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdge
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
       real (kind=RKIND), dimension(:), pointer :: waterThickness
@@ -758,12 +759,16 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
       real (kind=RKIND), dimension(:), pointer :: channelDebugMask
-      integer, dimension(:), pointer :: waterFluxMask
+      real (kind=RKIND), dimension(:), pointer :: pressureField
       integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
+      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge
       integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: baryCellsOnVertex
@@ -776,18 +781,24 @@ module li_subglacial_hydro
       character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoo
+      integer, pointer :: nTimesSmooth
       integer, pointer :: nEdges
       integer, pointer :: nCells
       integer, pointer :: nVertices
       integer :: iEdge, cell1, cell2
-      integer :: i, j, iVertex, iCell
+      integer :: i, j, iVertex, iCell, jCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
-
+      integer :: isMarineMargin
+      integer :: edgeNum
+      integer :: iNeighbor 
+      integer :: numCells
+      integer :: iter
+      real (kind=RKIND) :: totNeighborPressure
+      
       err = 0
       err_tmp = 0
-
 
       ! Get pools things
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
@@ -806,9 +817,11 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
-
+      call mpas_pool_get_config(liConfigs, 'config_SGH_iter_smooth_waterPressureSlopeNormal', nTimesSmooth)
+      
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+      call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -821,6 +834,9 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
       call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
@@ -836,7 +852,9 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
-
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+      call mpas_pool_get_array(hydroPool, 'pressureField', pressureField)
+      
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
@@ -853,7 +871,64 @@ module li_subglacial_hydro
 
          hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - hydropotentialBase(cell1)) / dcEdge(iEdge)
          hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - hydropotential(cell1)) / dcEdge(iEdge)
-         waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
+         !waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
+      end do
+
+
+      ! Create a smoothed waterPressure product used only for
+      ! calculating waterPressureSlopeNormal - to avoid channelPressureFreeze
+      ! instabilities
+
+      if (nTimesSmooth > 0) then
+         do iter = 1, nTimesSmooth !May need to iterate to smooth properly
+            if (iter == 1) then      
+               waterPressureSmooth = waterPressure
+               pressureField = waterPressure
+            else
+               pressureField = waterPressureSmooth
+            endif
+
+            do iCell = 1, nCells
+               if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then 
+               
+                     isMarineMargin = 0
+                     do edgeNum = 1, nEdgesOnCell(iCell)
+                        iEdge = edgesOnCell(edgeNum,iCell)
+                        if (hydroMarineMarginMask(iEdge) == 1) then
+                           isMarineMargin = 1
+                           exit
+                        endif
+                     enddo
+
+                     if (isMarineMargin == 0) then 
+                  
+                        totNeighborPressure = pressureField(iCell)
+                        numCells = 1
+                  
+                        do jCell = 1, nEdgesOnCell(iCell)
+                           iNeighbor = cellsOnCell(jCell,iCell)
+
+                           if (iNeighbor < nCells + 1) then
+                              totNeighborPressure = totNeighborPressure + pressureField(iNeighbor)
+                              numCells = numCells + 1
+                           endif
+                        end do
+                  
+                        !waterPressureSmooth is average of neighboring cells
+                        waterPressureSmooth(iCell) = totNeighborPressure / numCells 
+                     endif
+               endif
+            end do
+         end do
+      elseif (nTimesSmooth == 0) then
+         waterPressureSmooth = waterPressure
+      endif
+         
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+      
+         waterPressureSlopeNormal(iEdge) = (waterPressureSmooth(cell2) - waterPressureSmooth(cell1)) / dcEdge(iEdge)
       end do
 
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1857,7 +1857,7 @@ module li_subglacial_hydro
         enddo
 
 
-        channelPressureFreeze = iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
+        channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
          abs(channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
          * waterPressureSlopeNormal / latent_heat_ice
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1918,21 +1918,6 @@ module li_subglacial_hydro
          channelArea = 0.0_RKIND
       end where
 
-      !Disable channels if no sheet flux.
-      !This tends to only be an issue at steep hydropotential gradients
-      !with thin ice and at the grounding line. In the first case, we
-      !want to keep channels from forming at all, so make both channelArea
-      !and channelDischarge zero. At the grounding line, we want the
-      !channel to be able to reestablish its original position once the
-      !condition is no longer being met, so only zero out
-      !channelDischarge.
-
-      !TODO: Make a function of sheet dissipation threshold?
-      !where (abs(waterFlux) < 1e-15_RKIND)
-       ! channelDischarge = 0.0_RKIND
-        !channelArea = 0.0_RKIND
-      !end where
-      
       !Inhibit Channel discharge within subglacial lake interiors
       select case (trim(config_SGH_inhibit_chnls_on_lakes))
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1565,7 +1565,6 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
-      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
       
       do iCell = 1, nCells
         if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
@@ -1667,7 +1666,10 @@ module li_subglacial_hydro
       where (.not. li_mask_is_grounded_ice(cellmask))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
       end where
-      
+     
+      !Disallow negative effective pressure
+      effectivePressure = max(0.0_RKIND, effectivePressure)
+
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
       ! This is still correct under ice shelves/open ocean because waterPressure has been set appropriately there already.
       ! Note this leads to a nonuniform hydropotential at sea level that is a function of the ocean depth.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -864,30 +864,46 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                !set to arbitrarily small value, not zero.
-               hydropotentialBaseSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               !commented for debugging
+               !hydropotentialBaseSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               !hydropotentialSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               !debugging
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
                
                !Just in case values are between 0 and 1.0e-15
-               if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
-                  (hydropotentialBaseSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+               !commented for debugging
+               !if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
+               !   (hydropotentialBaseSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
 
-                  hydropotentialBaseSlopeNormal(iEdge) = 1.0e-15_RKIND
-               endif
-               if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
-                  (hydropotentialSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+                !  hydropotentialBaseSlopeNormal(iEdge) = 1.0e-15_RKIND
+               !endif
+               !if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
+                !  (hydropotentialSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
 
-                  hydropotentialSlopeNormal(iEdge) = 1.0e-15_RKIND
-               endif
+                 ! hydropotentialSlopeNormal(iEdge) = 1.0e-15_RKIND
+               !endif
             
             else ! cell1 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               !commented for debugging
+               !hydropotentialBaseSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               !hydropotentialSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
             
-               if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
-                  (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
+               !debugging
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+              
+              !commented for debugging
+              ! if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
+               !   (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
 
-                  hydropotentialSlopeNormal(iEdge) = -1.0e-15_RKIND
-               endif
+                !  hydropotentialSlopeNormal(iEdge) = -1.0e-15_RKIND
+              ! endif
+              !if ((hydropotentialBaseSlopeNormal(iEdge) <= 0) .and. &
+               !   (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
+
+                  !hydropotentialBaseSlopeNormal(iEdge) = -1.0e-15_RKIND
+               !endif
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
@@ -1843,8 +1859,8 @@ module li_subglacial_hydro
             channelDebugMask(iEdge) = 1
          elseif (.not. ((li_mask_is_grounded_ice(edgeMask(iEdge))) .or. (hydroMarineMarginMask(iEdge)==1))) then
             channelDebugMask(iEdge) = 2
-         !elseif (abs(waterFlux(iEdge)) <= 1e-15_RKIND)  then
-          !  channelDebugMask(iEdge) = 3
+         elseif (gradMagPhiEdge(iEdge) < 0.01_RKIND)  then
+            channelDebugMask(iEdge) = 3
       !   elseif ((channelEffectivePressure(iEdge) / channelOverburden) > 0.5_RKIND) then
        !     channelDebugMask(iEdge) = 4
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1843,8 +1843,8 @@ module li_subglacial_hydro
             channelDebugMask(iEdge) = 1
          elseif (.not. ((li_mask_is_grounded_ice(edgeMask(iEdge))) .or. (hydroMarineMarginMask(iEdge)==1))) then
             channelDebugMask(iEdge) = 2
-         elseif (abs(waterFlux(iEdge)) <= 1e-15_RKIND)  then
-            channelDebugMask(iEdge) = 3
+         !elseif (abs(waterFlux(iEdge)) <= 1e-15_RKIND)  then
+          !  channelDebugMask(iEdge) = 3
       !   elseif ((channelEffectivePressure(iEdge) / channelOverburden) > 0.5_RKIND) then
        !     channelDebugMask(iEdge) = 4
          endif
@@ -1872,10 +1872,10 @@ module li_subglacial_hydro
       !channelDischarge.
 
       !TODO: Make a function of sheet dissipation threshold?
-      where (abs(waterFlux) < 1e-15_RKIND)
-        channelDischarge = 0.0_RKIND
-        channelArea = 0.0_RKIND
-      end where
+      !where (abs(waterFlux) < 1e-15_RKIND)
+       ! channelDischarge = 0.0_RKIND
+        !channelArea = 0.0_RKIND
+      !end where
 
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1845,7 +1845,19 @@ module li_subglacial_hydro
       channelMelt = (abs(channelDischarge * hydropotentialSlopeNormal) &  ! channel dissipation
                   +  abs(waterFlux * hydropotentialSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
                   ) / latent_heat_ice
-      channelPressureFreeze = iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
+        
+        do iEdge = 1, nEdges
+            if (hydroMarineMarginMask(iEdge) == 1) then
+               if (waterPressureSlopeNormal(iEdge) > 0) then
+                  waterPressureSlopeNormal(iEdge) = 0.5_RKIND
+               else
+                  waterPressureSlopeNormal(iEdge) = -0.5_RKIND
+               endif
+            endif
+        enddo
+
+
+        channelPressureFreeze = iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
          abs(channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
          * waterPressureSlopeNormal / latent_heat_ice
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1036,6 +1036,7 @@ module li_subglacial_hydro
          endif
       end do
       where (waterFluxMask == 2)
+         diffusivity = 0.0_RKIND
          waterFluxAdvec = 0.0_RKIND
          waterFluxDiffu = 0.0_RKIND
          waterVelocity = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1858,7 +1858,7 @@ module li_subglacial_hydro
 
 
         channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
-         abs(channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
+         (channelDischarge + waterFlux * config_SGH_incipient_channel_width) &
          * waterPressureSlopeNormal / latent_heat_ice
 
       if (config_SGH_include_pressure_melt) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -757,6 +757,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFlux
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
+      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
@@ -834,7 +835,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-
+      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
 
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
@@ -891,9 +892,11 @@ module li_subglacial_hydro
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                     if (hydroMarineMarginMask(iEdge) == 1) then
                             if (hydropotentialBaseSlopeNormal(iEdge) > -1.0_RKIND) then
-                                 hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
+                                channelDebugMask(iEdge) = 1
+                                hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
                             endif
                             if (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND) then
+                                 channelDebugMask(iEdge) = 1
                                  hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
                             endif
                     endif
@@ -1738,8 +1741,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
       real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
-      real (kind=RKIND) :: channelOverburden
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
@@ -1795,7 +1796,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
       ! Calculate terms needed for opening (melt) rate
 
       where(gradMagPhiEdge < 0.01_RKIND)
@@ -1805,23 +1805,6 @@ module li_subglacial_hydro
             hydropotentialSlopeNormal
       end where
 
-      !Debugging
-      do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-
-         channelOverburden = ((thickness(cell1)+thickness(cell2)) / 2) * rhoi * gravity
-         if (waterFluxMask(iEdge) == 2) then
-            channelDebugMask(iEdge) = 1
-         elseif (.not. ((li_mask_is_grounded_ice(edgeMask(iEdge))) .or. (hydroMarineMarginMask(iEdge)==1))) then
-            channelDebugMask(iEdge) = 2
-         elseif (gradMagPhiEdge(iEdge) < 0.01_RKIND)  then
-            channelDebugMask(iEdge) = 3
-      !   elseif ((channelEffectivePressure(iEdge) / channelOverburden) > 0.5_RKIND) then
-       !     channelDebugMask(iEdge) = 4
-         endif
-      enddo
-      
       where (waterFluxMask == 2)
          channelDischarge = 0.0_RKIND
          channelArea = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2308,12 +2308,19 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
+      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: edgeMask
       integer, pointer :: nCells
+      integer :: edgeNum
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer :: iEdge
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
+      integer :: isMarineMargin
       real (kind=RKIND) :: maxNeighborHeight
       real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: meanNeighborHeight
@@ -2321,7 +2328,6 @@ module li_subglacial_hydro
       real (kind=RKIND) :: numCells
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
-      integer, dimension(:), pointer :: nEdgesOnCell
       logical, pointer :: config_SGH_use_iceThicknessHydro
       err = 0
 
@@ -2333,12 +2339,16 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
       iceThicknessHydro = thickness 
 
@@ -2347,53 +2357,63 @@ module li_subglacial_hydro
       !ice thickness
 
       if (config_SGH_use_iceThicknessHydro) then
-
          do iCell = 1, nCells
+
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
-
-               maxNeighborHeight = bigNegativeValue !allocate
-               minNeighborHeight = bigValue
                
-               do jCell = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(jCell,iCell)
-
-                  if (iNeighbor < nCells + 1) then
-
-                      if (jCell == 1) then
-                              totNeighborHeight = upperSurface(iNeighbor)
-                              numCells = 1
-                      endif 
-                      
-                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-
-                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
-
-                      totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
-                      numCells = numCells + 1
+               isMarineMargin = 0
+               do edgeNum = 1, nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(edgeNum,iCell)
+                  if (hydroMarineMarginMask(iEdge) == 1) then
+                     isMarineMargin = 1
+                     exit
                   endif
-               end do
+               enddo
 
-               meanNeighborHeight = totNeighborHeight / numCells
+               if (isMarineMargin == 0) then
+                  maxNeighborHeight = bigNegativeValue !allocate
+                  minNeighborHeight = bigValue
+                  
+                  do jCell = 1, nEdgesOnCell(iCell)
+                     iNeighbor = cellsOnCell(jCell,iCell)
 
-               !only adjust surface elevation if cell is local minimum or
-               !maximum
-               if ((upperSurface(iCell) < minNeighborHeight) &
-                       .and. (minNeighborHeight < bigValue)) then
+                     if (iNeighbor < nCells + 1) then
 
-                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+                         if (jCell == 1) then
+                                 totNeighborHeight = upperSurface(iNeighbor)
+                                 numCells = 1
+                         endif 
+                         
+                         minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
-               elseif ((upperSurface(iCell) > maxNeighborHeight) &
-                       .and. (maxNeighborHeight > bigNegativeValue)) then
+                         maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
 
-                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+                         totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
+                         numCells = numCells + 1
+                     endif
+                  end do
 
-               endif
+                  meanNeighborHeight = totNeighborHeight / numCells
 
-               !avoid negatives, default to original thickness
-               if (iceThicknessHydro(iCell) < 0.0_RKIND) then
-                  iceThicknessHydro(iCell) = thickness(iCell)
-               endif
-            
+                  !only adjust surface elevation if cell is local minimum or
+                  !maximum
+                  if ((upperSurface(iCell) < minNeighborHeight) &
+                          .and. (minNeighborHeight < bigValue)) then
+
+                     iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+                  elseif ((upperSurface(iCell) > maxNeighborHeight) &
+                          .and. (maxNeighborHeight > bigNegativeValue)) then
+
+                     iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+                  endif
+
+                  !avoid negatives, default to original thickness
+                  if (iceThicknessHydro(iCell) < 0.0_RKIND) then
+                     iceThicknessHydro(iCell) = thickness(iCell)
+                  endif
+               endif 
             endif
          enddo
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -894,46 +894,44 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                !set to arbitrarily small value, not zero.
-               !commented for debugging
-               !hydropotentialBaseSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               !hydropotentialSlopeNormal(iEdge) = min(1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               hydropotentialBaseSlopeNormal(iEdge) = min(1.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(1.0_RKIND, hydropotentialSlopeNormal(iEdge))
                !debugging
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               !hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               !hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
                
                !Just in case values are between 0 and 1.0e-15
                !commented for debugging
-               !if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
-               !   (hydropotentialBaseSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+               if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
+                  (hydropotentialBaseSlopeNormal(iEdge) < 1.0_RKIND)) then
 
-                !  hydropotentialBaseSlopeNormal(iEdge) = 1.0e-15_RKIND
-               !endif
-               !if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
-                !  (hydropotentialSlopeNormal(iEdge) < 1.0e-15_RKIND)) then
+                  hydropotentialBaseSlopeNormal(iEdge) = 1.0_RKIND
+               endif
+               if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
+                  (hydropotentialSlopeNormal(iEdge) < 1.0_RKIND)) then
 
-                 ! hydropotentialSlopeNormal(iEdge) = 1.0e-15_RKIND
-               !endif
+                  hydropotentialSlopeNormal(iEdge) = 1.0_RKIND
+               endif
             
             else ! cell1 is the cell outside the hydro domain
                !commented for debugging
-               !hydropotentialBaseSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               !hydropotentialSlopeNormal(iEdge) = max(-1.0e-15_RKIND, hydropotentialSlopeNormal(iEdge))
+               hydropotentialBaseSlopeNormal(iEdge) = max(-1.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(-1.0_RKIND, hydropotentialSlopeNormal(iEdge))
             
                !debugging
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               !hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               !hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
               
-              !commented for debugging
-              ! if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
-               !   (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
+               if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
+                  (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND)) then
 
-                !  hydropotentialSlopeNormal(iEdge) = -1.0e-15_RKIND
-              ! endif
-              !if ((hydropotentialBaseSlopeNormal(iEdge) <= 0) .and. &
-               !   (hydropotentialSlopeNormal(iEdge) > -1.0e-15_RKIND)) then
+                  hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
+               endif
+              if ((hydropotentialBaseSlopeNormal(iEdge) <= 0) .and. &
+                  (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND)) then
 
-                  !hydropotentialBaseSlopeNormal(iEdge) = -1.0e-15_RKIND
-               !endif
+                  hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
+              endif
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -856,6 +856,36 @@ module li_subglacial_hydro
          waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
       end do
 
+      ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
+      ! hydropotential gradients and unstable channel growth.
+      ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
+      ! but that is unrealistic.
+      ! So for all boundaries of the hydro system where outflow is occuring,
+      ! the hydropotential at the margin should be determined by the geometry
+      ! at the edge of the cell in a 1-sided sense.
+      do iEdge = 1, nEdges
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
+             (hydroMarineMarginMask(iEdge)==1)) then
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
+               hydropotentialBaseSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
+                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
+                  hydropotentialBase(cell1)) / dcEdge(iEdge)
+               hydropotentialSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
+                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
+                  hydropotential(cell1)) / dcEdge(iEdge)
+            else ! cell1 is the icefree cell - replace phi there with cell2 Phig
+               hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - &
+                  ( rho_water * gravity * bedTopography(cell2) + &
+                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
+               hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - &
+                  ( rho_water * gravity * bedTopography(cell2) + &
+                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
+            endif ! which cell is icefree
+         endif ! if edge of grounded ice
+      end do
+
       ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
       do iEdge = 1, nEdges
          if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
@@ -907,37 +937,7 @@ module li_subglacial_hydro
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
-
-      ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
-      ! hydropotential gradients and unstable channel growth.
-      ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
-      ! but that is unrealistic.
-      ! So for all boundaries of the hydro system where outflow is occuring,
-      ! the hydropotential at the margin should be determined by the geometry
-      ! at the edge of the cell in a 1-sided sense.
-      do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1)) then
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
-               hydropotentialBaseSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
-                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
-                  hydropotentialBase(cell1)) / dcEdge(iEdge)
-               hydropotentialSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
-                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
-                  hydropotential(cell1)) / dcEdge(iEdge)
-            else ! cell1 is the icefree cell - replace phi there with cell2 Phig
-               hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - &
-                  ( rho_water * gravity * bedTopography(cell2) + &
-                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
-               hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - &
-                  ( rho_water * gravity * bedTopography(cell2) + &
-                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
-            endif ! which cell is icefree
-         endif ! if edge of grounded ice
-      end do
-
+      
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -274,8 +274,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellX
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellY
-      real (kind=RKIND), dimension(:), pointer :: openingRate
-      real (kind=RKIND), dimension(:), pointer :: closingRate
       real (kind=RKIND), dimension(:), allocatable :: cellJunk
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -592,23 +590,15 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
          call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
          call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
-         call mpas_pool_get_array(hydroPool, 'closingRate', closingRate)
-         call mpas_pool_get_array(hydroPool, 'openingRate', openingRate)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
          waterThicknessOld = waterThickness
-         
-         if (config_SGH_chnl_active) then
-            waterThickness = waterThicknessOld + deltatSGH * ( &
-                  openingRate - closingRate)
-         else
-            waterThickness = waterThicknessOld + deltatSGH * ( &
-                (basalMeltInput + externalWaterInput) / rho_water &
-                + channelMeltInputCell &
-                - divergence  &
-                - divergenceChannel - channelAreaChangeCell  &
-                - (Wtill - WtillOld) / deltatSGH )
-         endif
+         waterThickness = waterThicknessOld + deltatSGH * ( &
+             (basalMeltInput + externalWaterInput) / rho_water &
+             + channelMeltInputCell &
+             - divergence  &
+             - divergenceChannel - channelAreaChangeCell  &
+             - (Wtill - WtillOld) / deltatSGH )
          waterThickness = waterThickness * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations
          waterThickness = max(0.0_RKIND, waterThickness)
          divergence = divergence * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations for more convenient viz
@@ -1827,26 +1817,10 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
-      real (kind=RKIND), dimension(:), pointer :: openingRate
-      real (kind=RKIND), dimension(:), pointer :: closingRate
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
       real (kind=RKIND), dimension(:), pointer :: dvEdge
-      real (kind=RKIND), dimension(:), pointer :: dcEdge
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: distributeMassCell
-      real (kind=RKIND), dimension(:), pointer :: diffMassConserveRate
-      real (kind=RKIND), dimension(:), pointer :: basalMeltInput
-      real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
-      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
-      real (kind=RKIND), pointer :: deltatSGH
-      real (kind=RKIND), dimension(:), pointer :: divergence
-      real (kind=RKIND), dimension(:), pointer :: divergenceChannel
-      real (kind=RKIND), dimension(:), pointer :: externalWaterInput
-      integer, dimension(:), pointer :: nEdgesOnCell
-      integer, dimension(:,:), pointer ::  edgesOnCell
-      real (kind=RKIND), dimension(:), pointer :: tillWaterThickness
-      real (kind=RKIND), dimension(:), pointer :: tillWaterThicknessOld
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
@@ -1860,8 +1834,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: xEdge
       real (kind=RKIND), dimension(:), pointer :: yEdge
       integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nEdgesSolve, nEdges, nCells
-      integer :: iEdge, cell1, cell2, edgeID, iCell
+      integer, pointer :: nEdgesSolve, nEdges
+      integer :: iEdge, cell1, cell2
 
       err = 0
 
@@ -1887,7 +1861,6 @@ module li_subglacial_hydro
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
@@ -1912,21 +1885,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
-      call mpas_pool_get_array(hydroPool, 'openingRate', openingRate)
-      call mpas_pool_get_array(hydroPool, 'closingRate', closingRate)
-      call mpas_pool_get_array(hydroPool, 'diffMassConserveRate', diffMassConserveRate)
-      call mpas_pool_get_array(hydroPool, 'distributeMassCell', distributeMassCell)
-      call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
-      call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
-      call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
-      call mpas_pool_get_array(hydroPool, 'divergence', divergence)
-      call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
-      call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
-      call mpas_pool_get_array(hydroPool, 'tillWaterThickness', tillWaterThickness)
-      call mpas_pool_get_array(hydroPool, 'tillWaterThicknessOld', tillWaterThicknessOld)
-      call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(meshPool, 'xCell', xCell)
@@ -1934,7 +1892,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
       call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
@@ -2041,33 +1998,12 @@ module li_subglacial_hydro
       end do
       channelClosingRate(:) = creep_coeff * channelArea(:) * flowParamAChannel(:) * channelEffectivePressure(:)**3
 
-      !There are two ways to calculate waterThickness, one using conservation of mass and one using cavity opening/closing, 
-      !but these do not always agree. We want waterThickness to be a product of cavity opening/closing, meaning we need
-      !to use channels as an alternate way to restore mass conservation. This is done by calculating the difference between the two
-      !different waterThickness methods and adjusting channelChangeRate to make up the difference.
-
-      diffMassConserveRate = (openingRate - closingRate) - &
-             ( (basalMeltInput + externalWaterInput) / rho_water &
-             + channelMeltInputCell &
-             - divergence  &
-             - divergenceChannel - channelAreaChangeCell  &
-             - (tillWaterThickness - tillWaterThicknessOld) / deltatSGH )
-
-      !Evenly distributed remaining mass across all channels flowing into cell and add to channelChangeRate
-      do iCell = 1, nCells
-         distributeMassCell(iCell) = diffMassConserveRate(iCell) / nEdgesOnCell(iCell)
-           do iEdge = 1, nEdgesOnCell(iCell)
-               edgeID = edgesOnCell(iEdge,iCell) 
-               channelChangeRate(edgeID) = channelOpeningRate(edgeID) - channelClosingRate(edgeID) + distributeMassCell(iCell) * dcEdge(edgeID) * 0.5_RKIND
-         end do
-      end do
-
       where (waterFluxMask == 2)
          channelOpeningRate = 0.0_RKIND
          channelClosingRate = 0.0_RKIND
-         channelChangeRate = 0.0_RKIND
       end where
-      
+      channelChangeRate = channelOpeningRate - channelClosingRate
+
       !calculate total grounding line discharges
       totalGroundingLineDischargeCell(:) = 0.0_RKIND
       totalGroundingLineDischargeEdge(:) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -857,14 +857,10 @@ module li_subglacial_hydro
 
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
-      ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
-      ! but that is unrealistic.
-      ! So for all boundaries of the hydro system where outflow is occuring,
-      ! the hydropotential at the margin should be determined by the geometry
+      ! The hydropotential at the terrestrial margin should be determined by the geometry
       ! at the edge of the cell in a 1-sided sense.
       do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1)) then
+         if (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
@@ -892,45 +888,14 @@ module li_subglacial_hydro
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               !set to arbitrarily small value, not zero.
-               hydropotentialBaseSlopeNormal(iEdge) = min(1.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(1.0_RKIND, hydropotentialSlopeNormal(iEdge))
-               !debugging
-               !hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               !hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
                
-               !Just in case values are between 0 and 1.0e-15
-               !commented for debugging
-               if ((hydropotentialBaseSlopeNormal(iEdge) >= 0) .and. &
-                  (hydropotentialBaseSlopeNormal(iEdge) < 1.0_RKIND)) then
-
-                  hydropotentialBaseSlopeNormal(iEdge) = 1.0_RKIND
-               endif
-               if ((hydropotentialSlopeNormal(iEdge) >= 0) .and. &
-                  (hydropotentialSlopeNormal(iEdge) < 1.0_RKIND)) then
-
-                  hydropotentialSlopeNormal(iEdge) = 1.0_RKIND
-               endif
-            
             else ! cell1 is the cell outside the hydro domain
-               !commented for debugging
-               hydropotentialBaseSlopeNormal(iEdge) = max(-1.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(-1.0_RKIND, hydropotentialSlopeNormal(iEdge))
             
-               !debugging
-               !hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               !hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
               
-               if ((hydropotentialSlopeNormal(iEdge) <= 0) .and. &
-                  (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND)) then
-
-                  hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
-               endif
-              if ((hydropotentialBaseSlopeNormal(iEdge) <= 0) .and. &
-                  (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND)) then
-
-                  hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
-              endif
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -257,7 +257,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:,:), pointer :: temperature, flowParamA
       real (kind=RKIND), dimension(:), pointer :: Wtill, WtillOld
       real (kind=RKIND), dimension(:), pointer :: basalMeltInput
-      real (kind=RKIND), dimension(:), pointer :: groundedBasalMassBal
+      real (kind=RKIND), dimension(:), pointer :: groundedBasalMassBalApplied
       real (kind=RKIND), dimension(:), pointer :: basalHeatFlux
       real (kind=RKIND), dimension(:), pointer :: basalFrictionFlux
       real (kind=RKIND), dimension(:), pointer :: externalWaterInput
@@ -368,8 +368,8 @@ module li_subglacial_hydro
              call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
              call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
              call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
-             call mpas_pool_get_array(geometryPool,'groundedBasalMassBal',groundedBasalMassBal)
-             basalMeltInput = -1.0_RKIND * groundedBasalMassBal ! TODO: Ensure positive flux?
+             call mpas_pool_get_array(geometryPool,'groundedBasalMassBalApplied',groundedBasalMassBalApplied)
+             basalMeltInput = -1.0_RKIND * groundedBasalMassBalApplied ! TODO: Ensure positive flux?
          elseif (trim(config_SGH_basal_melt) == 'basal_heat') then
              call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
              call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
@@ -758,7 +758,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFlux
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
-      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
       real (kind=RKIND), dimension(:), pointer :: pressureField
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: waterFluxMask
@@ -851,7 +850,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'pressureField', pressureField)
       
@@ -967,11 +965,9 @@ module li_subglacial_hydro
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                     if (hydroMarineMarginMask(iEdge) == 1) then
                             if (hydropotentialBaseSlopeNormal(iEdge) > -1.0_RKIND) then
-                                channelDebugMask(iEdge) = 1
                                 hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
                             endif
                             if (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND) then
-                                 channelDebugMask(iEdge) = 1
                                  hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
                             endif
                     endif
@@ -1798,6 +1794,8 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: rhoi
       real (kind=RKIND), pointer :: config_SGH_incipient_channel_width
       logical, pointer :: config_SGH_include_pressure_melt
+      real (kind=RKIND), pointer :: config_SGH_bed_roughness_max
+      real (kind=RKIND), pointer :: config_sea_level
 
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelMelt
@@ -1816,17 +1814,28 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
       real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: waterThickness
+      real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, pointer :: nVertLevels
-
-      integer, pointer :: nEdgesSolve
-      integer, pointer :: nEdges
+      real (kind=RKIND), pointer :: config_SGH_max_chnl_lake_depth
+      character (len=StrKIND), pointer :: config_SGH_inhibit_chnls_on_lakes
+      real (kind=RKIND), dimension(:), pointer :: xCell
+      real (kind=RKIND), dimension(:), pointer :: yCell
+      real (kind=RKIND), dimension(:), pointer :: xEdge
+      real (kind=RKIND), dimension(:), pointer :: yEdge
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nEdgesSolve, nEdges
       integer :: iEdge, cell1, cell2
-
 
       err = 0
 
@@ -1837,6 +1846,7 @@ module li_subglacial_hydro
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_conduc_coeff', Kc)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_alpha', alpha_c)
@@ -1844,7 +1854,10 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_creep_coefficient', creep_coeff)
       call mpas_pool_get_config(liConfigs, 'config_SGH_incipient_channel_width', config_SGH_incipient_channel_width)
       call mpas_pool_get_config(liConfigs, 'config_SGH_include_pressure_melt', config_SGH_include_pressure_melt)
-
+      call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', config_SGH_bed_roughness_max)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_max_chnl_lake_depth', config_SGH_max_chnl_lake_depth)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_inhibit_chnls_on_lakes', config_SGH_inhibit_chnls_on_lakes)
+      
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
@@ -1869,8 +1882,21 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
+      call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
+      call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(meshPool, 'xCell', xCell)
+      call mpas_pool_get_array(meshPool, 'yCell', yCell)
+      call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
+      call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+
       ! Calculate terms needed for opening (melt) rate
 
       where(gradMagPhiEdge < 0.01_RKIND)
@@ -1906,6 +1932,39 @@ module li_subglacial_hydro
        ! channelDischarge = 0.0_RKIND
         !channelArea = 0.0_RKIND
       !end where
+      
+      !Inhibit Channel discharge within subglacial lake interiors
+      select case (trim(config_SGH_inhibit_chnls_on_lakes))
+
+      !Completely turn off channel discharge if lake depth above threshold value
+      case ('lakeDepth')
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+
+            if (((waterThickness(cell1) - config_SGH_bed_roughness_max) > config_SGH_max_chnl_lake_depth) &
+                    .or. ((waterThickness(cell2) - config_SGH_bed_roughness_max) > config_SGH_max_chnl_lake_depth) &
+                     .and. (hydroMarineMarginMask(iEdge) .ne. 1)) then
+
+                     channelDischarge(iEdge) = 0.0_RKIND
+            endif
+          enddo
+
+      case ('flotation') !turn off channelDischarge if above flotation
+         do iEdge = 1, nEdges
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+
+            if ( (waterPressure(cell1) >= (rhoi * gravity * iceThicknessHydro(cell1))) .or. &
+                    (waterPressure(cell2) >= (rhoi * gravity * iceThicknessHydro(cell2))) .and. &
+                    (hydroMarineMarginMask(iEdge) .ne. 1) ) then
+
+               channelDischarge(iEdge) = 0.0_RKIND
+            endif
+         enddo
+      case('none')
+      case default
+      end select
 
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)
 
@@ -1960,6 +2019,29 @@ module li_subglacial_hydro
       end where
       channelChangeRate = channelOpeningRate - channelClosingRate
 
+      !calculate total grounding line discharges
+      totalGroundingLineDischargeCell(:) = 0.0_RKIND
+      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            ! We are looking for edges with 1 cell grounded ice and the
+            ! other cell floating ice or open ocean
+            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
+                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
+            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
+                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
+            endif
+         endif
+      enddo
 
    !--------------------------------------------------------------------
    end subroutine update_channel

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -45,6 +45,7 @@ module li_mask
    integer, parameter :: li_mask_ValueAlbanyMarginNeighbor  = 128  ! This the first cell beyond the last active albany cell
    integer, parameter :: li_mask_ValueGroundingLine         = 256
       !< This is grounded cell that has a floating neighbor, or vertex/edge on that boundary
+   integer, parameter :: li_mask_ValueDomainBoundary        = 512
 
    !--------------------------------------------------------------------
    !
@@ -143,7 +144,18 @@ module li_mask
       module procedure li_mask_is_grounding_line_logout_0d
    end interface
 
-   !--------------------------------------------------------------------
+
+   interface li_mask_is_boundary
+      module procedure li_mask_is_boundary_logout_1d
+      module procedure li_mask_is_boundary_logout_0d
+   end interface
+
+
+   interface li_mask_is_boundary_int
+      module procedure li_mask_is_boundary_intout_1d
+      module procedure li_mask_is_boundary_intout_0d
+   end interface   
+!--------------------------------------------------------------------
    !
    ! Private module variables
    !
@@ -294,10 +306,10 @@ contains
       logical :: isMargin
       logical :: isAlbanyMarginNeighbor
       logical :: aCellOnVertexHasIce, aCellOnVertexHasNoIce, aCellOnVertexHasDynamicIce, aCellOnVertexHasNoDynamicIce, &
-         aCellOnVertexIsFloating, aCellOnVertexIsFloatingAndDynamic, aCellOnVertexIsAlbanyActive
+         aCellOnVertexIsFloating, aCellOnVertexIsFloatingAndDynamic, aCellOnVertexIsAlbanyActive, aCellOnVertexIsDomainBoundary
       logical :: aCellOnVertexIsGrounded
       logical :: aCellOnEdgeHasIce, aCellOnEdgeHasNoIce, aCellOnEdgeHasDynamicIce, aCellOnEdgeHasNoDynamicIce, &
-         aCellOnEdgeIsFloating, aCellOnEdgeIsFloatingAndDynamic
+         aCellOnEdgeIsFloating, aCellOnEdgeIsFloatingAndDynamic, aCellOnEdgeIsDomainBoundary
       logical :: aCellOnEdgeIsGrounded
       logical :: aCellOnEdgeIsOpenOcean
       integer :: numCellsOnVertex
@@ -473,6 +485,16 @@ contains
           endif
       enddo
 
+      !identify domain boundaries
+      do i=1,nCells
+          do j=1,nEdgesOnCell(i)
+             iCellNeighbor = cellsOnCell(j,i)
+             if (iCellNeighbor == nCells+1) then
+                cellMask(i) = ior(cellMask(i), li_mask_ValueDomainBoundary)
+             endif
+          enddo
+      enddo
+
       !call mpas_timer_stop('calculate mask cell')
 
       ! ====
@@ -503,6 +525,7 @@ contains
           aCellOnVertexIsFloating = .false.
           aCellOnVertexIsGrounded = .false.
           aCellOnVertexIsFloatingAndDynamic = .false.
+          aCellOnVertexIsDomainBoundary = .false.
           do j = 1, vertexDegree  ! vertexDegree is usually 3 (e.g. CVT mesh) but could be something else (e.g. 4 for quad mesh)
               iCell = cellsOnVertex(j,i)
               aCellOnVertexHasIce = (aCellOnVertexHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -514,7 +537,9 @@ contains
                                                    (li_mask_is_floating_ice(cellMask(iCell)) .and. &
                                                     li_mask_is_dynamic_ice(cellMask(iCell))) )
               aCellOnVertexIsGrounded = (aCellOnVertexIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
+              aCellOnVertexIsDomainBoundary = (aCellOnVertexIsDomainBoundary .or. li_mask_is_boundary(cellMask(iCell)))
           end do
+
           if (aCellOnVertexHasIce) then
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueIce)
           endif
@@ -535,6 +560,9 @@ contains
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueDynamicMargin)
              ! vertex with both 1+ dynamic ice cell(s) and 1+ non-dynamic cell(s) as neighbors
           endif
+          if (aCellOnVertexIsDomainBoundary) then
+             vertexMask(i) = ior(vertexMask(i), li_mask_ValueDomainBoundary)
+          endif 
       end do
 
 
@@ -607,6 +635,7 @@ contains
           aCellOnEdgeIsGrounded = .false.
           aCellOnEdgeIsOpenOcean = .false.
           aCellOnEdgeIsFloatingAndDynamic = .false.
+          aCellOnEdgeIsDomainBoundary = .false.
           do j = 1, 2
               iCell = cellsOnEdge(j,i)
               aCellOnEdgeHasIce = (aCellOnEdgeHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -620,6 +649,7 @@ contains
               aCellOnEdgeIsGrounded = (aCellOnEdgeIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
               aCellOnEdgeIsOpenOcean = aCellOnEdgeIsOpenOcean .or. &
                  ((bedTopography(iCell) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCell))))
+              aCellOnEdgeIsDomainBoundary = (aCellOnEdgeIsDomainBoundary .or. li_mask_is_boundary(cellMask(iCell)))
           end do
           if (aCellOnEdgeHasIce) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueIce)
@@ -640,6 +670,9 @@ contains
           endif
           if (aCellOnEdgeHasDynamicIce .and. aCellOnEdgeHasNoDynamicIce) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueDynamicMargin)
+          endif
+          if (aCellOnEdgeIsDomainBoundary) then
+             edgeMask(i) = ior(edgeMask(i), li_mask_ValueDomainBoundary)
           endif
 
       end do
@@ -905,8 +938,35 @@ contains
       li_mask_is_initial_ice_logout_0d = (iand(mask, li_mask_ValueInitialIceExtent) == li_mask_ValueInitialIceExtent)
    end function li_mask_is_initial_ice_logout_0d
 
+   ! -- Functions that check for domain boundary --
+   function li_mask_is_boundary_logout_1d(mask)
+      integer, dimension(:), intent(in) :: mask
+      logical, dimension(size(mask)) :: li_mask_is_boundary_logout_1d
+
+      li_mask_is_boundary_logout_1d = (iand(mask, li_mask_ValueDomainBoundary) == li_mask_ValueDomainBoundary)
+   end function li_mask_is_boundary_logout_1d
+
+   function li_mask_is_boundary_logout_0d(mask)
+      integer, intent(in) :: mask
+      logical :: li_mask_is_boundary_logout_0d
+
+      li_mask_is_boundary_logout_0d = (iand(mask, li_mask_ValueDomainBoundary) == li_mask_ValueDomainBoundary)
+   end function li_mask_is_boundary_logout_0d
 
 
+   function li_mask_is_boundary_intout_1d(mask)
+      integer, dimension(:), intent(in) :: mask
+      integer, dimension(size(mask)) :: li_mask_is_boundary_intout_1d
+
+      li_mask_is_boundary_intout_1d = iand(mask, li_mask_ValueDomainBoundary) / li_mask_ValueDomainBoundary
+   end function li_mask_is_boundary_intout_1d
+
+   function li_mask_is_boundary_intout_0d(mask)
+      integer, intent(in) :: mask
+      integer :: li_mask_is_boundary_intout_0d
+
+      li_mask_is_boundary_intout_0d = iand(mask, li_mask_ValueDomainBoundary) / li_mask_ValueDomainBoundary
+   end function li_mask_is_boundary_intout_0d
 !***********************************************************************
 ! Private subroutines:
 !***********************************************************************

--- a/components/mpas-albany-landice/src/shared/mpas_li_setup.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_setup.F
@@ -53,7 +53,8 @@ module li_setup
              li_interpolate_vertex_to_cell_2d, &
              li_cells_to_vertices_1dfield_using_kiteAreas, &
              li_calculate_layerThickness, &
-             li_compute_gradient_2d
+             li_compute_gradient_2d, &
+             li_init_barycentric_weights_vertex
 
 
    !--------------------------------------------------------------------
@@ -815,6 +816,109 @@ contains
     deallocate(normalGrad)
 
   end subroutine li_compute_gradient_2d
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine li_init_barycentric_weights_vertex
+!
+!> \brief  compute barycentric weights for interpolating cells to vertices
+!> \author Matt Hoffman
+!> \date   May 2023
+!> \details
+!>  This routine uses a framework routine to compute the barycentric
+!>  weights for interpolating from cells to vertices
+!
+!-----------------------------------------------------------------------
+
+    subroutine li_init_barycentric_weights_vertex(block, err)
+
+      use mpas_geometry_utils, only: mpas_calculate_barycentric_weights_for_points
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: &
+         block          !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err            !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: scratchPool
+      integer :: iCell, iLevel, i, iVertex, err_tmp
+      integer, pointer :: nVertices
+      character (len=StrKIND), pointer :: config_velocity_solver
+      character (len=StrKIND), pointer :: config_sia_tangent_slope_calculation
+      logical, pointer :: config_SGH
+      character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
+      integer, dimension(:,:), pointer :: baryCellsOnVertex
+      real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
+      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+      type (field1dInteger), pointer :: vertexIndicesField
+
+      ! No block init needed.
+      err = 0
+      err_tmp = 0
+
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+      call mpas_pool_get_array(meshPool, 'baryCellsOnVertex', baryCellsOnVertex)
+      call mpas_pool_get_array(meshPool, 'baryWeightsOnVertex', baryWeightsOnVertex)
+      call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+      call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+      call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+      call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
+      call mpas_pool_get_config(liConfigs, 'config_sia_tangent_slope_calculation', config_sia_tangent_slope_calculation)
+      call mpas_pool_get_config(liConfigs, 'config_SGH', config_SGH)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
+      call mpas_pool_get_field(scratchPool, 'vertexIndices', vertexIndicesField)
+      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
+
+      if ( &
+          (trim(config_velocity_solver) == 'sia' .and. &
+           trim(config_sia_tangent_slope_calculation) == 'from_vertex_barycentric') &
+          .or. &
+          (config_SGH .and. trim(config_SGH_tangent_slope_calculation) == 'from_vertex_barycentric')) then
+
+         call mpas_allocate_scratch_field(vertexIndicesField, .true.)
+         do iVertex = 1, nVertices
+            vertexIndicesField % array(iVertex) = iVertex
+         enddo
+         call mpas_calculate_barycentric_weights_for_points(meshPool, &
+                xVertex(1:nVertices), yVertex(1:nVertices), zVertex(1:nVertices), &
+                vertexIndicesField % array(1:nVertices), &
+                baryCellsOnVertex(:, 1:nVertices), baryWeightsOnVertex(:, 1:nVertices), err_tmp)
+         ! TODO: Until framework can handle periodic meshs gracefully, this will return an error
+         ! for periodic meshes.  This error means that the velocity solver will be very wrong across
+         ! the periodicity, but it will be fine everywhere else.  For now, just print a warning but
+         ! don't make this a fatal error.
+         !err = ior(err, err_tmp)
+         if (err_tmp > 0) then
+            call mpas_log_write("The 'from_vertex_barycentric' option for 'config_sia_tangent_slope_calculation' " &
+                 // "'config_SGH_tangent_slope_calculation' " &
+                 // "does NOT work across the periodicity in periodic meshes.  However, it does work within the interior " &
+                 // "of the mesh.", MPAS_LOG_WARN)
+         endif
+         call mpas_deallocate_scratch_field(vertexIndicesField, .true.)
+
+      endif
+
+      ! === error check
+      if (err > 0) then
+          call mpas_log_write("An error has occurred in li_init_barycentric_weights_vertex", MPAS_LOG_ERR)
+      endif
+
+  end subroutine li_init_barycentric_weights_vertex
 
 
 !***********************************************************************


### PR DESCRIPTION
Introduces updates to the subglacial hydrology model to make it more stable, particularly around irregular bed/surface topography, near domain edges, over subglacial lakes, at the grounding line when coupled with ice dynamics, and when using the channelPressureFreeze term.

Important changes made:

- Add missing channel melt source term to mass conservation equation
- Disable diffusive flux at grounding line and at boundary edges
- Update of gradients along boundaries of domain
- Update gradMagPhiEdge to be dependent on full hydropotential, used only by channels. Distributed system is now dependent on gradMagPhiBaseEdge, which is equivalent to gradMagPhiEdge in previous commits.
- Introduces iceThicknessHydro and upperSurfaceHydro. These are copies of thickness and upperSurface that have local minima/maxima made equal to the mean of their neighbors. Done to enhance channel stability and is only used by the hydro model. 
- New output variable hydroTerrestrialMarginMask
- Allow for waterPressure above overburden (but disallow negative effective pressure)
- Impose small outflowing waterflux and hydropotential gradient at grounding line. Used instead of zeroing out waterFlux to inhibit inflow.
- Give ocean zero hydropotential and waterPressure, then allow for two-sided calculation of hydropotential across grounding line
- Introduce waterPressureSmooth, a smoothed version of waterPressure that is used only when calculating waterPressureSlopeNormal and channelPressureFreeze. Helps keep channelPressureFreeze stable
- Create option to limit channel growth over subglacial lakes. Done by making channelDischarge = 0 when subglacial lake depth is over a threshold value or if waterPressure is over flotation. channelArea is not affected so that channels do not have to start from scratch if lake geometry changes, essentially creating "ghost channels" over lakes