### PR TITLE
Subglacial hydro boundary and channel cleanup

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1125,10 +1125,10 @@ is the value of that variable from the *previous* time level!
                 />
 		<!-- Variables only needed by SIA solver -->
 		<var name="baryCellsOnVertex" type="integer" dimensions="R3 nVertices" units="unitless"
-			 description="Cell center indices to use for interpolating from cell centers to vertex locations.  Note these are local indices!" packages="SIAvelocity"
+			 description="Cell center indices to use for interpolating from cell centers to vertex locations.  Note these are local indices!" packages="SIAvelocity;hydro"
 		/>
 		<var name="baryWeightsOnVertex" type="real" dimensions="R3 nVertices" units="unitless"
-			 description="Weights to interpolate from cell centers to vertex locations.  Each weight is used with the corresponding cell center index indentified by baryCellsOnVertex." packages="SIAvelocity"
+			 description="Weights to interpolate from cell centers to vertex locations.  Each weight is used with the corresponding cell center index indentified by baryCellsOnVertex." packages="SIAvelocity;hydro"
 		/>
 		<!-- Variables only needed by HO solver -->
 		<var name="wachspressWeightVertex" type="real" dimensions="maxEdges nCells" units="unitless"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -869,7 +869,8 @@
                         <var name="groundedBasalMassBal" packages="hydro"/>  <!-- This is only needed if config_SGH_basal_melt='thermal', but adding it always-->
 			<var name="basalMeltInput" packages="hydro"/>  <!-- This is NOT needed if config_SGH_basal_melt='thermal', but adding it always-->
                         <var name="externalWaterInput" packages="hydro"/>
-                        <!-- SGH state variables: -->
+                        <!-- SGH variables: -->
+                        <var name="deltatSGH" packages="hydro"/>
 			<var name="waterThickness" packages="hydro"/>
 			<var name="tillWaterThickness" packages="hydro"/>
 			<var name="waterPressure" packages="hydro"/>

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -24,7 +24,7 @@
 		            description="Selection of the method for calculating the tangent component of slope at edges.
 'from_vertex_barycentric' interpolates scalar values from cell centers to vertices using the barycentric interpolation routine in operators (mpas_cells_to_points_using_baryweights) and then calculates the slope between vertices.  It works for obtuse triangles, but will not work correctly across the edges of periodic meshes.
 'from_vertex_barycentric_kiteareas' interpolates scalar values from cell centers to vertices using barycentric interpolation based on kiterea values and then calculates the slope between vertices.  It will work across the edges of periodic meshes, but will not work correctly for obtuse triangles.
-'from_normal_slope' uses the vector operator mpas_tangential_vector_1d to calculate the tangent slopes from the normal slopes on the edges of the adjacent cells.  It will work for any mesh configuration, but is the least accurate method."
+'from_normal_slope' uses the vector operator mpas_tangential_vector_1d to calculate the tangent slopes from the normal slopes on the edges of the adjacent cells.  It will work for any mesh configuration. 'from_normal_slope' uses a larger stencil, so may therefore produce a smoother 'gradMagPhiEdge' field. Detailed testing yielded nearly identical results between 'from_normal_slope' and 'from_vertex_barycentric' methods, but 'from_normal_slope' seemed to produce slightly more stable results at the grounding line."
 		            possible_values="'from_vertex_barycentric', 'from_vertex_barycentric_kiteareas', 'from_normal_slope'"
 		/>
 		<nml_option name="config_SGH_pressure_calc" type="character" default_value="cavity" units="unitless"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -174,7 +174,9 @@
                      description="mask indicating how to handle fluxes on each edge: 0=calculate based on hydropotential gradient; 1=allow outflow based on hydropotential gradient, but no inflow (NOT YET IMPLEMENTED); 2=zero flux" />
                 <var name="hydroMarineMarginMask" type="integer" dimensions="nEdges Time" units="none"
                      description="mask indicating the marine boundary of the active subglacial hydrology domain" />
-                <var name="waterFluxAdvec" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
+		<var name="hydroTerrestrialMarginMask" type="integer" dimensions="nEdges Time" units="none"
+	 	     description="mask indicating the terrestrial boundary of the active subglacial hydrology domain" />
+		<var name="waterFluxAdvec" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
                      description="advective water flux in subglacial hydrology system" />
                 <var name="waterFluxDiffu" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"
                      description="diffusive water flux in subglacial hydrology system" />

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -251,6 +251,8 @@
                      description="divergence due to channel flow in subglacial hydrology system" />
                 <var name="channelAreaChangeCell" type="real" dimensions="nCells Time" units="m s^{-1}"
                      description="change in channel area within each cell, averaged over cell area" />
+                <var name="channelMeltInputCell" type="real" dimensions="nCells Time" units="m s^{-1}"
+                     description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
 

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -196,14 +196,20 @@
                      description="hydropotential in subglacial hydrology system without water thickness contribution" />
                 <var name="hydropotentialBaseVertex" type="real" dimensions="nVertices Time" units="Pa"
                      description="hydropotential without water thickness contribution on vertices.  Only used for some choices of config_SGH_tangent_slope_calculation." />
+                <var name="hydropotentialVertex" type="real" dimensions="nVertices Time" units="Pa"
+                     description="hydropotential on vertices.  Only used for some choices of config_SGH_tangent_slope_calculation." />
                 <var name="hydropotentialBaseSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of hydropotentialBase" />
                 <var name="hydropotentialSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of hydropotential" />
                 <var name="hydropotentialBaseSlopeTangent" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="tangent component of gradient of hydropotentialBase" />
-             <var name="gradMagPhiEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                <var name="hydropotentialSlopeTangent" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                     description="tangent component of gradient of hydropotential" />
+                <var name="gradMagPhiBaseEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="magnitude of the gradient of hydropotentialBase, on Edges" />
+                <var name="gradMagPhiEdge" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
+                     description="magnitude of the gradient of hydropotential, on Edges" />
                 <var name="waterPressureSlopeNormal" type="real" dimensions="nEdges Time" units="Pa m^{-1}"
                      description="normal component of gradient of waterPressure in subglacial hydrology system" />
                 <var name="divergence" type="real" dimensions="nCells Time" units="m s^{-1}"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -1025,6 +1025,10 @@ module li_core
       err = ior(err, err_tmp)
       call mpas_timer_stop("initialize velocity")
 
+      ! SIA and hydro need these weights initialized for some options
+      call li_init_barycentric_weights_vertex(block, err_tmp)
+      err = ior(err, err_tmp)
+
       ! Higher-order velo solvers needs vertex-to-cell interp routine initialized
       if ( (trim(config_velocity_solver) == 'L1L2') .or.    &
            (trim(config_velocity_solver) == 'FO') .or.      &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_sia.F
@@ -154,53 +154,9 @@ contains
       ! local variables
       !
       !-----------------------------------------------------------------
-      type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: scratchPool
-      integer :: iCell, iLevel, i, iVertex, err_tmp
-      integer, pointer :: nVertices
-      character (len=StrKIND), pointer :: config_sia_tangent_slope_calculation
-      integer, dimension(:,:), pointer :: baryCellsOnVertex
-      real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
-      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
-      type (field1dInteger), pointer :: vertexIndicesField
 
       ! No block init needed.
       err = 0
-      err_tmp = 0
-
-      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
-      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
-      call mpas_pool_get_array(meshPool, 'baryCellsOnVertex', baryCellsOnVertex)
-      call mpas_pool_get_array(meshPool, 'baryWeightsOnVertex', baryWeightsOnVertex)
-      call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
-      call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
-      call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
-      call mpas_pool_get_config(liConfigs, 'config_sia_tangent_slope_calculation', config_sia_tangent_slope_calculation)
-      call mpas_pool_get_field(scratchPool, 'vertexIndices', vertexIndicesField)
-      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
-
-      ! The SIA solver may need to setup these weights for calculating upperSurfaceVertex
-      if (trim(config_sia_tangent_slope_calculation) == 'from_vertex_barycentric') then
-         call mpas_allocate_scratch_field(vertexIndicesField, .true.)
-         do iVertex = 1, nVertices
-            vertexIndicesField % array(iVertex) = iVertex
-         enddo
-         call mpas_calculate_barycentric_weights_for_points(meshPool, &
-                xVertex(1:nVertices), yVertex(1:nVertices), zVertex(1:nVertices), &
-                vertexIndicesField % array(1:nVertices), &
-                baryCellsOnVertex(:, 1:nVertices), baryWeightsOnVertex(:, 1:nVertices), err_tmp)
-         ! TODO: Until framework can handle periodic meshs gracefully, this will return an error
-         ! for periodic meshes.  This error means that the velocity solver will be very wrong across
-         ! the periodicity, but it will be fine everywhere else.  For now, just print a warning but
-         ! don't make this a fatal error.
-         !err = ior(err, err_tmp)
-         if (err_tmp > 0) then
-            call mpas_log_write("The 'from_vertex_barycentric' option for 'config_sia_tangent_slope_calculation' " &
-                 // "does NOT work across the periodicity in periodic meshes.  However, it does work within the interior " &
-                 // "of the mesh.", MPAS_LOG_WARN)
-         endif
-         call mpas_deallocate_scratch_field(vertexIndicesField, .true.)
-      endif
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2183,6 +2183,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
       integer, pointer :: nEdgesSolve
@@ -2199,6 +2200,7 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+         call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
 
@@ -2215,6 +2217,20 @@ module li_subglacial_hydro
                      (li_mask_is_floating_ice(cellMask(cell1)) .or. &
                      ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
                hydroMarineMarginMask(iEdge) = 1
+            endif
+         enddo
+
+         hydroTerrestrialMarginMask(:) = 0
+         do iEdge = 1, nEdgesSolve
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            !Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
+               .and. (bedTopography(cell2) > config_sea_level)) then
+               hydroTerrestrialMarginMask(iEdge) = 1
+            elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
+               .and. (bedTopography(cell1) > config_sea_level)) then
+               hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2227,10 +2227,10 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             !Look for edges with 1 cell on grounding ice and the other cell on land without ice
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
-               .and. (bedTopography(cell2) > config_sea_level)) then
+               .and. (bedTopography(cell2) >= config_sea_level)) then
                hydroTerrestrialMarginMask(iEdge) = 1
             elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
-               .and. (bedTopography(cell1) > config_sea_level)) then
+               .and. (bedTopography(cell1) >= config_sea_level)) then
                hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -720,6 +720,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBase
       real (kind=RKIND), dimension(:), pointer :: hydropotential
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialVertex
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdge
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
@@ -728,6 +729,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: waterPressureSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseSlopeTangent
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeTangent
+      real (kind=RKIND), dimension(:), pointer :: gradMagPhiBaseEdge
       real (kind=RKIND), dimension(:), pointer :: gradMagPhiEdge
       real (kind=RKIND), dimension(:), pointer :: effectiveConducEdge
       real (kind=RKIND), dimension(:), pointer :: diffusivity
@@ -802,6 +805,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
+      call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
+      call mpas_pool_get_array(hydroPool, 'gradMagPhiBaseEdge', gradMagPhiBaseEdge)
       call mpas_pool_get_array(hydroPool, 'gradMagPhiEdge', gradMagPhiEdge)
       call mpas_pool_get_array(hydroPool, 'effectiveConducEdge', effectiveConducEdge)
       call mpas_pool_get_array(hydroPool, 'diffusivity', diffusivity)
@@ -890,10 +895,13 @@ module li_subglacial_hydro
          endif
       end do
 
-      ! Calculate tangent slope of hydropotentialBase - three possible methods to consider
+      ! Calculate tangent slope of hydropotential and hydropotentialBase - three possible methods to consider
 
       ! Calculate hydropotentialBaseVertex if needed
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseVertex', hydropotentialBaseVertex)
+         ! < this array could be protected by logic if desired
+      ! caluculate hydropotentialVertex if needed
+      call mpas_pool_get_array(hydroPool, 'hydropotentialVertex', hydropotentialVertex)
          ! < this array could be protected by logic if desired
       select case (trim(config_SGH_tangent_slope_calculation))
       case ('from_vertex_barycentric')
@@ -902,8 +910,11 @@ module li_subglacial_hydro
          call mpas_cells_to_points_using_baryweights(meshPool, baryCellsOnVertex(:, 1:nVertices), &
               baryWeightsOnVertex(:, 1:nVertices), hydropotentialBase, hydropotentialBaseVertex(1:nVertices), err_tmp)
               err = ior(err, err_tmp)
+         call mpas_cells_to_points_using_baryweights(meshPool, baryCellsOnVertex(:, 1:nVertices), &
+              baryWeightsOnVertex(:, 1:nVertices), hydropotential, hydropotentialVertex(1:nVertices), err_tmp)
       case ('from_vertex_barycentric_kiteareas')
          call li_cells_to_vertices_1dfield_using_kiteAreas(meshPool, hydropotentialBase, hydropotentialBaseVertex)
+         call li_cells_to_vertices_1dfield_using_kiteAreas(meshPool, hydropotential, hydropotentialVertex)
       end select
 
       ! Now perform tangent slope calculation based on method chosen
@@ -920,8 +931,11 @@ module li_subglacial_hydro
             if ( li_mask_is_ice(edgeMask(iEdge)) ) then
                hydropotentialBaseSlopeTangent(iEdge) = ( hydropotentialBaseVertex(verticesOnEdge(1,iEdge)) -  &
                      hydropotentialBaseVertex(verticesOnEdge(2,iEdge)) ) / dvEdge(iEdge)
+               hydropotentialSlopeTangent(iEdge) = ( hydropotentialVertex(verticesOnEdge(1,iEdge)) -  &
+                     hydropotentialVertex(verticesOnEdge(2,iEdge)) ) / dvEdge(iEdge)
             else
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
             ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
             do i = 1, 2
@@ -930,17 +944,23 @@ module li_subglacial_hydro
                   iCell = cellsOnVertex(j, iVertex)
                   if (iCell == nCells + 1) then
                      hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+                     hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
                   endif
                enddo
             enddo
          end do  ! edges
       case ('from_normal_slope')
+         ! Do first with hydropotentialBase
          call mpas_tangential_vector_1d(hydropotentialBaseSlopeNormal, meshPool, &
-                  includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         ! Repeat for full hydropotential
+         call mpas_tangential_vector_1d(hydropotentialSlopeNormal, meshPool, &
+         includeHalo=.false., tangentialVector=hydropotentialSlopeTangent)
          ! ensure that edges that don't have ice on at least one side have tangent slope set to zero
          do iEdge = 1, nEdges
             if ( .not. li_mask_is_ice(edgeMask(iEdge)) ) then
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
          end do  ! edges
       case default
@@ -949,8 +969,12 @@ module li_subglacial_hydro
       end select
 
       ! calculate magnitude of gradient of Phi
-      gradMagPhiEdge = sqrt(hydropotentialBaseSlopeNormal**2 + hydropotentialBaseSlopeTangent**2)
-
+      gradMagPhiEdge = sqrt(hydropotentialSlopeNormal**2 + hydropotentialSlopeTangent**2)
+      
+      ! calculate magnitude of gradient of hydropotentialBase
+      gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 +&
+      hydropotentialBaseSlopeTangent**2)
+      
       ! calculate effective conductivity on edges
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
@@ -959,12 +983,12 @@ module li_subglacial_hydro
                              conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
                              (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
             effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-               (gradMagPhiEdge(iEdge)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+               (gradMagPhiBaseEdge(iEdge)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
          end do
       else
          ! Just use a single conductivity coeff.
          effectiveConducEdge(:) = conduc_coeff * waterThicknessEdge(:)**(alpha-1.0_RKIND) *&
-            (gradMagPhiEdge(:)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+            (gradMagPhiBaseEdge(:)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
       endif
 
       ! calculate diffusivity on edges

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -998,6 +998,7 @@ module li_subglacial_hydro
          ! we also don't want to assume it's the ocean water column height, because that would imply
          ! a diffusive flux inward, which is undesirable. So disabling diffusion at the GL.
          if (hydroMarineMarginMask(iEdge) == 1) then
+            diffusivity(iEdge) = 0.0_RKIND
             waterFluxDiffu(iEdge) = 0.0_RKIND
          else
             waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
@@ -1139,31 +1140,43 @@ module li_subglacial_hydro
          call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
          call mpas_pool_get_array(meshPool, 'indexToEdgeID', indexToEdgeID)
 
-         ! Calculate advective CFL-limited time step
-         dtSGHadvecBlock = 0.5_RKIND * minval(dcEdge(1:nEdgesSolve) / (abs(waterVelocity(1:nEdgesSolve)) &
-            + 1.0e-12_RKIND))  ! regularize
+         dtSGHadvecBlock = bigNumber
+         dtSGHdiffuBlock = bigNumber
+         dtSGHpressureBlock = bigNumber
+         dtSGHadvecChanBlock = bigNumber
+         dtSGHdiffuChanBlock = bigNumber
+
+         do iEdge = 1, nEdgesSolve
+            ! Calculate advective CFL-limited time step
+            if (abs(waterVelocity(iEdge)) > 0.0) then
+               dtSGHadvecBlock = min(dtSGHadvecBlock, 0.5_RKIND * dcEdge(iEdge) / abs(waterVelocity(iEdge)))
+            endif
+
+            if (diffusivity(iEdge) > 0.0) then
+               ! Calculate diffusive CFL-limited time step
+               dtSGHdiffuBlock = min(dtSGHdiffuBlock, 0.25_RKIND * dcEdge(iEdge)**2 / diffusivity(iEdge))
+               ! Calculate pressure limited time step
+               dtSGHpressureBlock = min(dtSGHpressureBlock, 1.0_RKIND * porosity * dcEdge(iEdge)**2 &
+                      / (2.0_RKIND * diffusivity(iEdge)))
+            endif
+
+            if (config_SGH_chnl_active) then
+               if (abs(channelVelocity(iEdge)) > 0.0) then
+                  ! Calculate channel advection limited time step
+                  dtSGHadvecChanBlock = min(dtSGHadvecChanBlock, 0.5_RKIND * dcEdge(iEdge) / (abs(channelVelocity(iEdge))))
+               endif
+               ! Calculate channel diffusion limited time step
+               if (channelDiffusivity(iEdge) > 0.0) then
+                  dtSGHdiffuChanBlock = min(dtSGHdiffuChanBlock, 0.25_RKIND * dcEdge(iEdge)**2 / channelDiffusivity(iEdge))
+               endif
+            endif
+         enddo
+
          dtSGHadvecProc = min(dtSGHadvecProc, dtSGHadvecBlock)
-
-         ! Calculate diffusive CFL-limited time step
-         dtSGHdiffuBlock = 0.25_RKIND * minval(dcEdge(1:nEdgesSolve)**2 / (diffusivity(1:nEdgesSolve) + 1.0e-12_RKIND))
          dtSGHdiffuProc = min(dtSGHdiffuProc, dtSGHdiffuBlock)
-
-         ! Calculate pressure limited time step
-         dtSGHpressureBlock = 1.0_RKIND * minval(porosity * dcEdge(1:nEdgesSolve)**2 &
-                   / (2.0_RKIND * diffusivity(1:nEdgesSolve) + 1.0e-12_RKIND))
          dtSGHpressureProc = min(dtSGHpressureProc, dtSGHpressureBlock)
-
-         if (config_SGH_chnl_active) then
-            ! Calculate channel advection limited time step
-            dtSGHadvecChanBlock = 0.5_RKIND * minval(dcEdge(1:nEdgesSolve) / (abs(channelVelocity(1:nEdgesSolve)) &
-               + 1.0e-12_RKIND))
-            ! regularize
-            dtSGHadvecChanProc = min(dtSGHadvecChanProc, dtSGHadvecChanBlock)
-            ! Calculate channel diffusion limited time step
-            dtSGHdiffuChanBlock = 0.25_RKIND * minval(dcEdge(1:nEdgesSolve)**2 / (channelDiffusivity(1:nEdgesSolve) + &
-               1.0e-12_RKIND))
-            dtSGHdiffuChanProc = min(dtSGHdiffuChanProc, dtSGHdiffuChanBlock)
-         endif
+         dtSGHadvecChanProc = min(dtSGHadvecChanProc, dtSGHadvecChanBlock)
+         dtSGHdiffuChanProc = min(dtSGHdiffuChanProc, dtSGHdiffuChanBlock)
 
          ! Master deltat is needed below, so grab it in this block loop
          call mpas_pool_get_array(meshPool, 'deltat', deltat)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -889,6 +889,16 @@ module li_subglacial_hydro
          endif ! GL edge or grounded margin
       end do
 
+      ! zero gradients at boundaries of the mesh
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+         if ((cell1 == nCells+1) .or. (cell2 == nCells+1)) then
+            hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
+            hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
+            waterPressureSlopeNormal(iEdge) = 0.0_RKIND
+         endif
+      end do
 
       ! Calculate tangent slope of hydropotentialBase - three possible methods to consider
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -544,19 +544,6 @@ module li_subglacial_hydro
 
 
       ! =============
-      ! Calculate pressure field
-      ! =============
-      block => domain % blocklist
-      do while (associated(block))
-
-         call calc_pressure(block, err_tmp)
-         err = ior(err, err_tmp)
-
-         block => block % next
-      end do
-
-
-      ! =============
       ! Update water layer thickness
       ! =============
       block => domain % blocklist
@@ -588,6 +575,33 @@ module li_subglacial_hydro
          waterThickness = max(0.0_RKIND, waterThickness)
          divergence = divergence * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations for more convenient viz
          waterThicknessTendency = (waterThickness - waterThicknessOld) / deltatSGH
+
+         block => block % next
+      end do
+
+      ! =============
+      ! Calculate pressure field
+      ! =============
+      ! Note: In Bueler and van Pelt, pressure is updated before waterThickness
+      ! (step vii on page 1625).  It does not matter which order they are calculated
+      ! because the update calculations are formulated on intermediate variables
+      ! such that neither depend directly on the other in the actual update.
+      ! However, calc_pressure also calculates the full hydropotential (including
+      ! the water thickness elevation head) which *is* a direct function of water thickness,
+      ! making the ordering of that calculation important.
+      ! Because the pressure variables calculated here are meant to be used on the
+      ! following timestep (forward Euler), the full hydropotential should be using
+      ! the updated waterThickness, not the old one.  To achieve that, calc_pressure
+      ! is called here, after waterThickness has been updated.
+      ! Note that the full hydropotential is only used by the channel model, so this
+      ! ordering choice is only needed to support channels.  Without it, runs with
+      ! channels would use an out of date waterThickness in the hydropotential and
+      ! do not restart correctly due to the order of operations mismatch.
+      block => domain % blocklist
+      do while (associated(block))
+
+         call calc_pressure(block, err_tmp)
+         err = ior(err, err_tmp)
 
          block => block % next
       end do
@@ -972,11 +986,11 @@ module li_subglacial_hydro
 
       ! calculate magnitude of gradient of Phi
       gradMagPhiEdge = sqrt(hydropotentialSlopeNormal**2 + hydropotentialSlopeTangent**2)
-      
+
       ! calculate magnitude of gradient of hydropotentialBase
       gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 +&
       hydropotentialBaseSlopeTangent**2)
-      
+
       ! calculate effective conductivity on edges
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -744,6 +744,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:,:), pointer :: verticesOnEdge
+      integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
       real (kind=RKIND), pointer :: alpha, beta
@@ -758,6 +759,7 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer, pointer :: nVertices
       integer :: iEdge, cell1, cell2
+      integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
@@ -917,11 +919,14 @@ module li_subglacial_hydro
       end select
 
       ! Now perform tangent slope calculation based on method chosen
+      ! For the two vertex based methods, edges with vertices on the boundary of the mesh will have invalid values
+      ! For the normal slope method, any edges on cells that are at the edge of the mesh will have
+      ! contaminated values.
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
+      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
       select case (trim(config_SGH_tangent_slope_calculation))
       case ('from_vertex_barycentric', 'from_vertex_barycentric_kiteareas')
-         call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-         call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-         call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
          do iEdge = 1, nEdges
             ! Only calculate slope for edges that have ice on at least one side.
             if ( li_mask_is_ice(edgeMask(iEdge)) ) then
@@ -930,10 +935,26 @@ module li_subglacial_hydro
             else
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
             endif
+            ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
+            do i = 1, 2
+               iVertex = verticesOnEdge(i, iEdge)
+               do j = 1, 3
+                  iCell = cellsOnVertex(j, iVertex)
+                  if (iCell == nCells + 1) then
+                     hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+                  endif
+               enddo
+            enddo
          end do  ! edges
       case ('from_normal_slope')
          call mpas_tangential_vector_1d(hydropotentialBaseSlopeNormal, meshPool, &
                   includeHalo=.false., tangentialVector=hydropotentialBaseSlopeTangent)
+         ! ensure that edges that don't have ice on at least one side have tangent slope set to zero
+         do iEdge = 1, nEdges
+            if ( .not. li_mask_is_ice(edgeMask(iEdge)) ) then
+               hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+            endif
+         end do  ! edges
       case default
          call mpas_log_write('Invalid value for config_SGH_tangent_slope_calculation.', MPAS_LOG_ERR)
          err = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -259,6 +259,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThicknessTendency
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
+      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
       real (kind=RKIND), dimension(:), pointer :: dvEdge
       real (kind=RKIND), dimension(:), pointer :: areaCell
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
@@ -534,6 +535,7 @@ module li_subglacial_hydro
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'divergenceChannel')
          call mpas_dmpar_field_halo_exch(domain, 'channelAreaChangeCell')
+         call mpas_dmpar_field_halo_exch(domain, 'channelMeltInputCell')
          call mpas_dmpar_field_halo_exch(domain, 'channelArea')
          call mpas_timer_stop("halo updates")
       endif
@@ -570,12 +572,16 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'divergence', divergence)
          call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
          call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+         call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
          waterThicknessOld = waterThickness
-         waterThickness = waterThicknessOld + deltatSGH * ( (basalMeltInput + externalWaterInput) / rho_water - divergence  &
+         waterThickness = waterThicknessOld + deltatSGH * ( &
+             (basalMeltInput + externalWaterInput) / rho_water &
+             + channelMeltInputCell &
+             - divergence  &
              - divergenceChannel - channelAreaChangeCell  &
-             - (Wtill - WtillOld) / deltatSGH)
+             - (Wtill - WtillOld) / deltatSGH )
          waterThickness = waterThickness * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations
          waterThickness = max(0.0_RKIND, waterThickness)
          divergence = divergence * li_mask_is_grounded_ice_int(cellMask)  ! zero in non-grounded locations for more convenient viz
@@ -1777,6 +1783,7 @@ module li_subglacial_hydro
       end where
       channelChangeRate = channelOpeningRate - channelClosingRate
 
+
    !--------------------------------------------------------------------
    end subroutine update_channel
 
@@ -1816,9 +1823,11 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: meshPool
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelDischarge
+      real (kind=RKIND), dimension(:), pointer :: channelMelt, channelPressureFreeze
       real (kind=RKIND), dimension(:), pointer :: channelChangeRate
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
+      real (kind=RKIND), dimension(:), pointer :: channelMeltInputCell
       real (kind=RKIND), pointer :: deltatSGH
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -1834,9 +1843,12 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+      call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+      call mpas_pool_get_array(hydroPool, 'channelPressureFreeze', channelPressureFreeze)
       call mpas_pool_get_array(hydroPool, 'channelChangeRate', channelChangeRate)
       call mpas_pool_get_array(hydroPool, 'divergenceChannel', divergenceChannel)
       call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
+      call mpas_pool_get_array(hydroPool, 'channelMeltInputCell', channelMeltInputCell)
       call mpas_pool_get_dimension(meshPool, 'nCellsSolve', nCellsSolve)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
@@ -1848,6 +1860,7 @@ module li_subglacial_hydro
       ! Calculate flux divergence on cells and channel area change on cells
       divergenceChannel(:) = 0.0_RKIND  ! zero div before accumulating
       channelAreaChangeCell(:) = 0.0_RKIND  ! zero before accumulating
+      channelMeltInputCell(:) = 0.0_RKIND  ! zero before accumulating
       ! loop over locally owned cells
       do iCell = 1, nCellsSolve
          ! TODO: could limit to grounded cells only
@@ -1858,10 +1871,12 @@ module li_subglacial_hydro
             divergenceChannel(iCell) = divergenceChannel(iCell) - channelDischarge(iEdge) * edgeSignOnCell(iEdgeOnCell, iCell)
             channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND
                ! < only half of channel is in this cell
+            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water
          end do ! edges
       end do ! cells
       divergenceChannel(1:nCellsSolve) = divergenceChannel(1:nCellsSolve) / areaCell(1:nCellsSolve)
       channelAreaChangeCell(1:nCellsSolve) = channelAreaChangeCell(1:nCellsSolve) / areaCell(1:nCellsSolve)
+      channelMeltInputCell(1:nCellsSolve) = channelMeltInputCell(1:nCellsSolve) / areaCell(1:nCellsSolve)
 
       ! Now update channel area
       channelArea = channelChangeRate * deltatSGH + channelArea

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -108,6 +108,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: tillMax
       real (kind=RKIND), pointer :: rhoi, rhoo
+      logical, pointer :: config_do_restart
       real (kind=RKIND), pointer :: config_sea_level
       integer, pointer :: config_num_halos
       integer :: err_tmp
@@ -138,6 +139,7 @@ module li_subglacial_hydro
          err = ior(err, 1)
       endif
 
+      call mpas_pool_get_config(liConfigs, 'config_do_restart', config_do_restart)
       call mpas_pool_get_config(liConfigs, 'config_SGH_till_max', tillMax)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
@@ -152,9 +154,16 @@ module li_subglacial_hydro
 
          call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
 
-         ! Until init is done properly, make this tiny.  It will be updated at the end of the first subcycle.
-         ! TODO: Set time step appropriately on first subcycle of init
-         deltatSGH = 1.0e-4_RKIND ! in seconds
+         if (.not. config_do_restart) then
+            ! On cold start, set initial timestep to a small value.
+            ! On a restart we will use the value from the last subcycle of the previous
+            ! master timestep to make restarts BFB.
+            ! Note the value here is only used for the first update of thetill model;
+            ! the sheet and channel models calculate the adaptive timestep, but that is not
+            ! available for the till model as the code is currently organized.
+            ! TODO: Move till update until after adaptive timestep has been set
+            deltatSGH = 1.0e-4_RKIND ! in seconds
+         endif
 
          ! Mask needs to be initialized for pressure calcs to be correct
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -900,7 +900,7 @@ module li_subglacial_hydro
       ! Calculate hydropotentialBaseVertex if needed
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseVertex', hydropotentialBaseVertex)
          ! < this array could be protected by logic if desired
-      ! caluculate hydropotentialVertex if needed
+      ! calculate hydropotentialVertex if needed
       call mpas_pool_get_array(hydroPool, 'hydropotentialVertex', hydropotentialVertex)
          ! < this array could be protected by logic if desired
       select case (trim(config_SGH_tangent_slope_calculation))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -833,12 +833,29 @@ module li_subglacial_hydro
          waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
       end do
 
+      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
+      do iEdge = 1, nEdges
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
+             (hydroMarineMarginMask(iEdge)==1)) then
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            else ! cell1 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            endif ! which cell is icefree
+         endif ! if edge of grounded ice
+      end do
+
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
       ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
       ! but that is unrealistic.
-      ! So for all boundaries of the hydro system, the hydropotential at the margin should be determined by the geometry
-      ! at the edge of the cell in a 1-sided sense
+      ! So for all boundaries of the hydro system where outflow is occuring,
+      ! the hydropotential at the margin should be determined by the geometry
+      ! at the edge of the cell in a 1-sided sense.
       do iEdge = 1, nEdges
          if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
              (hydroMarineMarginMask(iEdge)==1)) then
@@ -860,35 +877,6 @@ module li_subglacial_hydro
                     max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
             endif ! which cell is icefree
          endif ! if edge of grounded ice
-      end do
-
-      ! Disallow flow from ocean to glacier, or land to glacier,
-      ! which can occur under some circumstances
-      ! For ocean this is invalid because ocean water has a different density!
-      ! For land this would only happen if there is a supply of water, which is not currently handled.
-      ! Do this by simply zeroing the hydropotential gradient in those cases.
-      ! (Do this step only after the other hydropotential special cases are treated above.)
-      do iEdge = 1, nEdges
-         ! Find edges along GL or margin to check for 'backwards' flow
-         if ((hydroMarineMarginMask(iEdge)==1) .or. &
-             li_mask_is_margin(edgeMask(iEdge)) ) then
-            ! Now check if flow is backwards
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            if (hydropotentialBaseSlopeNormal(iEdge) > 0.0_RKIND) then
-               ! flow is from cell2 to cell1
-               if (.not. li_mask_is_grounded_ice(cellMask(cell2))) then
-                  hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
-                  hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
-               endif
-            elseif (hydropotentialBaseSlopeNormal(iEdge) < 0.0_RKIND) then
-               ! flow is from cell1 to cell2
-               if (.not. li_mask_is_grounded_ice(cellMask(cell1))) then
-                  hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
-                  hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
-               endif
-            endif
-         endif ! GL edge or grounded margin
       end do
 
       ! zero gradients at boundaries of the mesh

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -963,11 +963,15 @@ module li_subglacial_hydro
          waterFluxAdvec(iEdge) = waterVelocity(iEdge) * waterThicknessEdgeUpwind(iEdge)
 
          ! diffusive flux
-         ! Note: At the GL, the water thickness for one cell will be 0, meaning a large gradient.  However, the
-         ! diffusivity uses a one sided water thickness.  It's unclear what really happens to lakes at the GL/margin.
-         waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
+         ! Note: Water thickness at the GL is undefined.  I don't think we want to assume it's 0, and
+         ! we also don't want to assume it's the ocean water column height, because that would imply
+         ! a diffusive flux inward, which is undesirable. So disabling diffusion at the GL.
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            waterFluxDiffu(iEdge) = 0.0_RKIND
+         else
+            waterFluxDiffu(iEdge) = -1.0_RKIND * diffusivity(iEdge) * (waterThickness(cell2) - waterThickness(cell1)) &
                / dcEdge(iEdge)
-         !endif
+         endif
       end do
       where (waterFluxMask == 2)
          waterFluxAdvec = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -465,6 +465,8 @@ module li_subglacial_hydro
          call mpas_timer_start("halo updates")
          call mpas_dmpar_field_halo_exch(domain, 'channelChangeRate')
          call mpas_dmpar_field_halo_exch(domain, 'channelDischarge')
+         call mpas_dmpar_field_halo_exch(domain, 'channelMelt')
+         call mpas_dmpar_field_halo_exch(domain, 'channelPressureFreeze')
          call mpas_timer_stop("halo updates")
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1018,6 +1018,7 @@ module li_subglacial_hydro
          endif
       end do
       where (waterFluxMask == 2)
+         diffusivity = 0.0_RKIND
          waterFluxAdvec = 0.0_RKIND
          waterFluxDiffu = 0.0_RKIND
          waterVelocity = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1930,10 +1930,11 @@ module li_subglacial_hydro
             iEdge = edgesOnCell(iEdgeOnCell, iCell)
             ! add on advective & diffusive fluxes
             divergenceChannel(iCell) = divergenceChannel(iCell) - channelDischarge(iEdge) * edgeSignOnCell(iEdgeOnCell, iCell)
-            channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND
+            channelAreaChangeCell(iCell) = channelChangeRate(iEdge) * dcEdge(iEdge) * 0.5_RKIND + channelAreaChangeCell(iCell)
                ! < only half of channel is in this cell
-            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water
+            channelMeltInputCell(iCell) = 0.5_RKIND * (channelMelt(iEdge) - channelPressureFreeze(iEdge)) * dcEdge(iEdge) / rho_water + channelMeltInputCell(iCell)
          end do ! edges
+
       end do ! cells
       divergenceChannel(1:nCellsSolve) = divergenceChannel(1:nCellsSolve) / areaCell(1:nCellsSolve)
       channelAreaChangeCell(1:nCellsSolve) = channelAreaChangeCell(1:nCellsSolve) / areaCell(1:nCellsSolve)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1652,7 +1652,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelVelocity
       real (kind=RKIND), dimension(:), pointer :: gradMagPhiEdge
       real (kind=RKIND), dimension(:), pointer :: waterFlux
-      real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseSlopeNormal
+      real (kind=RKIND), dimension(:), pointer :: hydropotentialSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: waterPressureSlopeNormal
       real (kind=RKIND), dimension(:), pointer :: channelOpeningRate
       real (kind=RKIND), dimension(:), pointer :: channelClosingRate
@@ -1698,7 +1698,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
       call mpas_pool_get_array(hydroPool, 'channelVelocity', channelVelocity)
       call mpas_pool_get_array(hydroPool, 'gradMagPhiEdge', gradMagPhiEdge)
-      call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeNormal', hydropotentialBaseSlopeNormal)
+      call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeNormal', hydropotentialSlopeNormal)
       call mpas_pool_get_array(hydroPool, 'waterPressureSlopeNormal', waterPressureSlopeNormal)
       call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
       call mpas_pool_get_array(hydroPool, 'channelOpeningRate', channelOpeningRate)
@@ -1720,7 +1720,7 @@ module li_subglacial_hydro
          channelDischarge(:) = 0.0_RKIND
       elsewhere
          channelDischarge = -1.0_RKIND * Kc * channelArea**alpha_c * gradMagPhiEdge**(beta_c - 2.0_RKIND) * &
-            hydropotentialBaseSlopeNormal
+            hydropotentialSlopeNormal
       end where
 
       where (waterFluxMask == 2)
@@ -1752,8 +1752,8 @@ module li_subglacial_hydro
             Kc * channelArea**(alpha_c - 1.0_RKIND) * gradMagPhiEdge**(beta_c - 2.0_RKIND))
       end where
 
-      channelMelt = (abs(channelDischarge * hydropotentialBaseSlopeNormal) &  ! channel dissipation
-                  +  abs(waterFlux * hydropotentialBaseSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
+      channelMelt = (abs(channelDischarge * hydropotentialSlopeNormal) &  ! channel dissipation
+                  +  abs(waterFlux * hydropotentialSlopeNormal * config_SGH_incipient_channel_width) & !some sheet dissipation
                   ) / latent_heat_ice
       channelPressureFreeze = -1.0_RKIND * iceMeltingPointPressureDependence * cp_freshwater * rho_water * &
          (channelDischarge + waterFlux * config_SGH_incipient_channel_width) &

--- a/components/mpas-albany-landice/src/shared/mpas_li_setup.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_setup.F
@@ -53,7 +53,8 @@ module li_setup
              li_interpolate_vertex_to_cell_2d, &
              li_cells_to_vertices_1dfield_using_kiteAreas, &
              li_calculate_layerThickness, &
-             li_compute_gradient_2d
+             li_compute_gradient_2d, &
+             li_init_barycentric_weights_vertex
 
 
    !--------------------------------------------------------------------
@@ -815,6 +816,109 @@ contains
     deallocate(normalGrad)
 
   end subroutine li_compute_gradient_2d
+
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  routine li_init_barycentric_weights_vertex
+!
+!> \brief  compute barycentric weights for interpolating cells to vertices
+!> \author Matt Hoffman
+!> \date   May 2023
+!> \details
+!>  This routine uses a framework routine to compute the barycentric
+!>  weights for interpolating from cells to vertices
+!
+!-----------------------------------------------------------------------
+
+    subroutine li_init_barycentric_weights_vertex(block, err)
+
+      use mpas_geometry_utils, only: mpas_calculate_barycentric_weights_for_points
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: &
+         block          !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err            !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: scratchPool
+      integer :: iCell, iLevel, i, iVertex, err_tmp
+      integer, pointer :: nVertices
+      character (len=StrKIND), pointer :: config_velocity_solver
+      character (len=StrKIND), pointer :: config_sia_tangent_slope_calculation
+      logical, pointer :: config_SGH
+      character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
+      integer, dimension(:,:), pointer :: baryCellsOnVertex
+      real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
+      real (kind=RKIND), dimension(:), pointer :: xVertex, yVertex, zVertex
+      type (field1dInteger), pointer :: vertexIndicesField
+
+      ! No block init needed.
+      err = 0
+      err_tmp = 0
+
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'scratch', scratchPool)
+      call mpas_pool_get_array(meshPool, 'baryCellsOnVertex', baryCellsOnVertex)
+      call mpas_pool_get_array(meshPool, 'baryWeightsOnVertex', baryWeightsOnVertex)
+      call mpas_pool_get_array(meshPool, 'xVertex', xVertex)
+      call mpas_pool_get_array(meshPool, 'yVertex', yVertex)
+      call mpas_pool_get_array(meshPool, 'zVertex', zVertex)
+      call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
+      call mpas_pool_get_config(liConfigs, 'config_sia_tangent_slope_calculation', config_sia_tangent_slope_calculation)
+      call mpas_pool_get_config(liConfigs, 'config_SGH', config_SGH)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
+      call mpas_pool_get_field(scratchPool, 'vertexIndices', vertexIndicesField)
+      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
+
+      if ( &
+          (trim(config_velocity_solver) == 'sia' .and. &
+           trim(config_sia_tangent_slope_calculation) == 'from_vertex_barycentric') &
+          .or. &
+          (config_SGH .and. trim(config_SGH_tangent_slope_calculation) == 'from_vertex_barycentric')) then
+
+         call mpas_allocate_scratch_field(vertexIndicesField, .true.)
+         do iVertex = 1, nVertices
+            vertexIndicesField % array(iVertex) = iVertex
+         enddo
+         call mpas_calculate_barycentric_weights_for_points(meshPool, &
+                xVertex(1:nVertices), yVertex(1:nVertices), zVertex(1:nVertices), &
+                vertexIndicesField % array(1:nVertices), &
+                baryCellsOnVertex(:, 1:nVertices), baryWeightsOnVertex(:, 1:nVertices), err_tmp)
+         ! TODO: Until framework can handle periodic meshs gracefully, this will return an error
+         ! for periodic meshes.  This error means that the velocity solver will be very wrong across
+         ! the periodicity, but it will be fine everywhere else.  For now, just print a warning but
+         ! don't make this a fatal error.
+         !err = ior(err, err_tmp)
+         if (err_tmp > 0) then
+            call mpas_log_write("The 'from_vertex_barycentric' option for 'config_sia_tangent_slope_calculation' " &
+                 // "'config_SGH_tangent_slope_calculation' " &
+                 // "does NOT work across the periodicity in periodic meshes.  However, it does work within the interior " &
+                 // "of the mesh.", MPAS_LOG_WARN)
+         endif
+         call mpas_deallocate_scratch_field(vertexIndicesField, .true.)
+
+      endif
+
+      ! === error check
+      if (err > 0) then
+          call mpas_log_write("An error has occurred in li_init_barycentric_weights_vertex", MPAS_LOG_ERR)
+      endif
+
+  end subroutine li_init_barycentric_weights_vertex
 
 
 !***********************************************************************


### PR DESCRIPTION
This PR introduces a number of fixes and improvements to the subglacial hydrology model to get it to run more stably, mostly related to handling of boundaries of the subglacial hydrology domain:

* Adds a missing channel melt source term to the mass cons eqn.  This term is typically very small but was missing
* Make channels see the elevation head of lake thickness in the hydropotential to avoid channels flowing in to lakes
* Disable diffusive water flux at grounding line where water thickness is undefined
* Explicitly handle gradients at boundaries of the mesh where they are undefined
* Move the ordering of the pressure calculation to enable consistency in the time levels used for key model variables (affects channel model only)
* Update channel CFL calculation to only consider valid edges
* zero the diffusivity at domain boundaries to prevent those edges from affecting diffusive CFL
* creation of new hydroTerrestrialMarginMask to be used for handling boundaries of the SGH domain
* other minor cleanup/adjustments
