### PR TITLE
Add subglacial hydrology quantities to the regional stats analysis member

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+/?xml version="1.0"?>
 <registry model="mpas" core="landice" core_abbrev="li" version="7.0">
 
 
@@ -936,6 +936,8 @@
                                 input_interval="initial_only"
                                 runtime_format="single_file">
                         <var name="regionCellMasks"/>
+                        <var name="regionEdgeMasks"/>
+                        <var name="regionVertexMasks"/>
                         <!--var name="nCellsInRegion"/>
                         <var name="regionVertexMasks"/>
                         <var name="nVerticesInRegion"/>
@@ -1734,6 +1736,12 @@ is the value of that variable from the *previous* time level!
         <var_struct name="regions" time_levs="1">
 	  <var name="regionCellMasks" type="integer" dimensions="nRegions nCells" units="unitless" default_value="1"
 	       description="masks set to 1 in cells that fall within a given region and 0 otherwise"
+	       />
+	  <var name="regionEdgeMasks" type="integer" dimensions="nRegions nEdges" units="unitless" default_value="1"
+	       description="masks set to 1 in edges that fall within a given region and 0 otherwise"
+	       />
+	  <var name="regionVertexMasks" type="integer" dimensions="nRegions nVertices" units="unitless" default_value="1"
+	       description="masks set to 1 in vertices that fall within a given region and 0 otherwise"
 	       />
 	  <!--var name="nCellsInRegion" type="integer" dimensions="nRegions" units="unitless"
 	       description="number of cells that fall within a given region"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -940,7 +940,7 @@
                         <var name="regionEdgeMasks"/>
                         <!--var name="nCellsInRegion"/>
                         <var name="regionVertexMasks"/>
-                            <var name="nVertice<gion"/>
+                        <var name="nVerticesInRegion"/>
                         <var name="nRegionsInGroup"/>
                         <var name="regionsInGroup"/>
                         <var name="regionMaskNames"/>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1,4 +1,4 @@
-/?xml version="1.0"?>
+<?xml version="1.0"?>
 <registry model="mpas" core="landice" core_abbrev="li" version="7.0">
 
 
@@ -842,6 +842,7 @@
 			<var name="sfcMassBal"/>
                         <var name="floatingBasalMassBal"/>
                         <var name="regionCellMasks"/>
+                        <var name="regionEdgeMasks"/>
                         <!-- If restart file sizes become too large, eigencalvingParameter,
                              groundedVonMisesThresholdStress, and floatingVonMisesThresholdStress
                              could be moved to packages. -->
@@ -937,10 +938,9 @@
                                 runtime_format="single_file">
                         <var name="regionCellMasks"/>
                         <var name="regionEdgeMasks"/>
-                        <var name="regionVertexMasks"/>
                         <!--var name="nCellsInRegion"/>
                         <var name="regionVertexMasks"/>
-                        <var name="nVerticesInRegion"/>
+                            <var name="nVertice<gion"/>
                         <var name="nRegionsInGroup"/>
                         <var name="regionsInGroup"/>
                         <var name="regionMaskNames"/>
@@ -1739,9 +1739,6 @@ is the value of that variable from the *previous* time level!
 	       />
 	  <var name="regionEdgeMasks" type="integer" dimensions="nRegions nEdges" units="unitless" default_value="1"
 	       description="masks set to 1 in edges that fall within a given region and 0 otherwise"
-	       />
-	  <var name="regionVertexMasks" type="integer" dimensions="nRegions nVertices" units="unitless" default_value="1"
-	       description="masks set to 1 in vertices that fall within a given region and 0 otherwise"
 	       />
 	  <!--var name="nCellsInRegion" type="integer" dimensions="nRegions" units="unitless"
 	       description="number of cells that fall within a given region"

--- a/components/mpas-albany-landice/src/analysis_members/Registry_regional_stats.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_regional_stats.xml
@@ -103,6 +103,41 @@
                         description="maximum basal speed in the domain"
                 />
 
+                <!-- stats related to subglacial hydrology -->
+                <var name="regionalSumSubglacialWaterVolume" type="real" dimensions="nRegions Time" units="m^3"
+                        description="area-integrated subglacial water volume within region"
+                />
+                <var name="regionalSumSubglacialLakeVolume" type="real" dimensions="nRegions Time" units="m^3"
+                        description="area-integrated volume of subglacial lakes within region, defined as water volume exceeding bed bump height"
+                />
+                <var name="regionalSumSubglacialLakeArea" type="real" dimensions="nRegions Time" units="m^2"
+                        description="area-integrated area of subglacial lakes within region"
+                />
+                <var name="regionalSumBasalMeltInput" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated basal meltwater contributing to the subglacial hydrologic system within region"
+                />
+                <var name="regionalSumExternalWaterInput" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated external meltwater contributing to the subglacial hydrologic system within region"
+                />
+                <var name="regionalSumChannelMelt" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated melt rate in the subglacial hydrologic system within region"
+                />
+                <var name="regionalSumDistWaterFluxMarineMargin" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated distributed subglacial water flux across marine boundaries (grounding lines or grounded marine margins) within region"
+                />
+                <var name="regionalSumDistWaterFluxTerrestrialMargin" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated distributed subglacial water flux across terrestrial margins within region"
+                />
+                <var name="regionalSumChnlWaterFluxMarineMargin" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated channelized subglacial water flux across marine boundaries (grounding lines or grounded marine margins) within region"
+                />
+                <var name="regionalSumChnlWaterFluxTerrestrialMargin" type="real" dimensions="nRegions Time" units="kg s^{-1}"
+                        description="area-integrated channelized subglacial water flux across terrestrial margins within region"
+                />
+                <var name="regionalAvgFlotationFraction" type="real" dimensions="nRegions Time" units="none"
+                        description="area-weighted average of the flotation fraction under grounded ice within region"
+                />
+
  	</var_struct>
 
 	<streams>

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -440,7 +440,8 @@ contains
                                         basalMeltInput(iCell) * areaCell(iCell)
 
                ! External water input
-               blockSumExternalWaterInput = blockSumExternalWaterInput + externalWaterInput(iCell) * areaCell(iCell)
+               blockSumExternalWaterInput = blockSumExternalWaterInput + &
+                   real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * externalWaterInput(iCell) * areaCell(iCell)
 
                ! Lake Volume
                if (waterThickness(iCell) > bedBumpMax) then

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F
@@ -461,13 +461,14 @@ contains
 
          end do ! end loop over cells
 
-         if (config_SGH) then
-            ! Loop over edges
-            do iEdge = 1, nEdgesSolve
+         ! Loop over edges
+         do iEdge = 1, nEdgesSolve
 
-               ! Flux across GL, units = kg/yr
-               blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
-                         * scyr * rhoi ! convert from m^2/s to kg/yr
+            ! Flux across GL, units = kg/yr
+            blockGLflux = blockGLflux + fluxAcrossGroundingLine(iEdge) * dvEdge(iEdge) &
+                      * scyr * rhoi ! convert from m^2/s to kg/yr
+
+            if (config_SGH) then
 
                ! Channel Melt
                blockSumChannelMelt = blockSumChannelMelt + abs(channelMelt(iEdge) * dcEdge(iEdge))
@@ -484,8 +485,9 @@ contains
                ! Meltwater discharge in channels across terrestrial margin
                blockSumChannelTerrestrialMeltFlux = blockSumChannelTerrestrialMeltFlux + abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
 
-            end do ! end loop over edges
-         endif
+            endif ! is SGH is turned on 
+         end do ! end loop over edges
+         
          block => block % next
       end do    ! end loop over blocks
 
@@ -530,9 +532,9 @@ contains
       sums(13) = blockSumCalvingFlux
       sums(14) = blockSumFaceMeltingFlux
       sums(15) = blockSumVAF
+      sums(16) = blockGLflux
+      sums(17) = blockGLMigrationflux
       if (config_SGH) then
-         sums(16) = blockGLflux
-         sums(17) = blockGLMigrationflux
          sums(18) = blockSumSubglacialWaterVolume
          sums(19) = blockSumBasalMeltInput
          sums(20) = blockSumExternalWaterInput
@@ -546,7 +548,7 @@ contains
          sums(28) = blockSumFlotationFraction
          nVars = 28
       else
-        nVars = 15
+        nVars = 17
       endif
 
       call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
@@ -574,9 +576,9 @@ contains
          call mpas_pool_get_array(globalStatsAMPool, 'avgSubshelfMelt', avgSubshelfMelt)
          call mpas_pool_get_array(globalStatsAMPool, 'totalCalvingFlux', totalCalvingFlux)
          call mpas_pool_get_array(globalStatsAMPool, 'totalFaceMeltingFlux', totalFaceMeltingFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
+         call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
          if (config_SGH) then
-            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineFlux', groundingLineFlux)
-            call mpas_pool_get_array(globalStatsAMPool, 'groundingLineMigrationFlux', groundingLineMigrationFlux)
             call mpas_pool_get_array(globalStatsAMPool, 'totalSubglacialWaterVolume', totalSubglacialWaterVolume)
             call mpas_pool_get_array(globalStatsAMPool, 'totalBasalMeltInput', totalBasalMeltInput)
             call mpas_pool_get_array(globalStatsAMPool, 'totalExternalWaterInput', totalExternalWaterInput)
@@ -605,9 +607,9 @@ contains
          totalCalvingFlux = reductions(13)
          totalFaceMeltingFlux = reductions(14)
          volumeAboveFloatation = reductions(15)
+         groundingLineFlux = reductions(16)
+         groundingLineMigrationFlux = reductions(17)
          if (config_SGH) then
-            groundingLineFlux = reductions(16)
-            groundingLineMigrationFlux = reductions(17)
             totalSubglacialWaterVolume = reductions(18)
             totalBasalMeltInput = reductions(19)
             totalExternalWaterInput = reductions(20)

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -512,31 +512,37 @@ contains
 
                ! Subglacial Water Volume
                blockSumRegionSubglacialWaterVolume(iRegion) = blockSumRegionSubglacialWaterVolume(iRegion) + &
-                 waterThickness(iCell) * areaCell(iCell)
-
-               ! Basal melt input
-               blockSumRegionBasalMeltInput(iRegion) = blockSumRegionBasalMeltInput(iRegion) + &
-                 real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * basalMeltInput(iCell) * areaCell(iCell)
+                 (real(regionCellMasks(iRegion,iCell),RKIND) * waterThickness(iCell) * areaCell(iCell))
+               
+               if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                  ! Basal melt input
+                  blockSumRegionBasalMeltInput(iRegion) = blockSumRegionBasalMeltInput(iRegion) + &
+                    (real(regionCellMasks(iRegion,iCell),RKIND) * basalMeltInput(iCell) * areaCell(iCell))
+               endif
 
                ! External water input
                blockSumRegionExternalWaterInput(iRegion) = blockSumRegionExternalWaterInput(iRegion) + &
-                 externalWaterInput(iCell) * areaCell(iCell)
+                                                           (real(regionCellMasks(iRegion,iCell),RKIND) * &
+                                                            real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * &
+                                                            externalWaterInput(iCell) * areaCell(iCell))
 
                ! Lake Volume
                if (waterThickness(iCell) > bedBumpMax) then
                   blockSumRegionLakeVolume(iRegion) = blockSumRegionLakeVolume(iRegion) + &
-                    (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+                    (real(regionCellMasks(iRegion,iCell),RKIND) * (waterThickness(iCell) - bedBumpMax) * areaCell(iCell))
                endif
 
                ! Lake Area
                if (waterThickness(iCell) > bedBumpMax) then
-                   blockSumRegionLakeArea(iRegion) = blockSumRegionLakeArea(iRegion) + areaCell(iCell)
+                   blockSumRegionLakeArea(iRegion) = blockSumRegionLakeArea(iRegion) + &
+                    (real(regionCellMasks(iRegion,iCell),RKIND) * areaCell(iCell))
                endif
 
                ! Area-weighted flotation fraction for grounded ice
                if (li_mask_is_grounded_ice(cellMask(iCell))) then
                    blockSumRegionFlotationFraction(iRegion) = blockSumRegionFlotationFraction(iRegion) + &
-                     ( waterPressure(iCell) / rhoi / gravity / thickness(iCell) ) * areaCell(iCell)
+                     (real(regionCellMasks(iRegion,iCell),RKIND) * &
+                     ( waterPressure(iCell) / rhoi / gravity / thickness(iCell) ) * areaCell(iCell))
                endif
             endif
            end do ! end loop over regions
@@ -564,6 +570,12 @@ contains
                end do ! end loop over regions
             end if ! if GL
 
+            ! TO DO: Need to define our own condition on how to decide which region to put the edge quantities
+            ! TO DO: Make sure SGH terms are masked based on region (using regionEdgeMasks?) b/c calculations are 
+            !        currently unmasked and therefore global values 
+
+
+            ! assign the SGH stats this edge quantities to the region of the upwind cell
             if (config_SGH) then
                ! Channel Melt
                blockSumRegionChannelMelt(iRegion) = blockSumRegionChannelMelt(iRegion) + &
@@ -584,8 +596,7 @@ contains
                ! Meltwater discharge in channels across terrestrial margin
                blockSumRegionChannelTerrestrialMeltFlux(iRegion) = blockSumRegionChannelTerrestrialMeltFlux(iRegion) + &
                  abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
-           endif ! if SGH is on
-
+            endif ! if SGH is on
          end do ! end loop over edges
 
          block => block % next

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -203,6 +203,7 @@ contains
       logical, pointer :: config_SGH
 
       integer, dimension(:,:), pointer :: regionCellMasks
+      integer, dimension(:,:), pointer :: regionEdgeMasks
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
@@ -348,7 +349,12 @@ contains
 
          ! get region cell masks from regionMasks.nc input file
          call mpas_pool_get_array(regionsPool, 'regionCellMasks', regionCellMasks)
-
+         if (config_SGH) then
+             ! regionEdgeMasks is required if calculating regional stats with SGH, 
+             ! in the fututre will probably be required for standalone regional stats
+             ! but this is used a stopgap to forestall backwards compatibility problems
+            call mpas_pool_get_array(regionsPool, 'regionEdgeMasks', regionEdgeMasks)
+         endif
          ! allocate & initialize sums over blocks to 0
          allocate(blockSumRegionIceArea(nRegions)); allocate(blockSumRegionIceVolume(nRegions))
          allocate(blockSumRegionVAF(nRegions))
@@ -570,32 +576,34 @@ contains
                end do ! end loop over regions
             end if ! if GL
 
-            ! TO DO: Need to define our own condition on how to decide which region to put the edge quantities
-            ! TO DO: Make sure SGH terms are masked based on region (using regionEdgeMasks?) b/c calculations are 
-            !        currently unmasked and therefore global values 
-
-
-            ! assign the SGH stats this edge quantities to the region of the upwind cell
+            ! assign the SGH stats based on edge values using the regionEdgeMask 
             if (config_SGH) then
-               ! Channel Melt
-               blockSumRegionChannelMelt(iRegion) = blockSumRegionChannelMelt(iRegion) + &
-                 abs(channelMelt(iEdge) * dcEdge(iEdge))
 
-               ! Meltwater Flux across the grounding line
-               blockSumRegionGLMeltFlux(iRegion) = blockSumRegionGLMeltFlux(iRegion) + &
-                 abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+               do iRegion = 1,nRegions ! loop over regions
+                  ! Channel Melt
+                  blockSumRegionChannelMelt(iRegion) = blockSumRegionChannelMelt(iRegion) + &
+                    (real(regionEdgeMasks(iRegion,iEdge),RKIND) * abs(channelMelt(iEdge) * dcEdge(iEdge)))
 
-               ! Meltwater Flux across terrestrial margins
-               blockSumRegionTerrestrialMeltFlux(iRegion) = blockSumRegionTerrestrialMeltFlux(iRegion) + &
-                 abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+                  ! Meltwater Flux across the grounding line
+                  blockSumRegionGLMeltFlux(iRegion) = blockSumRegionGLMeltFlux(iRegion) + &
+                    (real(regionEdgeMasks(iRegion,iEdge),RKIND) * &
+                    abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water))
 
-               ! Meltwater Discharge in channels across grounding line
-               blockSumRegionChannelGLMeltFlux(iRegion) = blockSumRegionChannelGLMeltFlux(iRegion) + &
-                 abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+                  ! Meltwater Flux across terrestrial margins
+                  blockSumRegionTerrestrialMeltFlux(iRegion) = blockSumRegionTerrestrialMeltFlux(iRegion) + &
+                    (real(regionEdgeMasks(iRegion,iEdge),RKIND) * &
+                    abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water))
 
-               ! Meltwater discharge in channels across terrestrial margin
-               blockSumRegionChannelTerrestrialMeltFlux(iRegion) = blockSumRegionChannelTerrestrialMeltFlux(iRegion) + &
-                 abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+                  ! Meltwater Discharge in channels across grounding line
+                  blockSumRegionChannelGLMeltFlux(iRegion) = blockSumRegionChannelGLMeltFlux(iRegion) + &
+                    (real(regionEdgeMasks(iRegion,iEdge),RKIND) * &
+                    abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water))
+
+                  ! Meltwater discharge in channels across terrestrial margin
+                  blockSumRegionChannelTerrestrialMeltFlux(iRegion) = blockSumRegionChannelTerrestrialMeltFlux(iRegion) + &
+                    (real(regionEdgeMasks(iRegion,iEdge),RKIND) * &
+                    abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water))
+               end do ! end loop over regions 
             endif ! if SGH is on
          end do ! end loop over edges
 

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -164,12 +164,14 @@ contains
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: regionsPool
       type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: hydroPool
 
       ! arrays, vars needed from other pools for calculations here
       real (kind=RKIND), pointer ::  config_ice_density
       real (kind=RKIND), pointer ::  deltat
       real (kind=RKIND), dimension(:), pointer ::  areaCell
       real (kind=RKIND), dimension(:), pointer ::  dvEdge
+      real (kind=RKIND), dimension(:), pointer ::  dcEdge
       real (kind=RKIND), dimension(:), pointer ::  thickness
       real (kind=RKIND), dimension(:), pointer ::  bedTopography
       real (kind=RKIND), dimension(:), pointer ::  sfcMassBalApplied
@@ -185,15 +187,27 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  groundedToFloatingThickness
       real (kind=RKIND), dimension(:,:), pointer ::  normalVelocity
 
+      real (kind=RKIND), dimension(:), pointer ::  waterThickness
+      real (kind=RKIND), dimension(:), pointer ::  basalMeltInput
+      real (kind=RKIND), dimension(:), pointer ::  externalWaterInput
+      real (kind=RKIND), dimension(:), pointer ::  channelMelt
+      real (kind=RKIND), dimension(:), pointer ::  waterFlux
+      real (kind=RKIND), dimension(:), pointer ::  channelDischarge
+      real (kind=RKIND), dimension(:), pointer ::  waterPressure
+
       ! config options needed
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoi ! config_ice_density
       real (kind=RKIND), pointer :: rhow ! config_ocean_density
+      real (kind=RKIND), pointer :: bedBumpMax ! config_SGH_bed_roughness_max
+      logical, pointer :: config_SGH
 
       integer, dimension(:,:), pointer :: regionCellMasks
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
+      integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, pointer :: nRegions, nRegionGroups !, maxRegionsInGroup  !! maxRegionsInGroup not needed / used yet
       integer, pointer :: nCellsSolve, nEdgesSolve, nVertLevels
       integer :: k, iCell, iEdge
@@ -218,6 +232,17 @@ contains
       real (kind=RKIND), dimension(:), pointer ::  regionalAvgSubshelfMelt
       real (kind=RKIND), dimension(:), pointer ::  regionalSurfaceSpeedMax
       real (kind=RKIND), dimension(:), pointer ::  regionalBasalSpeedMax
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumSubglacialWaterVolume
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumBasalMeltInput
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumExternalWaterInput
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumChannelMelt
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumSubglacialLakeVolume
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumSubglacialLakeArea
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumDistWaterFluxMarineMargin
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumDistWaterFluxTerrestrialMargin
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumChnlWaterFluxMarineMargin
+      real (kind=RKIND), dimension(:), pointer ::  regionalSumChnlWaterFluxTerrestrialMargin
+      real (kind=RKIND), dimension(:), pointer ::  regionalAvgFlotationFraction
 
       ! storage for sums over blocks
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionIceArea, blockSumRegionIceVolume
@@ -234,12 +259,25 @@ contains
       real (kind=RKIND), dimension(:), allocatable ::  blockRegionGLMigrationFlux
       real (kind=RKIND), dimension(:), allocatable ::  blockRegionMaxSurfaceSpeed
       real (kind=RKIND), dimension(:), allocatable ::  blockRegionMaxBasalSpeed
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionSubglacialWaterVolume
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionBasalMeltInput
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionExternalWaterInput
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionChannelMelt
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionLakeVolume
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionLakeArea
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionGLMeltFlux
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionTerrestrialMeltFlux
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionChannelGLMeltFlux
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionChannelTerrestrialMeltFlux
+      real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionFlotationFraction
+      ! local variable needed calculating average floation fraction in a region
+      real (kind=RKIND), dimension(:), allocatable:: regionalSumFlotationFraction
 
       ! local variables
       real (kind=RKIND) :: fluxSign
 
       ! variables for processing stats
-      integer, parameter :: kMaxVariables = 32 ! Increase if number of stats increase
+      integer, parameter :: kMaxVariables = 43 ! Increase if number of stats increase
       integer :: nVars
       real (kind=RKIND), dimension(kMaxVariables) :: reductions, sums, mins, maxes
 
@@ -251,6 +289,8 @@ contains
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhow)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', bedBumpMax)
+      call mpas_pool_get_config(liConfigs, 'config_SGH', config_SGH)
 
       ! loop over blocks
       block => domain % blocklist
@@ -265,7 +305,8 @@ contains
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'regions', regionsPool)
-!         call mpas_pool_get_subpool(block % structs, 'regionalStatsAM', regionalStatsAMPool)
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+!        call mpas_pool_get_subpool(block % structs, 'regionalStatsAM', regionalStatsAMPool)
 
          ! get values and arrays from standard pools
          call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
@@ -292,6 +333,18 @@ contains
          call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
          call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLine', fluxAcrossGroundingLine)
          call mpas_pool_get_array(velocityPool, 'normalVelocity', normalVelocity)
+         if (config_SGH) then
+            call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
+            call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
+            call mpas_pool_get_array(hydroPool, 'basalMeltInput', basalMeltInput)
+            call mpas_pool_get_array(hydroPool, 'externalWaterInput', externalWaterInput)
+            call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
+            call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+            call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+            call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
+            call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+            call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+         endif 
 
          ! get region cell masks from regionMasks.nc input file
          call mpas_pool_get_array(regionsPool, 'regionCellMasks', regionCellMasks)
@@ -310,6 +363,20 @@ contains
          allocate(blockSumRegionFaceMeltingFlux(nRegions))
          allocate(blockSumRegionGLflux(nRegions))
          allocate(blockRegionGLMigrationFlux(nRegions))
+         if (config_SGH) then
+            allocate(blockSumRegionSubglacialWaterVolume(nRegions))
+            allocate(blockSumRegionBasalMeltInput(nRegions))
+            allocate(blockSumRegionExternalWaterInput(nRegions))
+            allocate(blockSumRegionChannelMelt(nRegions))
+            allocate(blockSumRegionLakeVolume(nRegions))
+            allocate(blockSumRegionLakeArea(nRegions))
+            allocate(blockSumRegionGLMeltFlux(nRegions))
+            allocate(blockSumRegionTerrestrialMeltFlux(nRegions))
+            allocate(blockSumRegionChannelGLMeltFlux(nRegions))
+            allocate(blockSumRegionChannelTerrestrialMeltFlux(nRegions))
+            allocate(blockSumRegionFlotationFraction(nRegions))
+            allocate(regionalSumFlotationFraction(nRegions))
+         endif 
 
          blockSumRegionIceArea = 0.0_RKIND; blockSumRegionIceVolume = 0.0_RKIND
          blockSumRegionVAF = 0.0_RKIND
@@ -324,6 +391,21 @@ contains
          blockSumRegionFaceMeltingFlux = 0.0_RKIND
          blockSumRegionGLflux = 0.0_RKIND
          blockRegionGLMigrationFlux = 0.0_RKIND
+         
+         if (config_SGH) then 
+            blockSumRegionSubglacialWaterVolume = 0.0_RKIND
+            blockSumRegionBasalMeltInput = 0.0_RKIND
+            blockSumRegionExternalWaterInput = 0.0_RKIND
+            blockSumRegionChannelMelt = 0.0_RKIND
+            blockSumRegionLakeVolume = 0.0_RKIND
+            blockSumRegionLakeArea = 0.0_RKIND
+            blockSumRegionGLMeltFlux = 0.0_RKIND
+            blockSumRegionTerrestrialMeltFlux = 0.0_RKIND
+            blockSumRegionChannelGLMeltFlux = 0.0_RKIND
+            blockSumRegionChannelTerrestrialMeltFlux = 0.0_RKIND
+            blockSumRegionFlotationFraction = 0.0_RKIND
+            regionalSumFlotationFraction = 0.0_RKIND
+         endif
 
          do iCell = 1,nCellsSolve      ! loop over cells
  !         do iGroup = 1,nRegionGroups  ! loop over groups
@@ -425,8 +507,39 @@ contains
                real(regionCellMasks(iRegion,iCell),RKIND) * &
                groundedToFloatingThickness(iCell) * areaCell(iCell) * rhoi / (deltat / scyr)
 
+            !! Subglacial Hydrology Calculations
+            if (config_SGH) then
+
+               ! Subglacial Water Volume
+               blockSumRegionSubglacialWaterVolume(iRegion) = blockSumRegionSubglacialWaterVolume(iRegion) + &
+                 waterThickness(iCell) * areaCell(iCell)
+
+               ! Basal melt input
+               blockSumRegionBasalMeltInput(iRegion) = blockSumRegionBasalMeltInput(iRegion) + &
+                 real(li_mask_is_grounded_ice_int(cellMask(iCell)),RKIND) * basalMeltInput(iCell) * areaCell(iCell)
+
+               ! External water input
+               blockSumRegionExternalWaterInput(iRegion) = blockSumRegionExternalWaterInput(iRegion) + &
+                 externalWaterInput(iCell) * areaCell(iCell)
+
+               ! Lake Volume
+               if (waterThickness(iCell) > bedBumpMax) then
+                  blockSumRegionLakeVolume(iRegion) = blockSumRegionLakeVolume(iRegion) + &
+                    (waterThickness(iCell) - bedBumpMax) * areaCell(iCell)
+               endif
+
+               ! Lake Area
+               if (waterThickness(iCell) > bedBumpMax) then
+                   blockSumRegionLakeArea(iRegion) = blockSumRegionLakeArea(iRegion) + areaCell(iCell)
+               endif
+
+               ! Area-weighted flotation fraction for grounded ice
+               if (li_mask_is_grounded_ice(cellMask(iCell))) then
+                   blockSumRegionFlotationFraction(iRegion) = blockSumRegionFlotationFraction(iRegion) + &
+                     ( waterPressure(iCell) / rhoi / gravity / thickness(iCell) ) * areaCell(iCell)
+               endif
+            endif
            end do ! end loop over regions
- !         end do ! end loop over groups
          end do ! end loop over cells
 
 
@@ -450,6 +563,29 @@ contains
                   end if ! if edge is on cell in region of interest
                end do ! end loop over regions
             end if ! if GL
+
+            if (config_SGH) then
+               ! Channel Melt
+               blockSumRegionChannelMelt(iRegion) = blockSumRegionChannelMelt(iRegion) + &
+                 abs(channelMelt(iEdge) * dcEdge(iEdge))
+
+               ! Meltwater Flux across the grounding line
+               blockSumRegionGLMeltFlux(iRegion) = blockSumRegionGLMeltFlux(iRegion) + &
+                 abs(hydroMarineMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+
+               ! Meltwater Flux across terrestrial margins
+               blockSumRegionTerrestrialMeltFlux(iRegion) = blockSumRegionTerrestrialMeltFlux(iRegion) + &
+                 abs(hydroTerrestrialMarginMask(iEdge) * waterFlux(iEdge) * dvEdge(iEdge) * rho_water)
+
+               ! Meltwater Discharge in channels across grounding line
+               blockSumRegionChannelGLMeltFlux(iRegion) = blockSumRegionChannelGLMeltFlux(iRegion) + &
+                 abs(hydroMarineMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+
+               ! Meltwater discharge in channels across terrestrial margin
+               blockSumRegionChannelTerrestrialMeltFlux(iRegion) = blockSumRegionChannelTerrestrialMeltFlux(iRegion) + &
+                 abs( hydroTerrestrialMarginMask(iEdge) * channelDischarge(iEdge) * rho_water)
+           endif ! if SGH is on
+
          end do ! end loop over edges
 
          block => block % next
@@ -494,7 +630,22 @@ contains
         sums(15) = blockSumRegionVAF(iRegion)
         sums(16) = blockSumRegionGLflux(iRegion)
         sums(17) = blockRegionGLMigrationFlux(iRegion)
-        nVars = 17
+        if (config_SGH) then
+           sums(18) = blockSumRegionSubglacialWaterVolume(iRegion)
+           sums(19) = blockSumRegionBasalMeltInput(iRegion)
+           sums(20) = blockSumRegionExternalWaterInput(iRegion)
+           sums(21) = blockSumRegionChannelMelt(iRegion)
+           sums(22) = blockSumRegionLakeVolume(iRegion)
+           sums(23) = blockSumRegionLakeArea(iRegion)
+           sums(24) = blockSumRegionGLMeltFlux(iRegion)
+           sums(25) = blockSumRegionTerrestrialMeltFlux(iRegion)
+           sums(26) = blockSumRegionChannelGLMeltFlux(iRegion)
+           sums(27) = blockSumRegionChannelTerrestrialMeltFlux(iRegion)
+           sums(28) = blockSumRegionFlotationFraction(iRegion)
+           nVars = 28
+        else
+          nVars = 17
+        endif
 
         call mpas_dmpar_sum_real_array(dminfo, nVars, sums(1:nVars), reductions(1:nVars))
 
@@ -526,6 +677,19 @@ contains
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumGroundingLineFlux', regionalSumGroundingLineFlux)
            call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumGroundingLineMigrationFlux', &
                    regionalSumGroundingLineMigrationFlux)
+           if (config_SGH) then
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumSubglacialWaterVolume', regionalSumSubglacialWaterVolume)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumBasalMeltInput', regionalSumBasalMeltInput)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumExternalWaterInput', regionalSumExternalWaterInput)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumChannelMelt', regionalSumChannelMelt)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumSubglacialLakeVolume', regionalSumSubglacialLakeVolume)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumSubglacialLakeArea', regionalSumSubglacialLakeArea)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumDistWaterFluxMarineMargin',regionalSumDistWaterFluxMarineMargin)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumDistWaterFluxTerrestrialMargin', regionalSumDistWaterFluxTerrestrialMargin)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumChnlWaterFluxMarineMargin',regionalSumChnlWaterFluxMarineMargin)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalSumChnlWaterFluxTerrestrialMargin', regionalSumChnlWaterFluxTerrestrialMargin)
+              call mpas_pool_get_array(regionalStatsAMPool, 'regionalAvgFlotationFraction', regionalAvgFlotationFraction)
+           endif
 
            regionalIceArea(iRegion) = reductions(1)
            regionalIceVolume(iRegion) = reductions(2)
@@ -544,6 +708,19 @@ contains
            regionalVolumeAboveFloatation(iRegion) = reductions(15)
            regionalSumGroundingLineFlux(iRegion) = reductions(16)
            regionalSumGroundingLineMigrationFlux(iRegion) = reductions(17)
+           if (config_SGH) then
+              regionalSumSubglacialWaterVolume(iRegion) = reductions(18)
+              regionalSumBasalMeltInput(iRegion) = reductions(19)
+              regionalSumExternalWaterInput(iRegion) = reductions(20)
+              regionalSumChannelMelt(iRegion) = reductions(21)
+              regionalSumSubglacialLakeVolume(iRegion) = reductions(22)
+              regionalSumSubglacialLakeArea(iRegion) = reductions(23)
+              regionalSumDistWaterFluxMarineMargin(iRegion) = reductions(24)
+              regionalSumDistWaterFluxTerrestrialMargin(iRegion) = reductions(25)
+              regionalSumChnlWaterFluxMarineMargin(iRegion) = reductions(26)
+              regionalSumChnlWaterFluxTerrestrialMargin(iRegion) = reductions(27)
+              regionalSumFlotationFraction(iRegion) = reductions(28)
+           endif
 
            if (regionalIceArea(iRegion) > 0.0_RKIND) then
               regionalIceThicknessMean(iRegion) = regionalIceVolume(iRegion) / regionalIceArea(iRegion)
@@ -563,6 +740,15 @@ contains
                  regionalFloatingIceArea(iRegion) / rhoi
            else
               regionalAvgSubshelfMelt(iRegion) = 0.0_RKIND
+           endif
+
+           if (config_SGH) then
+              if (regionalIceArea(iRegion) > 0.0_RKIND) then
+                  ! WHAT SHOULD totalFLoationFraction equivalent be? 
+                  regionalAvgFlotationFraction(iRegion) = regionalSumFlotationFraction(iRegion) / regionalIceArea(iRegion)
+              else
+                  regionalAvgFlotationFraction(iRegion) = 0.0_RKIND
+              endif
            endif
 
         block => block % next
@@ -624,6 +810,19 @@ contains
       deallocate(blockSumRegionFaceMeltingFlux)
       deallocate(blockSumRegionGLflux)
       deallocate(blockRegionGLMigrationflux)
+      if (config_SGH) then
+         deallocate(blockSumRegionSubglacialWaterVolume)
+         deallocate(blockSumRegionBasalMeltInput)
+         deallocate(blockSumRegionExternalWaterInput)
+         deallocate(blockSumRegionChannelMelt)
+         deallocate(blockSumRegionLakeVolume)
+         deallocate(blockSumRegionLakeArea)
+         deallocate(blockSumRegionGLMeltFlux)
+         deallocate(blockSumRegionTerrestrialMeltFlux)
+         deallocate(blockSumRegionChannelGLMeltFlux)
+         deallocate(blockSumRegionChannelTerrestrialMeltFlux)
+         deallocate(blockSumRegionFlotationFraction)
+      endif 
 
    end subroutine li_compute_regional_stats
 

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -270,7 +270,7 @@ contains
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionChannelGLMeltFlux
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionChannelTerrestrialMeltFlux
       real (kind=RKIND), dimension(:), allocatable ::  blockSumRegionFlotationFraction
-      ! local variable needed calculating average floation fraction in a region
+      ! local variable needed calculating numerator of regionalAvgFlotationFraction
       real (kind=RKIND), dimension(:), allocatable:: regionalSumFlotationFraction
 
       ! local variables
@@ -833,6 +833,8 @@ contains
          deallocate(blockSumRegionChannelGLMeltFlux)
          deallocate(blockSumRegionChannelTerrestrialMeltFlux)
          deallocate(blockSumRegionFlotationFraction)
+         ! local variable needed for calculating numerator of regionalAvgFlotationFraction
+         deallocate(regionalSumFlotationFraction)
       endif 
 
    end subroutine li_compute_regional_stats

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_regional_stats.F
@@ -762,9 +762,8 @@ contains
            endif
 
            if (config_SGH) then
-              if (regionalIceArea(iRegion) > 0.0_RKIND) then
-                  ! WHAT SHOULD totalFLoationFraction equivalent be? 
-                  regionalAvgFlotationFraction(iRegion) = regionalSumFlotationFraction(iRegion) / regionalIceArea(iRegion)
+              if (regionalGroundedIceArea(iRegion) > 0.0_RKIND) then
+                  regionalAvgFlotationFraction(iRegion) = regionalSumFlotationFraction(iRegion) / regionalGroundedIceArea(iRegion)
               else
                   regionalAvgFlotationFraction(iRegion) = 0.0_RKIND
               endif


### PR DESCRIPTION
- This PR follows #82, which added subglacial hydrology (SGH) quantities to the global stats analysis member by adding SGH quantities to the regional stats analysis member. 

- This PR also address a [bug](https://github.com/MALI-Dev/E3SM/blob/8be18efd4a8bff2008d38388de7fa1d28709a4a8/components/mpas-albany-landice/src/analysis_members/mpas_li_global_stats.F#L464-L470) introduced in #82 where the calculation of `groundingLineFlux` and `groundingLineMigrationFlux` were moved with a `if config_SGH then` condition. The bug prevents `groundingLineFlux` and `groundingLineMigrationFlux` from being calculated by global stats unless the SGH model is turned on, despite these quantities apply to simulation where SGH is not used. 