### PR TITLE
Add iceThicknessHydro and waterPressureSmooth

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -152,8 +152,6 @@
                 <!-- state vars -->
 		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
 			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
-		<var name="upperSurfaceHydro" type="real" dimensions="nCells Time" units="m"
-			description="upper surface used by the hydrology model if config_SGH_use_iceThicknessHydro = .true." />
 		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -125,6 +125,10 @@
 		            possible_values="'file', 'thermal', 'basal_heat'"
 		/>
 
+		  <nml_option name="config_SGH_iter_smooth_waterPressureSlopeNormal" type="integer" default_value="1" units="none"
+					 description="number of iterations to smooth waterPressure over when calculating waterPressureSlopeNormal. Used only to keep channelPressureFreeze stable and will not affect other aspects of the model that rely on waterPressure." 	
+					 possible_values="positive integer or zero"
+		/>
 	</nml_record>
 
 <!-- ======================================================================= -->
@@ -162,7 +166,9 @@
                      description="water layer thickness in subglacial till from previous time step" />
                 <var name="waterPressure" type="real" dimensions="nCells Time" units="Pa"
                      description="pressure in subglacial hydrology system" />
-                <var name="waterPressureOld" type="real" dimensions="nCells Time" units="Pa"
+					 <var name="waterPressureSmooth" type="real" dimensions="nCells Time" units="Pa"
+								description="smoothed water pressure used only for calculation of channelPressureFreeze" />
+					 <var name="waterPressureOld" type="real" dimensions="nCells Time" units="Pa"
                      description="pressure in subglacial hydrology system from previous time step" />
                 <var name="waterPressureTendency" type="real" dimensions="nCells Time" units="Pa s^{-1}"
                      description="tendency in pressure in subglacial hydrology system" />
@@ -239,7 +245,7 @@
                 <var name="deltatSGHpressure" type="real" dimensions="Time" units="s"
                      description="time step length limited by pressure equation scheme in subglacial hydrology system" />
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
-                        description="time step used for evolving subglacial hydrology system" />
+                     description="time step used for evolving subglacial hydrology system" />
 	     	<var name="distGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
 		     description="distributed discharge across the grounding line, summed from grounding line edges to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />
 	     	<var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
@@ -247,6 +253,9 @@
 	     	<!-- channel variables -->
 	     	<var name="chnlGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
 		     description="channel discharge across the grounding line, summed from grounding line edges to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />
+		<var name="pressureField" type="real" dimensions="nCells Time" units="Pa"
+		     description="Dummy variable used for smoothing waterPressureSlopeNormal" />
+		<!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -77,7 +77,13 @@
 		            description="notional englacial porosity"
 		            possible_values="positive real number"
 		/>
-                <!-- channel options -->
+		
+		<nml_option name="config_SGH_use_iceThicknessHydro" type="logical" default_value=".true." units="unitless"
+			    description="alter ice thickness along boundaries to avoid local maxima/minima in upperSurface. This can circumvent instabilities from forming along the boundaries of the hydro model that arise from unrealistic surface anomalies left over from building the domain. This option has no significant effect on the behavior of the model but makes it more stable."
+		            possible_values=".true. or .false."
+		/>
+	
+	        <!-- channel options -->
                 <nml_option name="config_SGH_chnl_active" type="logical" default_value=".false." units="unitless"
 		            description="activate channels in subglacial hydrology model"
 		            possible_values=".true. or .false."

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -79,7 +79,7 @@
 		/>
 		
 		<nml_option name="config_SGH_use_iceThicknessHydro" type="logical" default_value=".true." units="unitless"
-			    description="alter ice thickness along boundaries to avoid local maxima/minima in upperSurface. This can circumvent instabilities from forming along the boundaries of the hydro model that arise from unrealistic surface anomalies left over from building the domain. This option has no significant effect on the behavior of the model but makes it more stable."
+			    description="Option to use an altered ice thickness field called iceThicknessHydro that replaces local maxima/minima in upperSurface with a mean of the cells neighbors. This option has no significant effect on the behavior of the model but makes it more stable."
 		            possible_values=".true. or .false."
 		/>
 	

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -148,6 +148,8 @@
                 <!-- state vars -->
 		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
 			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
+		<var name="upperSurfaceHydro" type="real" dimensions="nCells Time" units="m"
+			description="upper surface used by the hydrology model if config_SGH_use_iceThicknessHydro = .true." />
 		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -140,7 +140,9 @@
 	<!-- Variables related to subglacial hydrology -->
         <var_struct name="hydro" time_levs="1" packages="hydro">
                 <!-- state vars -->
-                <var name="waterThickness" type="real" dimensions="nCells Time" units="m"
+		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
+			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
+		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system from previous time step" />

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -253,9 +253,6 @@
 	     	<!-- channel variables -->
 	     	<var name="chnlGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
 		     description="channel discharge across the grounding line, summed from grounding line edges to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />
-		<var name="pressureField" type="real" dimensions="nCells Time" units="Pa"
-		     description="Dummy variable used for smoothing waterPressureSlopeNormal" />
-		<!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -106,6 +106,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: tillMax
       real (kind=RKIND), pointer :: rhoi, rhoo
@@ -182,8 +183,12 @@ module li_subglacial_hydro
 
          call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
+         call calc_iceThicknessHydro(block, err_tmp) !adjust ice thickness along boundaries
+         err = ior(err,err_tmp)
+
          waterPressure = max(0.0_RKIND, waterPressure)
-         waterPressure = min(waterPressure, rhoi * gravity * thickness)
+         waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
          ! set pressure correctly under floating ice and open ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -324,6 +329,9 @@ module li_subglacial_hydro
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
          call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+
+         call calc_iceThicknessHydro(block, err_tmp)
+         err = ior(err, err_tmp)
 
          call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
          err = ior(err, err_tmp)
@@ -1480,6 +1488,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro      
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -1546,6 +1555,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
 
       openingRate(:) = bedRough * basalSpeed(:) * (bedRoughMax - waterThickness(:))
       !openingRate(:) = bedRough * basalSpeed(:) * (bedRoughMax - waterThickness(:)) + &
@@ -1566,7 +1576,7 @@ module li_subglacial_hydro
       case ('cavity')
 
          where (li_mask_is_floating_ice(cellMask))
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere (.not. li_mask_is_ice(cellMask))
             waterPressure = 0.0_RKIND
          elsewhere
@@ -1576,11 +1586,11 @@ module li_subglacial_hydro
 
       case ('overburden')
          where (li_mask_is_floating_ice(cellMask))
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere (.not. li_mask_is_ice(cellMask))
             waterPressure = 0.0_RKIND
          elsewhere
-            waterPressure = rhoi * gravity * thickness
+            waterPressure = rhoi * gravity * iceThicknessHydro
          end where
 
       case default
@@ -1589,7 +1599,7 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
-      waterPressure = min(waterPressure, rhoi * gravity * thickness)
+      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
 
       do iCell = 1, nCells
         if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
@@ -1638,7 +1648,6 @@ module li_subglacial_hydro
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
-
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -1663,6 +1672,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: hydropotential
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: config_sea_level
 
@@ -1683,9 +1693,10 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
-      effectivePressure = rhoi * gravity * thickness - waterPressure
+      effectivePressure = rhoi * gravity * iceThicknessHydro - waterPressure
          ! < this should evalute to 0 for floating ice if Pw set correctly there.
       where (.not. li_mask_is_grounded_ice(cellmask))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
@@ -2161,6 +2172,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), pointer :: rhoi, rhoo
 
       ! Calculate N assuming perfect ocean connection
@@ -2175,7 +2187,9 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-         effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+         
+         effectivePressure = rhoi * gravity * iceThicknessHydro - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
          effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
 
          block => block % next
@@ -2303,6 +2317,92 @@ module li_subglacial_hydro
 
    !--------------------------------------------------------------------
    end subroutine calc_hydro_mask
+   
+
+!***********************************************************************
+!
+!  routine calc_iceThicknessHydro
+!
+!> \brief   Calculate version of ice thickness used by hydrology model
+!> \author  Alex Hager
+!> \date    7 June 2023
+!> \details
+!>  This routine calculates a modified ice thickness that is altered at
+!   the domain boundaries to avoid local minima in hydropotential
+!-----------------------------------------------------------------------
+   subroutine calc_iceThicknessHydro(block, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: block    !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      ! Pools pointers
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: hydroPool
+      type (mpas_pool_type), pointer :: meshPool
+      real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: upperSurface
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nCells
+      integer :: iCell
+      integer :: jCell
+      real (kind=RKIND) :: minNeighborHeight
+      real (kind=RKIND), parameter :: bigValue = 1.0_RKIND
+      integer, dimension(:), pointer :: nEdgesOnCell
+      err = 0
+
+      ! Get pools things
+      call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+
+      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+      call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      
+      iceThicknessHydro = thickness
+
+      do iCell = 1, nCells
+         if ((li_mask_is_boundary(cellMask(iCell))) .and. (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+           minNeighborHeight = bigValue !allocate
+
+            do jCell = 1, nEdgesOnCell(iCell)
+               if ( .not. li_mask_is_boundary(cellMask(cellsOnCell(jCell,iCell)))) then
+                       minNeighborHeight = min(minNeighborHeight, upperSurface(cellsOnCell(jCell,iCell)))
+               endif            
+            end do
+            
+            !only adjust surface elevation if cell is local minimum
+            if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+               iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+            endif
+
+         endif
+      enddo
+
+!-------------------------------------------------------------------------      
+      end subroutine calc_iceThicknessHydro
 
 !***********************************************************************
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2375,8 +2375,11 @@ module li_subglacial_hydro
       integer :: numCellsChanged
       integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
+      real (kind=RKIND) :: maxNeighborHeight
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
+      real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
+      logical, pointer :: config_SGH_use_iceThicknessHydro
       err = 0
 
       ! Get pools things
@@ -2392,37 +2395,50 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      
-      iceThicknessHydro = thickness
-      numCellsChanged = 0
+      call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
+      iceThicknessHydro = thickness 
 
-      do iCell = 1, nCells
-         if ((li_mask_is_boundary(cellMask(iCell))) .and. &
-                 (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+      !iceThicknessHydro is equivalent to thickness if
+      !config_SGH_use_iceThicknessHydro is false. Default is to alter
+      !ice thickness along boundaries. 
+
+      if (config_SGH_use_iceThicknessHydro) then
+      
+         numCellsChanged = 0
+
+         do iCell = 1, nCells
+            if ((li_mask_is_boundary(cellMask(iCell))) .and. &
+                    (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
            
-            minNeighborHeight = bigValue !allocate
+               minNeighborHeight = bigValue !allocate
+               maxNeighborHeight = bigNegativeValue
 
-            do jCell = 1, nEdgesOnCell(iCell)
-               iNeighbor = cellsOnCell(jCell,iCell)
-               if ( .not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
-                   (iNeighbor < nCells + 1)) then
-                    minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-               endif            
-            end do
+               do jCell = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jCell,iCell)
+                  if (.not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
+                     (iNeighbor < nCells + 1)) then
+                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
+                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
+                  endif        
+               end do
             
-            !only adjust surface elevation if cell is local minimum
-            if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
-               call mpas_log_write("Changed ice thickness of cell $i", intArgs=(/iCell/))
-               numCellsChanged = numCellsChanged + 1
-               iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+               !only adjust surface elevation if cell is local minimum or
+               !maximum
+               if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+                  numCellsChanged = numCellsChanged + 1
+                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
+               elseif ((upperSurface(iCell) > maxNeighborHeight) .and. &
+                      (maxNeighborHeight > bigNegativeValue)) then
+                  numCellsChanged = numCellsChanged + 1
+                  iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+               endif
+
             endif
+         enddo
 
-         endif
-      enddo
-
-      call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
-      call mpas_log_write("Minimum Neighbor Height: $r", realArgs=(/minNeighborHeight/))
-      
+         call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
+      endif
+   
    end subroutine calc_iceThicknessHydro
 
 !***********************************************************************

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -181,12 +181,29 @@ module li_subglacial_hydro
          tillWaterThickness = max(0.0_RKIND, tillWaterThickness)
          tillWaterThickness = min(tillMax, tillWaterThickness)
 
-         call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
          call calc_iceThicknessHydro(block, err_tmp) !adjust ice thickness along boundaries
          err = ior(err,err_tmp)
+         block => block % next
+      end do
 
+      !update halo for iceThicknessHydro
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_timer_stop("halo updates")
+      
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+
+         call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+         call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
+         
          waterPressure = max(0.0_RKIND, waterPressure)
          waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
          ! set pressure correctly under floating ice and open ocean
@@ -201,22 +218,18 @@ module li_subglacial_hydro
          call calc_pressure_diag_vars(block, err_tmp)
          err = ior(err, err_tmp)
 
-         call calc_waterPressureSmooth(block, err_tmp) !adjust ice thickness along boundaries
+         !smooth water pressure for calculation of waterPressureSlopeNormal
+         call calc_waterPressureSmooth(block, err_tmp) 
          err = ior(err,err_tmp)
-
-         !updates halos for waterPressure
-         call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'waterPressureSlopeNormal')
-         call mpas_timer_stop("halo updates")
 
          block => block % next
       end do
 
-      !update halo for iceThicknessHydro
+      !updates halos for waterPressure
       call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_dmpar_field_halo_exch(domain, 'waterPressureSmooth')
       call mpas_timer_stop("halo updates")
-      
+     
       ! === error check
       if (err > 0) then
           call mpas_log_write("An error has occurred in li_SGH_init.", MPAS_LOG_ERR)
@@ -651,13 +664,13 @@ module li_subglacial_hydro
          call calc_waterPressureSmooth(block, err_tmp) !adjust ice thickness along boundaries
          err = ior(err,err_tmp)
 
-         !updates halos for waterPressure
-         call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'waterPressureSlopeNormal')
-         call mpas_timer_stop("halo updates")
-
          block => block % next
       end do
+
+      !updates halos for waterPressure
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'waterPressureSmooth')
+      call mpas_timer_stop("halo updates")
 
 
       ! =============
@@ -818,7 +831,6 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:,:), pointer :: cellsOnCell
-      integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
@@ -830,12 +842,11 @@ module li_subglacial_hydro
       character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoo
-      integer, pointer :: nTimesSmooth
       integer, pointer :: nEdges
       integer, pointer :: nCells
       integer, pointer :: nVertices
       integer :: iEdge, cell1, cell2
-      integer :: i, j, iVertex, iCell, jCell
+      integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
@@ -843,7 +854,6 @@ module li_subglacial_hydro
       integer :: edgeNum
       integer :: iNeighbor 
       integer :: numCells
-      integer :: iter
       
       err = 0
       err_tmp = 0
@@ -865,7 +875,6 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
-      call mpas_pool_get_config(liConfigs, 'config_SGH_iter_smooth_waterPressureSlopeNormal', nTimesSmooth)
       
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
@@ -883,7 +892,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
       call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
@@ -898,7 +906,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth) 
       
       do iEdge = 1, nEdges
@@ -2393,16 +2400,11 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
-      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:,:), pointer :: cellsOnCell
-      integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask
-      integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, pointer :: nCells
-      integer :: edgeNum
       integer, dimension(:), pointer :: nEdgesOnCell
-      integer :: iEdge
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
@@ -2424,17 +2426,14 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
-      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
-      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
 
       iceThicknessHydro = thickness 
@@ -2446,7 +2445,7 @@ module li_subglacial_hydro
       if (config_SGH_use_iceThicknessHydro) then
          do iCell = 1, nCells
 
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify grounded ice
                
                   maxNeighborHeight = bigNegativeValue !initialize
                   minNeighborHeight = bigValue
@@ -2646,7 +2645,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, pointer :: nTimesSmooth
       integer, pointer :: nCells
-      integer :: iCell, jCell
+      integer :: iCell, jEdge
       integer :: iNeighbor 
       integer :: iter
 
@@ -2677,8 +2676,8 @@ module li_subglacial_hydro
                totalPressure = pressureField(iCell)*areaCell(iCell) 
                totalArea = areaCell(iCell)
           
-               do jCell = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(jCell,iCell)
+               do jEdge = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jEdge,iCell)
 
                   if ((li_mask_is_grounded_ice(cellMask(iNeighbor)))) then
 
@@ -2690,13 +2689,11 @@ module li_subglacial_hydro
           
                waterPressureSmooth(iCell) = totalPressure / totalArea !area-weighted average pressure
             endif
+         end do
+         pressureField = waterPressureSmooth
       end do
-
-      pressureField = waterPressureSmooth
-
-   end do
-
-   deallocate(pressureField)
+      
+      deallocate(pressureField)
    end subroutine calc_waterPressureSmooth
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -195,13 +195,10 @@ module li_subglacial_hydro
       
       block => domain % blocklist
       do while (associated(block))
-         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
 
          call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
-         call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
          call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
          
          waterPressure = max(0.0_RKIND, waterPressure)
@@ -225,7 +222,7 @@ module li_subglacial_hydro
          block => block % next
       end do
 
-      !updates halos for waterPressure
+      !updates halos for waterPressureSmooth
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'waterPressureSmooth')
       call mpas_timer_stop("halo updates")
@@ -661,7 +658,7 @@ module li_subglacial_hydro
          call calc_pressure(block, err_tmp)
          err = ior(err, err_tmp)
         
-         call calc_waterPressureSmooth(block, err_tmp) !adjust ice thickness along boundaries
+         call calc_waterPressureSmooth(block, err_tmp) !compute smoothed version of waterPressure
          err = ior(err,err_tmp)
 
          block => block % next
@@ -830,7 +827,6 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:,:), pointer :: edgesOnCell
-      integer, dimension(:,:), pointer :: cellsOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
@@ -850,10 +846,6 @@ module li_subglacial_hydro
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
-      integer :: isMarineMargin
-      integer :: edgeNum
-      integer :: iNeighbor 
-      integer :: numCells
       
       err = 0
       err_tmp = 0
@@ -891,7 +883,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
       call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
@@ -2215,7 +2206,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: geometryPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
-      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), pointer :: rhoi, rhoo
 
       ! Calculate N assuming perfect ocean connection
@@ -2229,9 +2220,9 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', thickness)
          
-         effectivePressure = rhoi * gravity * iceThicknessHydro - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
+         effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
          effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
 
          block => block % next
@@ -2398,7 +2389,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
-      real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
       integer, dimension(:,:), pointer :: cellsOnCell
       integer, dimension(:), pointer :: cellMask
@@ -2427,7 +2417,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
-      call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -2498,8 +2487,6 @@ module li_subglacial_hydro
             endif
          enddo
       endif
-
-      upperSurfaceHydro = iceThicknessHydro + bedTopography
 
    end subroutine calc_iceThicknessHydro
 
@@ -2679,7 +2666,7 @@ module li_subglacial_hydro
                do jEdge = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jEdge,iCell)
 
-                  if ((li_mask_is_grounded_ice(cellMask(iNeighbor)))) then
+                  if ((li_mask_is_grounded_ice(cellMask(iNeighbor)))) then !only include GROUNDED neighboring cells in smoothing 
 
                      totalPressure = totalPressure + pressureField(iNeighbor)*areaCell(iNeighbor)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -777,6 +777,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
       real (kind=RKIND), dimension(:), pointer :: hydropotentialVertex
       real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdge
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
       real (kind=RKIND), dimension(:), pointer :: waterThickness
@@ -795,12 +796,17 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFlux
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
-      integer, dimension(:), pointer :: waterFluxMask
+      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
+      real (kind=RKIND), dimension(:), pointer :: pressureField
       integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
+      integer, dimension(:,:), pointer :: edgesOnCell
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: verticesOnEdge
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
@@ -812,18 +818,24 @@ module li_subglacial_hydro
       character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoo
+      integer, pointer :: nTimesSmooth
       integer, pointer :: nEdges
       integer, pointer :: nCells
       integer, pointer :: nVertices
-      integer :: i, j, iVertex, iCell
       integer :: iEdge, cell1, cell2
+      integer :: i, j, iVertex, iCell, jCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
-
+      integer :: isMarineMargin
+      integer :: edgeNum
+      integer :: iNeighbor 
+      integer :: numCells
+      integer :: iter
+      real (kind=RKIND) :: totNeighborPressure
+      
       err = 0
       err_tmp = 0
-
 
       ! Get pools things
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
@@ -842,9 +854,11 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
-
+      call mpas_pool_get_config(liConfigs, 'config_SGH_iter_smooth_waterPressureSlopeNormal', nTimesSmooth)
+      
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+      call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -857,6 +871,9 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'dcEdge', dcEdge)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgeSignOnCell', edgeSignOnCell)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeTangent', hydropotentialBaseSlopeTangent)
       call mpas_pool_get_array(hydroPool, 'hydropotentialSlopeTangent', hydropotentialSlopeTangent)
@@ -871,8 +888,10 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-
-
+      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+      call mpas_pool_get_array(hydroPool, 'pressureField', pressureField)
+      
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
@@ -889,7 +908,64 @@ module li_subglacial_hydro
 
          hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - hydropotentialBase(cell1)) / dcEdge(iEdge)
          hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - hydropotential(cell1)) / dcEdge(iEdge)
-         waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
+         !waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
+      end do
+
+
+      ! Create a smoothed waterPressure product used only for
+      ! calculating waterPressureSlopeNormal - to avoid channelPressureFreeze
+      ! instabilities
+
+      if (nTimesSmooth > 0) then
+         do iter = 1, nTimesSmooth !May need to iterate to smooth properly
+            if (iter == 1) then      
+               waterPressureSmooth = waterPressure
+               pressureField = waterPressure
+            else
+               pressureField = waterPressureSmooth
+            endif
+
+            do iCell = 1, nCells
+               if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then 
+               
+                     isMarineMargin = 0
+                     do edgeNum = 1, nEdgesOnCell(iCell)
+                        iEdge = edgesOnCell(edgeNum,iCell)
+                        if (hydroMarineMarginMask(iEdge) == 1) then
+                           isMarineMargin = 1
+                           exit
+                        endif
+                     enddo
+
+                     if (isMarineMargin == 0) then 
+                  
+                        totNeighborPressure = pressureField(iCell)
+                        numCells = 1
+                  
+                        do jCell = 1, nEdgesOnCell(iCell)
+                           iNeighbor = cellsOnCell(jCell,iCell)
+
+                           if (iNeighbor < nCells + 1) then
+                              totNeighborPressure = totNeighborPressure + pressureField(iNeighbor)
+                              numCells = numCells + 1
+                           endif
+                        end do
+                  
+                        !waterPressureSmooth is average of neighboring cells
+                        waterPressureSmooth(iCell) = totNeighborPressure / numCells 
+                     endif
+               endif
+            end do
+         end do
+      elseif (nTimesSmooth == 0) then
+         waterPressureSmooth = waterPressure
+      endif
+         
+      do iEdge = 1, nEdges
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+      
+         waterPressureSlopeNormal(iEdge) = (waterPressureSmooth(cell2) - waterPressureSmooth(cell1)) / dcEdge(iEdge)
       end do
 
       ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2450,6 +2450,11 @@ module li_subglacial_hydro
 
                endif
 
+               !avoid negatives, default to original thickness
+               if (iceThicknessHydro(iCell) < 0.0_RKIND) then
+                  iceThicknessHydro(iCell) = thickness(iCell)
+               endif
+            
             endif
          enddo
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2412,19 +2412,19 @@ module li_subglacial_hydro
          do iCell = 1, nCells
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
 
-               maxNeighborHeight = bigValue !allocate
-               minNeighborHeight = bigNegativeValue
+               maxNeighborHeight = bigNegativeValue !allocate
+               minNeighborHeight = bigValue
                
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
 
-                  if (jCell == 1) then
-                          totNeighborHeight = upperSurface(iNeighbor)
-                          numCells = 1
-                  endif 
-
                   if (iNeighbor < nCells + 1) then
 
+                      if (jCell == 1) then
+                              totNeighborHeight = upperSurface(iNeighbor)
+                              numCells = 1
+                      endif 
+                      
                       minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
                       maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2674,7 +2674,7 @@ module li_subglacial_hydro
          do iCell = 1, nCells
             if (li_mask_is_grounded_ice(cellMask(iCell))) then !smooth over all grounded cells
 
-               totalPressure = pressureField(iCell)
+               totalPressure = pressureField(iCell)*areaCell(iCell) 
                totalArea = areaCell(iCell)
           
                do jCell = 1, nEdgesOnCell(iCell)
@@ -2688,7 +2688,7 @@ module li_subglacial_hydro
                   endif
                end do
           
-               waterPressureSmooth(iCell) = totalPressure / totalArea !area-weighted average height
+               waterPressureSmooth(iCell) = totalPressure / totalArea !area-weighted average pressure
             endif
       end do
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2368,12 +2368,19 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
+      integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: edgeMask
       integer, pointer :: nCells
+      integer :: edgeNum
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer :: iEdge
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
+      integer :: isMarineMargin
       real (kind=RKIND) :: maxNeighborHeight
       real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: meanNeighborHeight
@@ -2381,7 +2388,6 @@ module li_subglacial_hydro
       real (kind=RKIND) :: numCells
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
-      integer, dimension(:), pointer :: nEdgesOnCell
       logical, pointer :: config_SGH_use_iceThicknessHydro
       err = 0
 
@@ -2393,12 +2399,16 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
 
       iceThicknessHydro = thickness 
@@ -2408,53 +2418,63 @@ module li_subglacial_hydro
       !ice thickness
 
       if (config_SGH_use_iceThicknessHydro) then
-
          do iCell = 1, nCells
+
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
-
-               maxNeighborHeight = bigNegativeValue !allocate
-               minNeighborHeight = bigValue
                
-               do jCell = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(jCell,iCell)
-
-                  if (iNeighbor < nCells + 1) then
-
-                      if (jCell == 1) then
-                              totNeighborHeight = upperSurface(iNeighbor)
-                              numCells = 1
-                      endif 
-                      
-                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-
-                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
-
-                      totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
-                      numCells = numCells + 1
+               isMarineMargin = 0
+               do edgeNum = 1, nEdgesOnCell(iCell)
+                  iEdge = edgesOnCell(edgeNum,iCell)
+                  if (hydroMarineMarginMask(iEdge) == 1) then
+                     isMarineMargin = 1
+                     exit
                   endif
-               end do
+               enddo
 
-               meanNeighborHeight = totNeighborHeight / numCells
+               if (isMarineMargin == 0) then
+                  maxNeighborHeight = bigNegativeValue !allocate
+                  minNeighborHeight = bigValue
+                  
+                  do jCell = 1, nEdgesOnCell(iCell)
+                     iNeighbor = cellsOnCell(jCell,iCell)
 
-               !only adjust surface elevation if cell is local minimum or
-               !maximum
-               if ((upperSurface(iCell) < minNeighborHeight) &
-                       .and. (minNeighborHeight < bigValue)) then
+                     if (iNeighbor < nCells + 1) then
 
-                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+                         if (jCell == 1) then
+                                 totNeighborHeight = upperSurface(iNeighbor)
+                                 numCells = 1
+                         endif 
+                         
+                         minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
-               elseif ((upperSurface(iCell) > maxNeighborHeight) &
-                       .and. (maxNeighborHeight > bigNegativeValue)) then
+                         maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
 
-                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+                         totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
+                         numCells = numCells + 1
+                     endif
+                  end do
 
-               endif
+                  meanNeighborHeight = totNeighborHeight / numCells
 
-               !avoid negatives, default to original thickness
-               if (iceThicknessHydro(iCell) < 0.0_RKIND) then
-                  iceThicknessHydro(iCell) = thickness(iCell)
-               endif
-            
+                  !only adjust surface elevation if cell is local minimum or
+                  !maximum
+                  if ((upperSurface(iCell) < minNeighborHeight) &
+                          .and. (minNeighborHeight < bigValue)) then
+
+                     iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+                  elseif ((upperSurface(iCell) > maxNeighborHeight) &
+                          .and. (maxNeighborHeight > bigNegativeValue)) then
+
+                     iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+                  endif
+
+                  !avoid negatives, default to original thickness
+                  if (iceThicknessHydro(iCell) < 0.0_RKIND) then
+                     iceThicknessHydro(iCell) = thickness(iCell)
+                  endif
+               endif 
             endif
          enddo
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2372,10 +2372,12 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer :: iCell
       integer :: jCell
-      integer :: numCellsChanged
       integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: maxNeighborHeight
+      real (kind=RKIND) :: meanNeighborHeight
+      real (kind=RKIND) :: totNeighborHeight
+      real (kind=RKIND) :: numCells
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -2396,6 +2398,7 @@ module li_subglacial_hydro
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
+
       iceThicknessHydro = thickness 
 
       !iceThicknessHydro is equivalent to thickness if
@@ -2403,42 +2406,67 @@ module li_subglacial_hydro
       !ice thickness along boundaries. 
 
       if (config_SGH_use_iceThicknessHydro) then
-      
-         numCellsChanged = 0
 
          do iCell = 1, nCells
-            if ((li_mask_is_boundary(cellMask(iCell))) .and. &
-                    (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
-           
-               minNeighborHeight = bigValue !allocate
-               maxNeighborHeight = bigNegativeValue
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
+               !Smooth by making each cell equal to the mean of its
+               !neighbors.
 
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
-                  if (.not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
-                     (iNeighbor < nCells + 1)) then
-                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
-                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
-                  endif        
+                  if (iNeighbor < nCells + 1) then
+                          if (jCell == 1) then
+                             totNeighborHeight = upperSurface(iNeighbor)
+                             numCells = 1
+                          else
+                             totNeighborHeight = totNeighborHeight +  upperSurface(iNeighbor)
+                             numCells = numCells + 1
+                          endif
+                  endif
+
+                     meanNeighborHeight = totNeighborHeight / numCells
                end do
-            
+
+               iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
+
+               !Above averaging is not sequential with respect to flow
+               !direction, so cells can still be local minima or maxima
+               !after smoothing. Find and correct cells where this is the case
+
+               minNeighborHeight = bigValue !allocate
+               maxNeighborHeight = bigNegativeValue
+               
+               do jCell = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jCell,iCell)
+                  if (iNeighbor < nCells + 1) then
+
+                      minNeighborHeight = min(minNeighborHeight, iceThicknessHydro(iNeighbor) + &
+                      bedTopography(iNeighbor))
+
+                      maxNeighborHeight = max(maxNeighborHeight, iceThicknessHydro(iNeighbor) + &
+                      bedTopography(iNeighbor))
+
+                  endif
+               end do
+
                !only adjust surface elevation if cell is local minimum or
                !maximum
-               if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
-                  numCellsChanged = numCellsChanged + 1
-                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
-               elseif ((upperSurface(iCell) > maxNeighborHeight) .and. &
-                      (maxNeighborHeight > bigNegativeValue)) then
-                  numCellsChanged = numCellsChanged + 1
+               if (((iceThicknessHydro(iCell) + bedTopography(iCell)) < minNeighborHeight) &
+                       .and. (minNeighborHeight < bigValue)) then
+
+                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)
+
+               elseif (((iceThicknessHydro(iCell) + bedTopography(iCell)) > maxNeighborHeight) &
+                       .and. (maxNeighborHeight > bigNegativeValue)) then
+
                   iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+
                endif
 
             endif
          enddo
-
-         call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
       endif
-   
+
    end subroutine calc_iceThicknessHydro
 
 !***********************************************************************

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1610,7 +1610,7 @@ module li_subglacial_hydro
 
       waterPressure = max(0.0_RKIND, waterPressure)
       waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
-
+      
       do iCell = 1, nCells
         if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
              ((.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) ) then
@@ -1711,7 +1711,7 @@ module li_subglacial_hydro
       where (.not. li_mask_is_grounded_ice(cellmask))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
       end where
-
+      
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
       ! This is still correct under ice shelves/open ocean because waterPressure has been set appropriately there already.
       ! Note this leads to a nonuniform hydropotential at sea level that is a function of the ocean depth.
@@ -2408,7 +2408,7 @@ module li_subglacial_hydro
       if (config_SGH_use_iceThicknessHydro) then
 
          do iCell = 1, nCells
-            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
+            if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
                !Smooth by making each cell equal to the mean of its
                !neighbors.
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2366,6 +2366,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: upperSurfaceHydro
       real (kind=RKIND), dimension(:), pointer :: upperSurface
       integer, dimension(:,:), pointer :: cellsOnCell
       integer, dimension(:), pointer :: cellMask
@@ -2373,8 +2374,8 @@ module li_subglacial_hydro
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
-      real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: maxNeighborHeight
+      real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: meanNeighborHeight
       real (kind=RKIND) :: totNeighborHeight
       real (kind=RKIND) :: numCells
@@ -2393,6 +2394,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
+      call mpas_pool_get_array(hydroPool, 'upperSurfaceHydro', upperSurfaceHydro)
       call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -2403,69 +2405,56 @@ module li_subglacial_hydro
 
       !iceThicknessHydro is equivalent to thickness if
       !config_SGH_use_iceThicknessHydro is false. Default is to alter
-      !ice thickness along boundaries. 
+      !ice thickness
 
       if (config_SGH_use_iceThicknessHydro) then
 
          do iCell = 1, nCells
             if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
-               !Smooth by making each cell equal to the mean of its
-               !neighbors.
 
-               do jCell = 1, nEdgesOnCell(iCell)
-                  iNeighbor = cellsOnCell(jCell,iCell)
-                  if (iNeighbor < nCells + 1) then
-                          if (jCell == 1) then
-                             totNeighborHeight = upperSurface(iNeighbor)
-                             numCells = 1
-                          else
-                             totNeighborHeight = totNeighborHeight +  upperSurface(iNeighbor)
-                             numCells = numCells + 1
-                          endif
-                  endif
-
-                     meanNeighborHeight = totNeighborHeight / numCells
-               end do
-
-               iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
-
-               !Above averaging is not sequential with respect to flow
-               !direction, so cells can still be local minima or maxima
-               !after smoothing. Find and correct cells where this is the case
-
-               minNeighborHeight = bigValue !allocate
-               maxNeighborHeight = bigNegativeValue
+               maxNeighborHeight = bigValue !allocate
+               minNeighborHeight = bigNegativeValue
                
                do jCell = 1, nEdgesOnCell(iCell)
                   iNeighbor = cellsOnCell(jCell,iCell)
+
+                  if (jCell == 1) then
+                          totNeighborHeight = upperSurface(iNeighbor)
+                          numCells = 1
+                  endif 
+
                   if (iNeighbor < nCells + 1) then
 
-                      minNeighborHeight = min(minNeighborHeight, iceThicknessHydro(iNeighbor) + &
-                      bedTopography(iNeighbor))
+                      minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
-                      maxNeighborHeight = max(maxNeighborHeight, iceThicknessHydro(iNeighbor) + &
-                      bedTopography(iNeighbor))
+                      maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
 
+                      totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
+                      numCells = numCells + 1
                   endif
                end do
 
+               meanNeighborHeight = totNeighborHeight / numCells
+
                !only adjust surface elevation if cell is local minimum or
                !maximum
-               if (((iceThicknessHydro(iCell) + bedTopography(iCell)) < minNeighborHeight) &
+               if ((upperSurface(iCell) < minNeighborHeight) &
                        .and. (minNeighborHeight < bigValue)) then
 
-                  iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)
+                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
 
-               elseif (((iceThicknessHydro(iCell) + bedTopography(iCell)) > maxNeighborHeight) &
+               elseif ((upperSurface(iCell) > maxNeighborHeight) &
                        .and. (maxNeighborHeight > bigNegativeValue)) then
 
-                  iceThicknessHydro(iCell) = maxNeighborHeight - bedTopography(iCell)
+                  iceThicknessHydro(iCell) = meanNeighborHeight - bedTopography(iCell)
 
                endif
 
             endif
          enddo
       endif
+
+      upperSurfaceHydro = iceThicknessHydro + bedTopography
 
    end subroutine calc_iceThicknessHydro
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -204,6 +204,11 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      !update halo for iceThicknessHydro
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_timer_stop("halo updates")
+      
       ! === error check
       if (err > 0) then
           call mpas_log_write("An error has occurred in li_SGH_init.", MPAS_LOG_ERR)
@@ -339,6 +344,11 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      !update halo for iceThicknessHydro
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
+      call mpas_timer_stop("halo updates")
+      
       ! initialize while loop
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)  ! can get from any block
       call mpas_pool_get_array(meshPool, 'deltat', masterDeltat)
@@ -2362,8 +2372,10 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer :: iCell
       integer :: jCell
+      integer :: numCellsChanged
+      integer :: iNeighbor
       real (kind=RKIND) :: minNeighborHeight
-      real (kind=RKIND), parameter :: bigValue = 1.0_RKIND
+      real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       integer, dimension(:), pointer :: nEdgesOnCell
       err = 0
 
@@ -2382,27 +2394,36 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       
       iceThicknessHydro = thickness
+      numCellsChanged = 0
 
       do iCell = 1, nCells
-         if ((li_mask_is_boundary(cellMask(iCell))) .and. (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
-           minNeighborHeight = bigValue !allocate
+         if ((li_mask_is_boundary(cellMask(iCell))) .and. &
+                 (li_mask_is_grounded_ice(cellMask(iCell)))) then !identify domain boundaries
+           
+            minNeighborHeight = bigValue !allocate
 
             do jCell = 1, nEdgesOnCell(iCell)
-               if ( .not. li_mask_is_boundary(cellMask(cellsOnCell(jCell,iCell)))) then
-                       minNeighborHeight = min(minNeighborHeight, upperSurface(cellsOnCell(jCell,iCell)))
+               iNeighbor = cellsOnCell(jCell,iCell)
+               if ( .not. li_mask_is_boundary(cellMask(iNeighbor)) .and. &
+                   (iNeighbor < nCells + 1)) then
+                    minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
                endif            
             end do
             
             !only adjust surface elevation if cell is local minimum
             if ((upperSurface(iCell) < minNeighborHeight) .and. (minNeighborHeight < bigValue)) then
+               call mpas_log_write("Changed ice thickness of cell $i", intArgs=(/iCell/))
+               numCellsChanged = numCellsChanged + 1
                iceThicknessHydro(iCell) = minNeighborHeight - bedTopography(iCell)            
             endif
 
          endif
       enddo
 
-!-------------------------------------------------------------------------      
-      end subroutine calc_iceThicknessHydro
+      call mpas_log_write("Number of Cells Changed in iceThicknessHydro: $i", intArgs=(/numCellsChanged/))
+      call mpas_log_write("Minimum Neighbor Height: $r", realArgs=(/minNeighborHeight/))
+      
+   end subroutine calc_iceThicknessHydro
 
 !***********************************************************************
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -201,6 +201,14 @@ module li_subglacial_hydro
          call calc_pressure_diag_vars(block, err_tmp)
          err = ior(err, err_tmp)
 
+         call calc_waterPressureSmooth(block, err_tmp) !adjust ice thickness along boundaries
+         err = ior(err,err_tmp)
+
+         !updates halos for waterPressure
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'waterPressureSlopeNormal')
+         call mpas_timer_stop("halo updates")
+
          block => block % next
       end do
 
@@ -301,8 +309,6 @@ module li_subglacial_hydro
       real (kind=RKIND) :: timeLeft ! subcycling time remaining until master dt is reached
       integer :: numSubCycles ! number of subcycles
       integer :: err_tmp
-
-
 
       err = 0
       err_tmp = 0
@@ -641,6 +647,14 @@ module li_subglacial_hydro
 
          call calc_pressure(block, err_tmp)
          err = ior(err, err_tmp)
+        
+         call calc_waterPressureSmooth(block, err_tmp) !adjust ice thickness along boundaries
+         err = ior(err,err_tmp)
+
+         !updates halos for waterPressure
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'waterPressureSlopeNormal')
+         call mpas_timer_stop("halo updates")
 
          block => block % next
       end do
@@ -777,7 +791,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
       real (kind=RKIND), dimension(:), pointer :: hydropotentialVertex
       real (kind=RKIND), dimension(:), pointer :: waterPressure
-      real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdge
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
       real (kind=RKIND), dimension(:), pointer :: waterThickness
@@ -796,8 +809,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFlux
       real (kind=RKIND), dimension(:), pointer :: waterFluxAdvec
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
-      real (kind=RKIND), dimension(:), pointer :: channelDebugMask
-      real (kind=RKIND), dimension(:), pointer :: pressureField
+      real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
@@ -832,7 +844,6 @@ module li_subglacial_hydro
       integer :: iNeighbor 
       integer :: numCells
       integer :: iter
-      real (kind=RKIND) :: totNeighborPressure
       
       err = 0
       err_tmp = 0
@@ -858,7 +869,6 @@ module li_subglacial_hydro
       
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
-      call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -888,9 +898,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(hydroPool, 'channelDebugMask', channelDebugMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
-      call mpas_pool_get_array(hydroPool, 'pressureField', pressureField)
+      call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth) 
       
       do iEdge = 1, nEdges
          cell1 = cellsOnEdge(1, iEdge)
@@ -908,63 +917,7 @@ module li_subglacial_hydro
 
          hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - hydropotentialBase(cell1)) / dcEdge(iEdge)
          hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - hydropotential(cell1)) / dcEdge(iEdge)
-         !waterPressureSlopeNormal(iEdge) = (waterPressure(cell2) - waterPressure(cell1)) / dcEdge(iEdge)
-      end do
 
-
-      ! Create a smoothed waterPressure product used only for
-      ! calculating waterPressureSlopeNormal - to avoid channelPressureFreeze
-      ! instabilities
-
-      if (nTimesSmooth > 0) then
-         do iter = 1, nTimesSmooth !May need to iterate to smooth properly
-            if (iter == 1) then      
-               waterPressureSmooth = waterPressure
-               pressureField = waterPressure
-            else
-               pressureField = waterPressureSmooth
-            endif
-
-            do iCell = 1, nCells
-               if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then 
-               
-                     isMarineMargin = 0
-                     do edgeNum = 1, nEdgesOnCell(iCell)
-                        iEdge = edgesOnCell(edgeNum,iCell)
-                        if (hydroMarineMarginMask(iEdge) == 1) then
-                           isMarineMargin = 1
-                           exit
-                        endif
-                     enddo
-
-                     if (isMarineMargin == 0) then 
-                  
-                        totNeighborPressure = pressureField(iCell)
-                        numCells = 1
-                  
-                        do jCell = 1, nEdgesOnCell(iCell)
-                           iNeighbor = cellsOnCell(jCell,iCell)
-
-                           if (iNeighbor < nCells + 1) then
-                              totNeighborPressure = totNeighborPressure + pressureField(iNeighbor)
-                              numCells = numCells + 1
-                           endif
-                        end do
-                  
-                        !waterPressureSmooth is average of neighboring cells
-                        waterPressureSmooth(iCell) = totNeighborPressure / numCells 
-                     endif
-               endif
-            end do
-         end do
-      elseif (nTimesSmooth == 0) then
-         waterPressureSmooth = waterPressure
-      endif
-         
-      do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-      
          waterPressureSlopeNormal(iEdge) = (waterPressureSmooth(cell2) - waterPressureSmooth(cell1)) / dcEdge(iEdge)
       end do
 
@@ -1751,7 +1704,6 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: hydroPool
       real (kind=RKIND), pointer :: rhoi, rhoo
-      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: waterPressure
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBase
@@ -1773,7 +1725,6 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
 
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
@@ -2255,7 +2206,6 @@ module li_subglacial_hydro
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: geometryPool
-      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
@@ -2270,7 +2220,6 @@ module li_subglacial_hydro
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
          call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
@@ -2413,8 +2362,8 @@ module li_subglacial_hydro
 !> \author  Alex Hager
 !> \date    7 June 2023
 !> \details
-!>  This routine calculates a modified ice thickness that is altered at
-!   the domain boundaries to avoid local minima in hydropotential
+!> This routine calculates a modified ice thickness that is altered to 
+!> avoid local minima in hydropotential
 !-----------------------------------------------------------------------
    subroutine calc_iceThicknessHydro(block, err)
 
@@ -2566,7 +2515,6 @@ module li_subglacial_hydro
 !> \details Find the total amount of freshwater entering the first ocean cell from the grounding line.
 !-----------------------------------------------------------------------
    subroutine calc_gl_totals(block, err)
-
       !-----------------------------------------------------------------
       ! input variables
       !-----------------------------------------------------------------
@@ -2580,11 +2528,6 @@ module li_subglacial_hydro
       ! output variables
       !-----------------------------------------------------------------
       integer, intent(out) :: err !< Output: error flag
-
-      !-----------------------------------------------------------------
-      !-----------------------------------------------------------------
-      ! output variables
-      !-----------------------------------------------------------------
 
       !-----------------------------------------------------------------
       ! local variables
@@ -2652,5 +2595,108 @@ module li_subglacial_hydro
          endif
       enddo
    end subroutine calc_gl_totals
+
+!***********************************************************************
+!
+!  routine calc_waterPressureSmooth
+!
+!> \brief   Calculate smoothed version of waterPressure used for calculation
+!>          of waterPressureSlopeNormal
+!> \author  Alex Hager
+!> \date    29 February 2024
+!> \details Creates a smoothed version of waterPressure, called waterPressureSmooth,
+!>          that is used for calculation of waterPressureSlopeNormal.
+!>          This is necessary to increase stability with channelPressureFreeze
+!>          with spatially variable bedTopography and upperSurface. waterPressureSmooth 
+!>          an area-weighted average of the current cells and its neighbors. Possible to
+!>          perform multiple iterations of smoothing by adjusting
+!>          config_SGH_iter_smooth_waterPressureSlopeNormal
+!-----------------------------------------------------------------------
+   subroutine calc_waterPressureSmooth(block,err)
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: block    !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: hydroPool
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
+      real (kind=RKIND), dimension(:), pointer :: areaCell
+      real (kind=RKIND), dimension(:), allocatable :: pressureField
+      real(kind=RKIND) :: totalPressure
+      real(kind=RKIND) :: totalArea
+      integer, dimension(:), pointer :: cellMask
+      integer, dimension(:,:), pointer :: cellsOnCell
+      integer, dimension(:), pointer :: nEdgesOnCell
+      integer, pointer :: nTimesSmooth
+      integer, pointer :: nCells
+      integer :: iCell, jCell
+      integer :: iNeighbor 
+      integer :: iter
+
+      err = 0
+
+      ! Get pools things
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_iter_smooth_waterPressureSlopeNormal', nTimesSmooth)
+      call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+      call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
+      call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+      allocate(pressureField(nCells+1))
+
+      waterPressureSmooth = waterPressure
+      pressureField = waterPressure
+
+      do iter = 1, nTimesSmooth !May need to iterate to smooth properly
+
+         do iCell = 1, nCells
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then !smooth over all grounded cells
+
+               totalPressure = pressureField(iCell)
+               totalArea = areaCell(iCell)
+          
+               do jCell = 1, nEdgesOnCell(iCell)
+                  iNeighbor = cellsOnCell(jCell,iCell)
+
+                  if ((li_mask_is_grounded_ice(cellMask(iNeighbor)))) then
+
+                     totalPressure = totalPressure + pressureField(iNeighbor)*areaCell(iNeighbor)
+
+                     totalArea = totalArea + areaCell(iNeighbor)
+                  endif
+               end do
+          
+               waterPressureSmooth(iCell) = totalPressure / totalArea !area-weighted average height
+            endif
+      end do
+
+      pressureField = waterPressureSmooth
+
+   end do
+
+   deallocate(pressureField)
+   end subroutine calc_waterPressureSmooth
 
 end module li_subglacial_hydro

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2449,6 +2449,7 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: edgesOnCell
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: edgeMask
+      real (kind=RKIND), dimension(:), pointer :: areaCell
       integer, pointer :: nCells
       integer :: edgeNum
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -2456,12 +2457,11 @@ module li_subglacial_hydro
       integer :: iCell
       integer :: jCell
       integer :: iNeighbor
-      integer :: isMarineMargin
       real (kind=RKIND) :: maxNeighborHeight
       real (kind=RKIND) :: minNeighborHeight
       real (kind=RKIND) :: meanNeighborHeight
-      real (kind=RKIND) :: totNeighborHeight
-      real (kind=RKIND) :: numCells
+      real (kind=RKIND) :: totalNeighborHeight
+      real (kind=RKIND) :: totalArea
       real (kind=RKIND), parameter :: bigValue = 1.0e6_RKIND
       real (kind=RKIND), parameter :: bigNegativeValue = -1.0e6_RKIND
       logical, pointer :: config_SGH_use_iceThicknessHydro
@@ -2484,6 +2484,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
+      call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_config(liConfigs, 'config_SGH_use_iceThicknessHydro', config_SGH_use_iceThicknessHydro)
 
@@ -2496,41 +2497,37 @@ module li_subglacial_hydro
       if (config_SGH_use_iceThicknessHydro) then
          do iCell = 1, nCells
 
-            if ((li_mask_is_grounded_ice(cellMask(iCell))) .and. (.not. li_mask_is_margin(cellMask(iCell)))) then !identify domain boundaries
+            if (li_mask_is_grounded_ice(cellMask(iCell))) then !identify domain boundaries
                
-               isMarineMargin = 0
-               do edgeNum = 1, nEdgesOnCell(iCell)
-                  iEdge = edgesOnCell(edgeNum,iCell)
-                  if (hydroMarineMarginMask(iEdge) == 1) then
-                     isMarineMargin = 1
-                     exit
-                  endif
-               enddo
-
-               if (isMarineMargin == 0) then
-                  maxNeighborHeight = bigNegativeValue !allocate
+                  maxNeighborHeight = bigNegativeValue !initialize
                   minNeighborHeight = bigValue
                   
+                  totalNeighborHeight = 0.0_RKIND
+                  totalArea = 0.0_RKIND
+
                   do jCell = 1, nEdgesOnCell(iCell)
+                  
                      iNeighbor = cellsOnCell(jCell,iCell)
 
-                     if (iNeighbor < nCells + 1) then
+                     !Only include neighbor cell in averaging if it contains grounded ice
+                     if ((li_mask_is_grounded_ice(cellMask(iNeighbor)))) then
 
-                         if (jCell == 1) then
-                                 totNeighborHeight = upperSurface(iNeighbor)
-                                 numCells = 1
-                         endif 
-                         
                          minNeighborHeight = min(minNeighborHeight, upperSurface(iNeighbor))
 
                          maxNeighborHeight = max(maxNeighborHeight, upperSurface(iNeighbor))
 
-                         totNeighborHeight = totNeighborHeight + upperSurface(iNeighbor)
-                         numCells = numCells + 1
+                         totalNeighborHeight = totalNeighborHeight + upperSurface(iNeighbor)*areaCell(iNeighbor)
+
+                         totalArea = totalArea + areaCell(iNeighbor)
+                         
                      endif
                   end do
-
-                  meanNeighborHeight = totNeighborHeight / numCells
+                  
+                  if ((totalNeighborHeight == 0.0_RKIND) .or. (totalArea == 0.0_RKIND)) then
+                     meanNeighborHeight = upperSurface(iCell) !no smoothing in single-cell islands
+                  else
+                     meanNeighborHeight = totalNeighborHeight / totalArea !area-weighted average height
+                  endif
 
                   !only adjust surface elevation if cell is local minimum or
                   !maximum
@@ -2550,7 +2547,6 @@ module li_subglacial_hydro
                   if (iceThicknessHydro(iCell) < 0.0_RKIND) then
                      iceThicknessHydro(iCell) = thickness(iCell)
                   endif
-               endif 
             endif
          enddo
       endif

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -45,6 +45,7 @@ module li_mask
    integer, parameter :: li_mask_ValueAlbanyMarginNeighbor  = 128  ! This the first cell beyond the last active albany cell
    integer, parameter :: li_mask_ValueGroundingLine         = 256
       !< This is grounded cell that has a floating neighbor, or vertex/edge on that boundary
+   integer, parameter :: li_mask_ValueDomainBoundary        = 512
 
    !--------------------------------------------------------------------
    !
@@ -143,7 +144,18 @@ module li_mask
       module procedure li_mask_is_grounding_line_logout_0d
    end interface
 
-   !--------------------------------------------------------------------
+
+   interface li_mask_is_boundary
+      module procedure li_mask_is_boundary_logout_1d
+      module procedure li_mask_is_boundary_logout_0d
+   end interface
+
+
+   interface li_mask_is_boundary_int
+      module procedure li_mask_is_boundary_intout_1d
+      module procedure li_mask_is_boundary_intout_0d
+   end interface   
+!--------------------------------------------------------------------
    !
    ! Private module variables
    !
@@ -294,10 +306,10 @@ contains
       logical :: isMargin
       logical :: isAlbanyMarginNeighbor
       logical :: aCellOnVertexHasIce, aCellOnVertexHasNoIce, aCellOnVertexHasDynamicIce, aCellOnVertexHasNoDynamicIce, &
-         aCellOnVertexIsFloating, aCellOnVertexIsFloatingAndDynamic, aCellOnVertexIsAlbanyActive
+         aCellOnVertexIsFloating, aCellOnVertexIsFloatingAndDynamic, aCellOnVertexIsAlbanyActive, aCellOnVertexIsDomainBoundary
       logical :: aCellOnVertexIsGrounded
       logical :: aCellOnEdgeHasIce, aCellOnEdgeHasNoIce, aCellOnEdgeHasDynamicIce, aCellOnEdgeHasNoDynamicIce, &
-         aCellOnEdgeIsFloating, aCellOnEdgeIsFloatingAndDynamic
+         aCellOnEdgeIsFloating, aCellOnEdgeIsFloatingAndDynamic, aCellOnEdgeIsDomainBoundary
       logical :: aCellOnEdgeIsGrounded
       logical :: aCellOnEdgeIsOpenOcean
       integer :: numCellsOnVertex
@@ -473,6 +485,16 @@ contains
           endif
       enddo
 
+      !identify domain boundaries
+      do i=1,nCells
+          do j=1,nEdgesOnCell(i)
+             iCellNeighbor = cellsOnCell(j,i)
+             if (iCellNeighbor == nCells+1) then
+                cellMask(i) = ior(cellMask(i), li_mask_ValueDomainBoundary)
+             endif
+          enddo
+      enddo
+
       !call mpas_timer_stop('calculate mask cell')
 
       ! ====
@@ -503,6 +525,7 @@ contains
           aCellOnVertexIsFloating = .false.
           aCellOnVertexIsGrounded = .false.
           aCellOnVertexIsFloatingAndDynamic = .false.
+          aCellOnVertexIsDomainBoundary = .false.
           do j = 1, vertexDegree  ! vertexDegree is usually 3 (e.g. CVT mesh) but could be something else (e.g. 4 for quad mesh)
               iCell = cellsOnVertex(j,i)
               aCellOnVertexHasIce = (aCellOnVertexHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -514,7 +537,9 @@ contains
                                                    (li_mask_is_floating_ice(cellMask(iCell)) .and. &
                                                     li_mask_is_dynamic_ice(cellMask(iCell))) )
               aCellOnVertexIsGrounded = (aCellOnVertexIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
+              aCellOnVertexIsDomainBoundary = (aCellOnVertexIsDomainBoundary .or. li_mask_is_boundary(cellMask(iCell)))
           end do
+
           if (aCellOnVertexHasIce) then
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueIce)
           endif
@@ -535,6 +560,9 @@ contains
              vertexMask(i) = ior(vertexMask(i), li_mask_ValueDynamicMargin)
              ! vertex with both 1+ dynamic ice cell(s) and 1+ non-dynamic cell(s) as neighbors
           endif
+          if (aCellOnVertexIsDomainBoundary) then
+             vertexMask(i) = ior(vertexMask(i), li_mask_ValueDomainBoundary)
+          endif 
       end do
 
 
@@ -607,6 +635,7 @@ contains
           aCellOnEdgeIsGrounded = .false.
           aCellOnEdgeIsOpenOcean = .false.
           aCellOnEdgeIsFloatingAndDynamic = .false.
+          aCellOnEdgeIsDomainBoundary = .false.
           do j = 1, 2
               iCell = cellsOnEdge(j,i)
               aCellOnEdgeHasIce = (aCellOnEdgeHasIce .or. li_mask_is_ice(cellMask(iCell)))
@@ -620,6 +649,7 @@ contains
               aCellOnEdgeIsGrounded = (aCellOnEdgeIsGrounded .or. li_mask_is_grounded_ice(cellMask(iCell)))
               aCellOnEdgeIsOpenOcean = aCellOnEdgeIsOpenOcean .or. &
                  ((bedTopography(iCell) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(iCell))))
+              aCellOnEdgeIsDomainBoundary = (aCellOnEdgeIsDomainBoundary .or. li_mask_is_boundary(cellMask(iCell)))
           end do
           if (aCellOnEdgeHasIce) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueIce)
@@ -640,6 +670,9 @@ contains
           endif
           if (aCellOnEdgeHasDynamicIce .and. aCellOnEdgeHasNoDynamicIce) then
              edgeMask(i) = ior(edgeMask(i), li_mask_ValueDynamicMargin)
+          endif
+          if (aCellOnEdgeIsDomainBoundary) then
+             edgeMask(i) = ior(edgeMask(i), li_mask_ValueDomainBoundary)
           endif
 
       end do
@@ -905,8 +938,35 @@ contains
       li_mask_is_initial_ice_logout_0d = (iand(mask, li_mask_ValueInitialIceExtent) == li_mask_ValueInitialIceExtent)
    end function li_mask_is_initial_ice_logout_0d
 
+   ! -- Functions that check for domain boundary --
+   function li_mask_is_boundary_logout_1d(mask)
+      integer, dimension(:), intent(in) :: mask
+      logical, dimension(size(mask)) :: li_mask_is_boundary_logout_1d
+
+      li_mask_is_boundary_logout_1d = (iand(mask, li_mask_ValueDomainBoundary) == li_mask_ValueDomainBoundary)
+   end function li_mask_is_boundary_logout_1d
+
+   function li_mask_is_boundary_logout_0d(mask)
+      integer, intent(in) :: mask
+      logical :: li_mask_is_boundary_logout_0d
+
+      li_mask_is_boundary_logout_0d = (iand(mask, li_mask_ValueDomainBoundary) == li_mask_ValueDomainBoundary)
+   end function li_mask_is_boundary_logout_0d
 
 
+   function li_mask_is_boundary_intout_1d(mask)
+      integer, dimension(:), intent(in) :: mask
+      integer, dimension(size(mask)) :: li_mask_is_boundary_intout_1d
+
+      li_mask_is_boundary_intout_1d = iand(mask, li_mask_ValueDomainBoundary) / li_mask_ValueDomainBoundary
+   end function li_mask_is_boundary_intout_1d
+
+   function li_mask_is_boundary_intout_0d(mask)
+      integer, intent(in) :: mask
+      integer :: li_mask_is_boundary_intout_0d
+
+      li_mask_is_boundary_intout_0d = iand(mask, li_mask_ValueDomainBoundary) / li_mask_ValueDomainBoundary
+   end function li_mask_is_boundary_intout_0d
 !***********************************************************************
 ! Private subroutines:
 !***********************************************************************


### PR DESCRIPTION
This PR introduces two smoothed fields that help keep the hydro model stable when run with spatially variable bed topography and ice thickness. The first is iceThicknessHydro, which is a modified version of thickness that is only used by the hydrology model in place of the original thickness field. This PR moves through multiple iterations of iceThicknessHydro; however, the ultimate version is nearly identical to thickness but with all local minima and maxima removed. Local minima/maxima are defined as a single cell that has a thinner/thicker thickness than all of its immediate neighbors. Local minima/maxima are then removed by setting iceThicknessHydro at that cell equal to the mean of its neighbors. iceThicknessHydro is necessary to avoid channel and diffusivity instabilities that arise from single-cell minima and maxima. A new output variable, upperSurfaceHydro, is then introduced as the sum of bedTopography and iceThicknessHydro. The use of iceThicknessHydro can be toggled on and off with namelist option config_SGH_use_iceThicknessHydro.

The second change is the introduction of waterPressureSmooth, which is a smoothed version of waterPressure that is only used for calculation of waterPressureSlopeNormal. This updated version of waterPressureSlopeNormal has more gradual gradients that help keep channelPressureFreeze stable. However, channelPressureFreeze is not yet fully functional due to additional necessary improvements to marine boundary conditions in realistic geometries. This will be addressed in the next pull request.