### PR TITLE
Remove "Build Type" option from albany input file

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.yaml
@@ -1,7 +1,6 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Build Type: Tpetra
 
 # Discretization Description
   Discretization:


### PR DESCRIPTION
Remove "Build Type" option from albany input file.

Epetra solver stack is no longer available through Albany and this change will be needed with newer versions of Albany.
See https://github.com/sandialabs/Albany/pull/1028

This will work with older versions of Albnay if Albany is built with no Epetra support.