### PR TITLE
Allow for interior no-flow ice boundaries

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -230,7 +230,11 @@
                      description="time step length limited by pressure equation scheme in subglacial hydrology system" />
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
                      description="time step used for evolving subglacial hydrology system" />
-                <!-- channel variables -->
+	     	<var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
+		     description="total discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell" />	
+	     	<var name="totalGroundingLineDischargeEdge" type="real" dimensions="Time nEdges" units="m^{3} s^{-1}"
+		     description="total discharge across grounding line edge" />
+	     	<!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"
@@ -263,7 +267,7 @@
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
-
+		
 	</var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2205,6 +2205,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
+      integer, dimension(:), pointer :: waterFluxMask
       integer, pointer :: nEdgesSolve
       integer :: cell1, cell2, iEdge
       real (kind=RKIND), pointer :: config_sea_level
@@ -2220,6 +2221,7 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
          call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+         call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
 
@@ -2230,11 +2232,13 @@ module li_subglacial_hydro
             ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
-                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) &
+                  .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroMarineMarginMask(iEdge) = 1
             elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
                      (li_mask_is_floating_ice(cellMask(cell1)) .or. &
-                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) &
+                     .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroMarineMarginMask(iEdge) = 1
             endif
          enddo
@@ -2245,10 +2249,12 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             !Look for edges with 1 cell on grounding ice and the other cell on land without ice
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
-               .and. (bedTopography(cell2) >= config_sea_level)) then
+               .and. (bedTopography(cell2) >= config_sea_level) &
+               .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroTerrestrialMarginMask(iEdge) = 1
             elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
-               .and. (bedTopography(cell1) >= config_sea_level)) then
+               .and. (bedTopography(cell1) >= config_sea_level) &
+               .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -911,9 +911,7 @@ module li_subglacial_hydro
 
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-         if ((cell1 == nCells+1) .or. (cell2 == nCells+1)) then
+         if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
             hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
             waterPressureSlopeNormal(iEdge) = 0.0_RKIND
@@ -962,17 +960,11 @@ module li_subglacial_hydro
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
-            ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
-            do i = 1, 2
-               iVertex = verticesOnEdge(i, iEdge)
-               do j = 1, 3
-                  iCell = cellsOnVertex(j, iVertex)
-                  if (iCell == nCells + 1) then
-                     hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
-                     hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
-                  endif
-               enddo
-            enddo
+            ! check for edges on the edge of the mesh and zero the tangent slope there
+            if (waterFluxMask(iEdge) == 2) then
+               hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
+            endif
          end do  ! edges
       case ('from_normal_slope')
          ! Do first with hydropotentialBase

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -960,7 +960,7 @@ module li_subglacial_hydro
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
-            ! check for edges on the edge of the mesh and zero the tangent slope there
+            ! check for edges on no-flow boundaries (which should include boundaries of the mesh) and zero the tangent slope there
             if (waterFluxMask(iEdge) == 2) then
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1710,7 +1710,6 @@ module li_subglacial_hydro
       ! local variables
       !-----------------------------------------------------------------
       ! Pools pointers
-!!      type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: velocityPool
@@ -1722,7 +1721,8 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: rhoi
       real (kind=RKIND), pointer :: config_SGH_incipient_channel_width
       logical, pointer :: config_SGH_include_pressure_melt
-
+      real (kind=RKIND), pointer :: config_SGH_bed_roughness_max
+      real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelMelt
       real (kind=RKIND), dimension(:), pointer :: channelPressureFreeze
@@ -1739,26 +1739,37 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
+      real (kind=RKIND), dimension(:), pointer :: waterThickness
+      real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, pointer :: nVertLevels
-
-      integer, pointer :: nEdgesSolve
+      real (kind=RKIND), pointer :: config_SGH_max_chnl_lake_depth
+      character (len=StrKIND), pointer :: config_SGH_inhibit_chnls_on_lakes
+      real (kind=RKIND), dimension(:), pointer :: xCell
+      real (kind=RKIND), dimension(:), pointer :: yCell
+      real (kind=RKIND), dimension(:), pointer :: xEdge
+      real (kind=RKIND), dimension(:), pointer :: yEdge
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nEdgesSolve, nEdges
       integer :: iEdge, cell1, cell2
-
 
       err = 0
 
       ! Get pools things
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
-!      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_conduc_coeff', Kc)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_alpha', alpha_c)
@@ -1766,10 +1777,8 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_creep_coefficient', creep_coeff)
       call mpas_pool_get_config(liConfigs, 'config_SGH_incipient_channel_width', config_SGH_incipient_channel_width)
       call mpas_pool_get_config(liConfigs, 'config_SGH_include_pressure_melt', config_SGH_include_pressure_melt)
-
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
       call mpas_pool_get_array(hydroPool, 'channelPressureFreeze', channelPressureFreeze)
@@ -1791,7 +1800,15 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-
+      call mpas_pool_get_array(meshPool, 'xCell', xCell)
+      call mpas_pool_get_array(meshPool, 'yCell', yCell)
+      call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
+      call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       ! Calculate terms needed for opening (melt) rate
 
       where(gradMagPhiEdge < 0.01_RKIND)
@@ -1859,9 +1876,31 @@ module li_subglacial_hydro
          channelOpeningRate = 0.0_RKIND
          channelClosingRate = 0.0_RKIND
       end where
+    
       channelChangeRate = channelOpeningRate - channelClosingRate
-
-
+     
+      totalGroundingLineDischargeCell(:) = 0.0_RKIND
+      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
+      do iEdge = 1, nEdgesSolve
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+         
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            ! We are looking for edges with 1 cell grounded ice and the
+            ! other cell floating ice or open ocean
+            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
+                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
+            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
+                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
+            endif
+         endif
+      enddo
    !--------------------------------------------------------------------
    end subroutine update_channel
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -909,7 +909,7 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
-      ! zero gradients at boundaries of the mesh
+      ! zero gradients at edges that are marked as no flux.  These should be applied at boundaries of the mesh
       do iEdge = 1, nEdges
          if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2206,9 +2206,10 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: waterFluxMask
-      integer, pointer :: nEdgesSolve
+      integer, pointer :: nEdgesSolve, nCells
       integer :: cell1, cell2, iEdge
       real (kind=RKIND), pointer :: config_sea_level
+      integer :: wfmWarning
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
@@ -2224,12 +2225,25 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
          hydroMarineMarginMask(:) = 0
+         hydroTerrestrialMarginMask(:) = 0
+         wfmWarning = 0
+
          do iEdge = 1, nEdgesSolve
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
-            ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            
+            !ensure no-flow conditions on edges of domain if not set up
+            !in input file
+            if ( ((cell1 == nCells + 1) .or. (cell2 == nCells +1 )) &
+               .and. (waterFluxMask(iEdge) .ne. 2)) then
+                 waterFluxMask(iEdge) = 2
+                 wfmWarning = 1
+            endif
+
+            ! hydroMarineMarginMask: We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
             ! Exclude no-flow boundaries
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
@@ -2242,13 +2256,8 @@ module li_subglacial_hydro
                      .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroMarineMarginMask(iEdge) = 1
             endif
-         enddo
-
-         hydroTerrestrialMarginMask(:) = 0
-         do iEdge = 1, nEdgesSolve
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            ! Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            
+            ! hydroTerrestrialMarginMask: Look for edges with 1 cell on grounding ice and the other cell on land without ice
             ! Exclude no-flow boundaries
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
                .and. (bedTopography(cell2) >= config_sea_level) &
@@ -2264,8 +2273,13 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      if (wfmWarning == 1) then
+         call mpas_log_write('WARNING: Changing waterFluxMask to enforce no-flow conditions at domain boundaries')
+      endif
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'hydroMarineMarginMask')
+      call mpas_dmpar_field_halo_exch(domain, 'hydroTerrestrialMarginMask')
+      call mpas_dmpar_field_halo_exch(domain, 'waterFluxMask')
       call mpas_timer_stop("halo updates")
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2230,6 +2230,7 @@ module li_subglacial_hydro
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            ! Exclude no-flow boundaries
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
                  ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -975,7 +975,8 @@ module li_subglacial_hydro
          includeHalo=.false., tangentialVector=hydropotentialSlopeTangent)
          ! ensure that edges that don't have ice on at least one side have tangent slope set to zero
          do iEdge = 1, nEdges
-            if ( .not. li_mask_is_ice(edgeMask(iEdge)) ) then
+            if ( (.not. li_mask_is_ice(edgeMask(iEdge))) .or. &
+               (waterFluxMask(iEdge) == 2) ) then
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2248,7 +2248,8 @@ module li_subglacial_hydro
          do iEdge = 1, nEdgesSolve
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
-            !Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            ! Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            ! Exclude no-flow boundaries
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
                .and. (bedTopography(cell2) >= config_sea_level) &
                .and. (waterFluxMask(iEdge) .ne. 2) ) then


### PR DESCRIPTION
This PR adds two minor changes that allow for masking out of interior regions of a glacier/ice sheet. Originally designed to run on a configuration where all cells within regions of frozen ice are neglected by setting `thickness` to zero, and frozen regions are surrounded by no flux conditions (`waterFluxMask` =2). Originally, domain boundaries were defined by any cell with a neighbor ID of `nCells +1`, and hydropotential gradients were set to zero along connecting edge. Now, the model relies on `waterFluxMask` to define where gradients should be set to zero, allowing for the creation of no-flow conditions along interior boundaries if desired. Additionally logic was then also added to the definitions of `hydroMarineMarginMask` and `hydroTerrestrialMarginMask` so that they do not include interior boundaries in their masks. Changes made in this PR should not affect model performance for simulations run in typical configurations, as long as `waterFluxMask` is properly implemented along domain boundaries, which is already best practice. 