### PR TITLE
Call `remove_small_islands` from calving driver

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -315,7 +315,8 @@ module li_calving
       ! now also remove any icebergs
       call remove_icebergs(domain)
 
-      ! Final operations after calving has been applied.
+      ! Final operations after calving has been applied, including removal
+      ! of small islands
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
@@ -324,6 +325,7 @@ module li_calving
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
+         call remove_small_islands(meshPool, geometryPool)
          ! In data calving mode we just calculate what should be calved but don't actually calve it.
          ! So set thickness back to original value.
          if (config_data_calving) then
@@ -927,8 +929,6 @@ module li_calving
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
 
-         call remove_small_islands(meshPool, geometryPool)
-
          block => block % next
       enddo
 
@@ -1002,8 +1002,6 @@ module li_calving
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
-
-         call remove_small_islands(meshPool, geometryPool)
 
          block => block % next
       enddo
@@ -1179,8 +1177,6 @@ module li_calving
 
          ! === apply calving ===
          thickness(:) = thickness(:) - calvingThickness(:)
-
-         call remove_small_islands(meshPool, geometryPool)
 
          block => block % next
       enddo
@@ -1412,8 +1408,6 @@ module li_calving
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
 
-         call remove_small_islands(meshPool, geometryPool)
-
          block => block % next
       enddo
 
@@ -1595,8 +1589,6 @@ module li_calving
            endif
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
-
-         call remove_small_islands(meshPool, geometryPool)
 
          block => block % next
       enddo
@@ -1985,8 +1977,6 @@ module li_calving
           call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
           err = ior(err, err_tmp)
 
-          call remove_small_islands(meshPool, geometryPool)
-          
           block => block % next
 
       enddo ! associated(block)
@@ -2256,7 +2246,6 @@ module li_calving
       ! update mask
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
       err = ior(err, err_tmp)
-      call remove_small_islands(meshPool, geometryPool)
 
       deallocate(submergedArea)
 
@@ -3326,8 +3315,6 @@ module li_calving
          enddo
          ! TODO: global reduce & reporting on amount of calving generated in this step
 
-         call remove_small_islands(meshPool, geometryPool)
-
          block => block % next
 
       enddo
@@ -3985,8 +3972,6 @@ module li_calving
          ! update mask
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
-
-         call remove_small_islands(meshPool, geometryPool)
 
          block => block % next
       enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -305,6 +305,12 @@ module li_calving
 
       endif
 
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+
       ! Consider mask calving as a possible additional step
       ! Mask calving can occur by itself or in conjunction with a physical calving law
       if (config_apply_calving_mask) then
@@ -312,8 +318,12 @@ module li_calving
          err = ior(err, err_tmp)
       endif
 
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+
       ! now also remove any icebergs
       call remove_icebergs(domain)
+
+      call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
       ! Final operations after calving has been applied, including removal
       ! of small islands
@@ -321,6 +331,7 @@ module li_calving
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
          call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -350,7 +361,6 @@ module li_calving
          endif   ! config_print_calving_info
 
          ! Update mask and geometry
-         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          err = ior(err, err_tmp)
          call li_update_geometry(geometryPool)


### PR DESCRIPTION
Always remove small islands if `config_remove_small_islands = .true.`, even if no other calving is active. Previously, `remove_small_islands` was only called from within each calving routine, which caused issues with AIS simulations that used `config_calving = .none.` along with `config_restore_calving_front = .true.`.