### PR TITLE
Do not update FCT masks between RK stages

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -717,13 +717,7 @@ module li_advection
       ! Deallocate arrays for fct
       if ( (trim(config_thickness_advection) .eq. 'fct') .or. &
            (trim(config_tracer_advection) .eq. 'fct') ) then
-         deallocate( nAdvCellsForEdge, &
-                     advCellsForEdge, &
-                     advCoefs, &
-                     advCoefs3rd, &
-                     advMaskHighOrder, &
-                     advMask2ndOrder, &
-                     tend)
+         deallocate(tend)
       endif
 
       ! clean up
@@ -1093,7 +1087,6 @@ module li_advection
          nTracers)
 
       use li_thermal, only: li_temperature_to_enthalpy_kelvin
-      use li_tracer_advection_fct_shared
       use li_tracer_advection_fct
       !-----------------------------------------------------------------
       !
@@ -1301,7 +1294,6 @@ module li_advection
       !       May need to increase maxTracers in the Registry.
       if ( (trim(config_tracer_advection) == 'fct') .or. &
            (trim(config_thickness_advection) == 'fct') ) then
-         call li_tracer_advection_fct_shared_init(geometryPool, err1)
          call li_tracer_advection_fct_init(err2)
 
          if (err1 /= 0 .or. err2 /= 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1161,11 +1161,9 @@ module li_advection
       real (kind=RKIND), pointer ::  &
            config_ice_density         ! ice density
 
-      integer :: iCell, iTracer, k, err, err1, err2
+      integer :: iCell, iTracer, k, err
 
       err  = 0
-      err1 = 0
-      err2 = 0
 
       ! get dimensions
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
@@ -1294,13 +1292,12 @@ module li_advection
       !       May need to increase maxTracers in the Registry.
       if ( (trim(config_tracer_advection) == 'fct') .or. &
            (trim(config_thickness_advection) == 'fct') ) then
-         call li_tracer_advection_fct_init(err2)
+         call li_tracer_advection_fct_init(err)
 
-         if (err1 /= 0 .or. err2 /= 0) then
-            err = 1
+         if (err /= 0) then
             call mpas_log_write(                                 &
                'Error encountered during fct tracer advection init', &
-               MPAS_LOG_ERR, masterOnly=.true.)
+               MPAS_LOG_ERR)
          endif
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -37,6 +37,7 @@ module li_time_integration_fe_rk
    use li_constants
    use li_mesh
    use li_mask
+   use li_tracer_advection_fct_shared
 
    implicit none
    private
@@ -112,7 +113,8 @@ module li_time_integration_fe_rk
       logical, pointer :: config_calculate_damage
       logical, pointer :: config_finalize_damage_after_advection
       logical, pointer :: config_update_velocity_before_calving
-      character (len=StrKIND), pointer :: config_thickness_advection
+      character (len=StrKIND), pointer :: config_thickness_advection, &
+                                          config_tracer_advection
       character (len=StrKIND), pointer :: config_thermal_solver
       character (len=StrKIND), pointer :: config_time_integration
       integer, pointer :: config_rk_order, config_rk3_stages
@@ -164,9 +166,10 @@ module li_time_integration_fe_rk
 
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front', config_restore_calving_front)
       call mpas_pool_get_config(liConfigs, 'config_restore_calving_front_prevent_retreat', config_restore_calving_front_prevent_retreat)
-      call mpas_pool_get_config(liConfigs, 'config_calculate_damage',config_calculate_damage)
+      call mpas_pool_get_config(liConfigs, 'config_calculate_damage', config_calculate_damage)
       call mpas_pool_get_config(liConfigs, 'config_finalize_damage_after_advection', config_finalize_damage_after_advection)
       call mpas_pool_get_config(liConfigs, 'config_thickness_advection', config_thickness_advection)
+      call mpas_pool_get_config(liConfigs, 'config_tracer_advection', config_tracer_advection)
       call mpas_pool_get_config(liConfigs, 'config_thermal_solver', config_thermal_solver)
       call mpas_pool_get_config(liConfigs, 'config_rk_order', config_rk_order)
       call mpas_pool_get_config(liConfigs, 'config_rk3_stages', config_rk3_stages)
@@ -278,6 +281,17 @@ module li_time_integration_fe_rk
          passiveTracer3dPrev(k,:) = passiveTracer2d(:)
       enddo
       deltatFull = deltat ! Save deltat in order to reset it at end of RK loop
+
+      if ( (trim(config_tracer_advection) == 'fct') .or. &
+           (trim(config_thickness_advection) == 'fct') ) then
+         call li_tracer_advection_fct_shared_init(geometryPool, err_tmp)
+         if (err_tmp /= 0) then
+            err = 1
+            call mpas_log_write(                                 &
+               'Error encountered during fct tracer advection shared init', &
+               MPAS_LOG_ERR, masterOnly=.true.)
+         endif
+      endif
 
       ! Set RK weights based on desired time integration method. Note
       ! that rkSubstepWeights are used to update at each sub-step, and
@@ -513,6 +527,17 @@ module li_time_integration_fe_rk
       floatingBasalMassBalApplied(:) = floatingBasalMassBalAccum(:)
       fluxAcrossGroundingLine(:) = fluxAcrossGroundingLineAccum(:)
       fluxAcrossGroundingLineOnCells(:) = fluxAcrossGroundingLineOnCellsAccum(:)
+
+      ! Deallocate arrays for fct
+      if ( (trim(config_thickness_advection) .eq. 'fct') .or. &
+           (trim(config_tracer_advection) .eq. 'fct') ) then
+         deallocate( nAdvCellsForEdge, &
+                     advCellsForEdge, &
+                     advCoefs, &
+                     advCoefs3rd, &
+                     advMaskHighOrder, &
+                     advMask2ndOrder)
+      endif
 
 ! Reset time step to full length after RK loop
       deltat = deltatFull

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -289,7 +289,7 @@ module li_time_integration_fe_rk
             err = 1
             call mpas_log_write(                                 &
                'Error encountered during fct tracer advection shared init', &
-               MPAS_LOG_ERR, masterOnly=.true.)
+               MPAS_LOG_ERR)
          endif
       endif
 


### PR DESCRIPTION
Do not update FCT masks between RK stages. The masking for FCT is now calculated in the first RK stage and not updated again in the time step.