### PR TITLE
Automatically create waterFluxMask around domain boundaries

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -909,7 +909,7 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
-      ! zero gradients at boundaries of the mesh
+      ! zero gradients at edges that are marked as no flux. These should be applied at boundaries of the mesh.
       do iEdge = 1, nEdges
          if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -56,7 +56,8 @@ module li_subglacial_hydro
    ! Private module variables
    !
    !--------------------------------------------------------------------
-
+! Minimum gradMagPhiBaseEdge and gradMagPhiEdge allowed before all dependent variables are zeroed out
+real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
 
 !***********************************************************************
    contains
@@ -1000,7 +1001,7 @@ module li_subglacial_hydro
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
          do iEdge = 1, nEdges
-            if (gradMagPhiBaseEdge(iEdge) < 0.01_RKIND) then
+            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
                effectiveConducEdge(iEdge) = 0.0_RKIND
             else
                conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
@@ -1014,7 +1015,7 @@ module li_subglacial_hydro
       else
          do iEdge = 1, nEdges
             ! Just use a single conductivity coeff.
-            if (gradMagPhiBaseEdge(iEdge) < 0.01_RKIND) then
+            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
                effectiveConducEdge(iEdge) = 0.0_RKIND
             else
                effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
@@ -1809,7 +1810,7 @@ module li_subglacial_hydro
 
       ! Calculate terms needed for opening (melt) rate
 
-      where(gradMagPhiEdge < 0.01_RKIND)
+      where(gradMagPhiEdge < SMALL_GRADPHI)
          channelDischarge(:) = 0.0_RKIND
       elsewhere
          channelDischarge = -1.0_RKIND * Kc * channelArea**alpha_c * gradMagPhiEdge**(beta_c - 2.0_RKIND) * &
@@ -1838,7 +1839,7 @@ module li_subglacial_hydro
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)
 
       ! diffusivity used only to limit channel dt right now
-      where(gradMagPhiEdge < 0.01_RKIND)
+      where(gradMagPhiEdge < SMALL_GRADPHI)
          channelDiffusivity = 0.0_RKIND
       elsewhere
          channelDiffusivity = abs(rho_water * gravity * channelArea *  &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2213,9 +2213,11 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nEdgesSolve
+      integer, dimension(:), pointer :: waterFluxMask
+      integer, pointer :: nEdgesSolve, nCells
       integer :: cell1, cell2, iEdge
       real (kind=RKIND), pointer :: config_sea_level
+      integer :: wfmWarning
 
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
@@ -2228,14 +2230,29 @@ module li_subglacial_hydro
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
          call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
+         call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
          call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
          call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
-
+         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+         
          hydroMarineMarginMask(:) = 0
+         hydroTerrestrialMarginMask(:) = 0
+         wfmWarning = 0
+
          do iEdge = 1, nEdgesSolve
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
-            ! We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            
+            !ensure no-flow conditions on edges of domain if not set up
+            !in input file
+            if ( ((cell1 == nCells + 1) .or. (cell2 == nCells +1 )) &
+               .and. (waterFluxMask(iEdge) .ne. 2)) then
+                 waterFluxMask(iEdge) = 2
+                 wfmWarning = 1
+            endif
+
+            ! hydroMarineMarginMask: We are looking for edges with 1 edge grounded ice and the other edge floating ice or open ocean
+            ! Exclude no-flow boundaries
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
                  ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
@@ -2245,13 +2262,9 @@ module li_subglacial_hydro
                      ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
                hydroMarineMarginMask(iEdge) = 1
             endif
-         enddo
-
-         hydroTerrestrialMarginMask(:) = 0
-         do iEdge = 1, nEdgesSolve
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            !Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            
+            ! hydroTerrestrialMarginMask: Look for edges with 1 cell on grounding ice and the other cell on land without ice
+            ! Exclude no-flow boundaries
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
                .and. (bedTopography(cell2) >= config_sea_level)) then
                hydroTerrestrialMarginMask(iEdge) = 1
@@ -2264,8 +2277,13 @@ module li_subglacial_hydro
          block => block % next
       end do
 
+      if (wfmWarning == 1) then
+         call mpas_log_write('WARNING: Changing waterFluxMask to enforce no-flow conditions at domain boundaries')
+      endif
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'hydroMarineMarginMask')
+      call mpas_dmpar_field_halo_exch(domain, 'hydroTerrestrialMarginMask')
+      call mpas_dmpar_field_halo_exch(domain, 'waterFluxMask')
       call mpas_timer_stop("halo updates")
 
    !--------------------------------------------------------------------

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2221,7 +2221,8 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: waterFluxMask
-      integer, pointer :: nEdgesSolve, nCells
+      integer, pointer :: nEdgesSolve
+      integer, pointer :: nCells
       integer :: cell1, cell2, iEdge
       real (kind=RKIND), pointer :: config_sea_level
       integer :: wfmWarning
@@ -2262,21 +2263,25 @@ module li_subglacial_hydro
             ! Exclude no-flow boundaries
             if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
                  (li_mask_is_floating_ice(cellMask(cell2)) .or. &
-                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) &
+                  .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroMarineMarginMask(iEdge) = 1
             elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
                      (li_mask_is_floating_ice(cellMask(cell1)) .or. &
-                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) &
+                     .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroMarineMarginMask(iEdge) = 1
             endif
             
             ! hydroTerrestrialMarginMask: Look for edges with 1 cell on grounding ice and the other cell on land without ice
             ! Exclude no-flow boundaries
             if ((li_mask_is_grounded_ice(cellMask(cell1))) .and. ( .not. li_mask_is_ice(cellMask(cell2))) &
-               .and. (bedTopography(cell2) >= config_sea_level)) then
+               .and. (bedTopography(cell2) >= config_sea_level) &
+               .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroTerrestrialMarginMask(iEdge) = 1
             elseif ((li_mask_is_grounded_ice(cellMask(cell2))) .and. ( .not. li_mask_is_ice(cellMask(cell1))) &
-               .and. (bedTopography(cell1) >= config_sea_level)) then
+               .and. (bedTopography(cell1) >= config_sea_level) &
+               .and. (waterFluxMask(iEdge) .ne. 2) ) then
                hydroTerrestrialMarginMask(iEdge) = 1
             endif
          enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1000,16 +1000,27 @@ module li_subglacial_hydro
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
          do iEdge = 1, nEdges
-            conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
-                             conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
-                             (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
-            effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-               (gradMagPhiBaseEdge(iEdge)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+            if (gradMagPhiBaseEdge(iEdge) < 0.01_RKIND) then
+               effectiveConducEdge(iEdge) = 0.0_RKIND
+            else
+               conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
+                  conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
+                  (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
+            
+               effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
+                  gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)              
+            endif
          end do
       else
-         ! Just use a single conductivity coeff.
-         effectiveConducEdge(:) = conduc_coeff * waterThicknessEdge(:)**(alpha-1.0_RKIND) *&
-            (gradMagPhiBaseEdge(:)+1.0e-30_RKIND)**(beta - 2.0_RKIND)   ! small value used for regularization
+         do iEdge = 1, nEdges
+            ! Just use a single conductivity coeff.
+            if (gradMagPhiBaseEdge(iEdge) < 0.01_RKIND) then
+               effectiveConducEdge(iEdge) = 0.0_RKIND
+            else
+               effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
+               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)   
+            endif
+         enddo
       endif
 
       ! calculate diffusivity on edges

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -911,9 +911,7 @@ module li_subglacial_hydro
 
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-         if ((cell1 == nCells+1) .or. (cell2 == nCells+1)) then
+         if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
             hydropotentialSlopeNormal(iEdge) = 0.0_RKIND
             waterPressureSlopeNormal(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2192,7 +2192,7 @@ module li_subglacial_hydro
 !> \date    24 October 2022
 !> \details
 !>  This routine calculates a mask of the boundaries of the active hydrology domain.
-!>  If there no waterFluxMask around domain boundaries, then calc_hydro_mask creates one.
+!>  If there is no waterFluxMask set around domain boundaries, then calc_hydro_mask creates one.
 !-----------------------------------------------------------------------
    subroutine calc_hydro_mask(domain)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -786,8 +786,8 @@ module li_subglacial_hydro
       integer, pointer :: nEdges
       integer, pointer :: nCells
       integer, pointer :: nVertices
-      integer :: iEdge, cell1, cell2
       integer :: i, j, iVertex, iCell
+      integer :: iEdge, cell1, cell2
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       integer :: err_tmp
@@ -946,7 +946,6 @@ module li_subglacial_hydro
       ! contaminated values.
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
       call mpas_pool_get_array(meshPool, 'verticesOnEdge', verticesOnEdge)
-      call mpas_pool_get_array(meshPool, 'cellsOnVertex', cellsOnVertex)
       select case (trim(config_SGH_tangent_slope_calculation))
       case ('from_vertex_barycentric', 'from_vertex_barycentric_kiteareas')
          do iEdge = 1, nEdges
@@ -960,17 +959,11 @@ module li_subglacial_hydro
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
-            ! check for edges where a vertex is on the edge of the mesh and zero the tangent slope there
-            do i = 1, 2
-               iVertex = verticesOnEdge(i, iEdge)
-               do j = 1, 3
-                  iCell = cellsOnVertex(j, iVertex)
-                  if (iCell == nCells + 1) then
-                     hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
-                     hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
-                  endif
-               enddo
-            enddo
+            ! zero tangent slope at waterFluxMask==2            
+            if (waterFluxMask(iEdge) == 2) then
+                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
+             endif
          end do  ! edges
       case ('from_normal_slope')
          ! Do first with hydropotentialBase
@@ -985,6 +978,11 @@ module li_subglacial_hydro
                hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
                hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
             endif
+            if (waterFluxMask(iEdge) == 2) then
+               hydropotentialBaseSlopeTangent(iEdge) = 0.0_RKIND
+               hydropotentialSlopeTangent(iEdge) = 0.0_RKIND
+            endif
+
          end do  ! edges
       case default
          call mpas_log_write('Invalid value for config_SGH_tangent_slope_calculation.', MPAS_LOG_ERR)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -56,8 +56,8 @@ module li_subglacial_hydro
    ! Private module variables
    !
    !--------------------------------------------------------------------
-! Minimum gradMagPhiBaseEdge and gradMagPhiEdge allowed before all dependent variables are zeroed out
-real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
+   ! Minimum gradMagPhiBaseEdge and gradMagPhiEdge allowed before all dependent variables are zeroed out
+   real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
 
 !***********************************************************************
    contains
@@ -773,7 +773,6 @@ real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
       integer, dimension(:), pointer :: edgeMask
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:,:), pointer :: verticesOnEdge
-      integer, dimension(:,:), pointer :: cellsOnVertex
       integer, dimension(:,:), pointer :: baryCellsOnVertex
       real (kind=RKIND), dimension(:,:), pointer :: baryWeightsOnVertex
       real (kind=RKIND), pointer :: alpha, beta
@@ -1019,7 +1018,7 @@ real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
                effectiveConducEdge(iEdge) = 0.0_RKIND
             else
                effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
-               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)   
+                  gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)   
             endif
          enddo
       endif
@@ -2192,7 +2191,8 @@ real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
 !> \author  Matt Hoffman
 !> \date    24 October 2022
 !> \details
-!>  This routine calculates a mask of the boundaries of the active hydrology domain
+!>  This routine calculates a mask of the boundaries of the active hydrology domain.
+!>  If there no waterFluxMask around domain boundaries, then calc_hydro_mask creates one.
 !-----------------------------------------------------------------------
    subroutine calc_hydro_mask(domain)
 
@@ -2291,7 +2291,7 @@ real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
       end do
 
       if (wfmWarning == 1) then
-         call mpas_log_write('WARNING: Changing waterFluxMask to enforce no-flow conditions at domain boundaries')
+         call mpas_log_write('Changing waterFluxMask to enforce no-flow conditions at domain boundaries', MPAS_LOG_WARN)
       endif
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'hydroMarineMarginMask')


### PR DESCRIPTION
This PR addresses two preexisting bugs in the subglacial hydro model relating to the handling of gradients on along domain boundaries, while simultaneously adding a new capability to the model. No-flow conditions along domain boundaries are now established solely based on the `waterFluxMask`, instead of a combination of the `waterFluxMask` and domain boundary criteria. The previous no-flow criteria left a loophole where hydropotential tangent slopes were not actually zeroed out at domain boundaries, and thus neither were `gradMagPhiEdge` or `gradMagPhiBaseEdge`. Additionally, using the `waterFluxMask` to define all no-flow boundaries now allows us to define interior boundaries and section off inactive parts of the hydro domain. 

**This PR changes the baseline results for the hydro integration test suite at two different commits: **c833924** and **684bd0f**. 

 **c833924**: Previously, manually inserting a `waterFluxMask` of 2 around domain boundaries in the input file of the humboldt test cases was enough fail baseline comparisons, even without any changes to the code, because of the discrepancy in no-flow definitions mentioned above. Therefore, automatically adding no-flow conditions with the `waterFluxMask` also causes the baseline comparison to fail as well. (In both situations, the differences between baseline and test cases are extremely small – within rounding error in Paraview). However, baseline comparisons for this commit pass if compared to an `origin/develop` run where a `waterFluxMask` has been manually added to the Humboldt input file.

**684bd0f**: This commit redefines `effectiveConducEdge` at edges where `gradMagPhiBaseEdge` is small <0.01, and is therefore expected to fail baseline comparison. This is necessary because otherwise `effectiveConducEdge` and `diffusivity` blow up when `gradMagPhiBaseEdge` is truly set to zero where `waterFluxMask=2`. (Note this is now consistent with the equivalent implementation in the channel model). The differences between baseline and test cases in the Humboldt simulations are indistinguishable in Paraview, but are noticeable in the hydro-radial test cases (see below). Differences in the hydro-radial cases are primarily in the spinup when hydropotential gradients are still being solidified, and are small once at steady-state (difference in `gradMagPhiEdge` is about ~3 pa/m at year 50).  

-  Impact of **684bd0f** on integration test results are dependent on threshold for gradMagPhiBaseEdge. A threshold of 0.01 – chosen to be consistent with the channel model – fails the baseline integration comparison in both hydro radial tests and the Humboldt restart test, although the Humboldt decomposition baseline comparison passes. This new version now defines a private module variable, SMALL_GRADPHI (currently set at 1e-6), that sets the lower limit of gradMagPhiEdge and gradMagPhiBaseEdge before dependent variables are zeroed out. 


Hydro radial test case comparison (left is baseline, right is test case) for commit **684bd0fd**:
https://github.com/MALI-Dev/E3SM/assets/131483939/90f1e241-0c34-43c0-a349-333159b683bb

First timestep (year 1):
![Screenshot 2024-04-02 at 2 20 17 PM](https://github.com/MALI-Dev/E3SM/assets/131483939/7fa2ea2e-15bb-4cfb-966e-12a5c1271a9c)

Second timestep (year 2): 
![Screenshot 2024-04-02 at 2 20 23 PM](https://github.com/MALI-Dev/E3SM/assets/131483939/d6c0942f-fb16-41ef-a459-a4138b24754d)

Last timestep (year 50):
![Screenshot 2024-04-02 at 4 09 27 PM](https://github.com/MALI-Dev/E3SM/assets/131483939/a410a71d-72bd-4c1a-920f-4d967596f1d9)

** `origin/develop` and the current branch have identical results from the hydro radial steady state drift test:**

**Baseline:**
avg W err=0.010364214556899048
max W err=0.02064233953534006
avg P err=0.2952744700279815
max P err=0.70539095924675

**Test:**
avg W err=0.010364214556899048
max W err=0.02064233953534006
avg P err=0.2952744700279815
max P err=0.70539095924675

**`origin/develop` and the current branch have identical nearly results from the hydro radial spinup test:**
**Baseline:**
avg W err=0.34703457272351895
max W err=0.9384276382111274
avg P err=14.025509996565308
max P err=42.78864785312645

**Test:**
avg W err=0.3470345727235292
max W err=0.9384276382111274
avg P err=14.02550999656507
max P err=42.78864785312135