### PR TITLE
New Variable: Total grounding line discharge entering adjacent ocean cell

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -229,10 +229,14 @@
                 <var name="deltatSGHpressure" type="real" dimensions="Time" units="s"
                      description="time step length limited by pressure equation scheme in subglacial hydrology system" />
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
-                     description="time step used for evolving subglacial hydrology system" />
+                        description="time step used for evolving subglacial hydrology system" />
+	     	<var name="distGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
+		     description="distributed discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />	
 	     	<var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
-		     description="total discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell" />	
+		     description="total (channel + dist.) discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />	
 	     	<!-- channel variables -->
+	     	<var name="chnlGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
+		     description="channel discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell. Values from all edges are summed if multiple grounding line edges border a single ungrounded cell" />	
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -230,7 +230,11 @@
                      description="time step length limited by pressure equation scheme in subglacial hydrology system" />
                 <var name="deltatSGH" type="real" dimensions="Time" units="s"
                      description="time step used for evolving subglacial hydrology system" />
-                <!-- channel variables -->
+	     	<var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
+		     description="total discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell" />	
+	     	<var name="totalGroundingLineDischargeEdge" type="real" dimensions="Time nEdges" units="m^{3} s^{-1}"
+		     description="total discharge across grounding line edge" />
+	     	<!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
                 <var name="channelDischarge" type="real" dimensions="nEdges Time" units="m^{3} s^{-1}"
@@ -263,7 +267,7 @@
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
-
+		
 	</var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -232,8 +232,6 @@
                      description="time step used for evolving subglacial hydrology system" />
 	     	<var name="totalGroundingLineDischargeCell" type="real" dimensions="Time nCells" units="m^{3} s^{-1}"
 		     description="total discharge across the grounding line, extrapolated from edge to adjacent ungrounded cell" />	
-	     	<var name="totalGroundingLineDischargeEdge" type="real" dimensions="Time nEdges" units="m^{3} s^{-1}"
-		     description="total discharge across grounding line edge" />
 	     	<!-- channel variables -->
                 <var name="channelArea" type="real" dimensions="nEdges Time" units="m^{2}"
                      description="area of channel in subglacial hydrology system" />
@@ -267,7 +265,6 @@
                      description="rate of channel melt production within each cell, averaged over cell area" />
                 <var name="channelDiffusivity" type="real" dimensions="nEdges Time" units="m^{2} s^{-1}"
                      description="diffusivity in channel in subglacial hydrology system" />
-		
 	</var_struct>
 
 <!-- ======================================================================= -->

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -562,10 +562,6 @@ module li_subglacial_hydro
 
          block => block % next
       end do
-      call mpas_timer_start("halo updates")
-      call mpas_dmpar_field_halo_exch(domain, 'totalGroundingLineDischargeCell')
-      call mpas_dmpar_field_halo_exch(domain, 'totalGroundingLineDischargeEdge')
-      call mpas_timer_stop("halo updates")
 
       ! =============
       ! Update water layer thickness
@@ -2318,7 +2314,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: distGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: chnlGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
-      real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: channelDischarge
       real (kind=RKIND), dimension(:), pointer :: waterFlux
       real (kind=RKIND), dimension(:), pointer :: dvEdge
@@ -2330,7 +2325,6 @@ module li_subglacial_hydro
       real (kind=RKIND) :: distGroundingLineDischargeEdge
       real (kind=RKIND) :: chnlGroundingLineDischargeEdge
       real (kind=RKIND) :: totalGroundingLineDischargeEdge
-      real (kind=RKIND), pointer :: config_sea_level
 
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
@@ -2339,7 +2333,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'distGroundingLineDischargeCell', distGroundingLineDischargeCell)
       call mpas_pool_get_array(hydroPool, 'chnlGroundingLineDischargeCell', chnlGroundingLineDischargeCell)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
-      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
       call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
@@ -2347,18 +2340,18 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
       distGroundingLineDischargeCell(:) = 0.0_RKIND
       chnlGroundingLineDischargeCell(:) = 0.0_RKIND
       totalGroundingLineDischargeCell(:) = 0.0_RKIND
       
       do iEdge = 1, nEdgesSolve
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
          
          if (hydroMarineMarginMask(iEdge) == 1) then
                
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            
             !calculate totals at each grounding line edge
             distGroundingLineDischargeEdge = abs(waterFlux(iEdge) * dvEdge(iEdge))
             chnlGroundingLineDischargeEdge = abs(channelDischarge(iEdge))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1802,7 +1802,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-      
       ! Calculate terms needed for opening (melt) rate
       where(gradMagPhiEdge < 0.01_RKIND)
          channelDischarge(:) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1744,8 +1744,6 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: rhoi
       real (kind=RKIND), pointer :: config_SGH_incipient_channel_width
       logical, pointer :: config_SGH_include_pressure_melt
-      real (kind=RKIND), pointer :: config_SGH_bed_roughness_max
-      real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelMelt
       real (kind=RKIND), dimension(:), pointer :: channelPressureFreeze
@@ -1762,27 +1760,13 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
-      real (kind=RKIND), dimension(:), pointer :: waterThickness
-      real (kind=RKIND), dimension(:), pointer :: waterPressure
-      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
-      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
-      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
-      real (kind=RKIND), dimension(:), pointer :: dvEdge
-      real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, pointer :: nVertLevels
-      real (kind=RKIND), pointer :: config_SGH_max_chnl_lake_depth
-      character (len=StrKIND), pointer :: config_SGH_inhibit_chnls_on_lakes
-      real (kind=RKIND), dimension(:), pointer :: xCell
-      real (kind=RKIND), dimension(:), pointer :: yCell
-      real (kind=RKIND), dimension(:), pointer :: xEdge
-      real (kind=RKIND), dimension(:), pointer :: yEdge
-      integer, dimension(:), pointer :: cellMask
-      integer, pointer :: nEdgesSolve, nEdges
+      integer, pointer :: nEdgesSolve
       integer :: iEdge, cell1, cell2
 
       err = 0
@@ -1792,7 +1776,6 @@ module li_subglacial_hydro
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_conduc_coeff', Kc)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_alpha', alpha_c)
@@ -1800,8 +1783,8 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_creep_coefficient', creep_coeff)
       call mpas_pool_get_config(liConfigs, 'config_SGH_incipient_channel_width', config_SGH_incipient_channel_width)
       call mpas_pool_get_config(liConfigs, 'config_SGH_include_pressure_melt', config_SGH_include_pressure_melt)
-      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
       call mpas_pool_get_array(hydroPool, 'channelPressureFreeze', channelPressureFreeze)
@@ -1823,17 +1806,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-      call mpas_pool_get_array(meshPool, 'xCell', xCell)
-      call mpas_pool_get_array(meshPool, 'yCell', yCell)
-      call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
-      call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
-      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
-      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
-      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      
       ! Calculate terms needed for opening (melt) rate
-
       where(gradMagPhiEdge < 0.01_RKIND)
          channelDischarge(:) = 0.0_RKIND
       elsewhere
@@ -2307,11 +2281,11 @@ module li_subglacial_hydro
 !
 !  routine calc_gl_total
 !
-!> \brief   Calculate total grounding line discharge on edges and
-!           adjacent cells
+!> \brief   Calculate total grounding line discharge on
+!           adjacent ocean cell
 !> \author  Alex Hager
 !> \date    27 March 2024
-!> \details
+!> \details Find the total amount of freshwater entering the first ocean cell from the grounding line. 
 !-----------------------------------------------------------------------
    subroutine calc_gl_totals(block, err)
 
@@ -2342,7 +2316,6 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: meshPool
 
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
-      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: channelDischarge
       real (kind=RKIND), dimension(:), pointer :: waterFlux
@@ -2352,6 +2325,7 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
+      real (kind=RKIND) :: totalGroundingLineDischargeEdge
       real (kind=RKIND), pointer :: config_sea_level
 
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
@@ -2359,7 +2333,6 @@ module li_subglacial_hydro
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
-      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
       call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
@@ -2371,25 +2344,18 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
       totalGroundingLineDischargeCell(:) = 0.0_RKIND
-      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
       
       do iEdge = 1, nEdgesSolve
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
          
          if (hydroMarineMarginMask(iEdge) == 1) then
-            ! We are looking for edges with 1 cell grounded ice and the
-            ! other cell floating ice or open ocean
-            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
-                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
-                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
-               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
-               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
-            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
-                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
-                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
-               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
-               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then
+               totalGroundingLineDischargeEdge = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge
+            elseif (li_mask_is_grounded_ice(cellMask(cell2))) then
+               totalGroundingLineDischargeEdge = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge
             endif
          endif
       enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2315,6 +2315,8 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: meshPool
 
+      real (kind=RKIND), dimension(:), pointer :: distGroundingLineDischargeCell
+      real (kind=RKIND), dimension(:), pointer :: chnlGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: channelDischarge
@@ -2325,6 +2327,8 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
+      real (kind=RKIND) :: distGroundingLineDischargeEdge
+      real (kind=RKIND) :: chnlGroundingLineDischargeEdge
       real (kind=RKIND) :: totalGroundingLineDischargeEdge
       real (kind=RKIND), pointer :: config_sea_level
 
@@ -2332,6 +2336,8 @@ module li_subglacial_hydro
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       
+      call mpas_pool_get_array(hydroPool, 'distGroundingLineDischargeCell', distGroundingLineDischargeCell)
+      call mpas_pool_get_array(hydroPool, 'chnlGroundingLineDischargeCell', chnlGroundingLineDischargeCell)
       call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
@@ -2343,6 +2349,8 @@ module li_subglacial_hydro
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
 
+      distGroundingLineDischargeCell(:) = 0.0_RKIND
+      chnlGroundingLineDischargeCell(:) = 0.0_RKIND
       totalGroundingLineDischargeCell(:) = 0.0_RKIND
       
       do iEdge = 1, nEdgesSolve
@@ -2350,11 +2358,20 @@ module li_subglacial_hydro
          cell2 = cellsOnEdge(2, iEdge)
          
          if (hydroMarineMarginMask(iEdge) == 1) then
+               
+            !calculate totals at each grounding line edge
+            distGroundingLineDischargeEdge = abs(waterFlux(iEdge) * dvEdge(iEdge))
+            chnlGroundingLineDischargeEdge = abs(channelDischarge(iEdge))
+            totalGroundingLineDischargeEdge = distGroundingLineDischargeEdge + chnlGroundingLineDischargeEdge
+
+            !Assign sum of edge totals to adjacent ungrounded cell
             if (li_mask_is_grounded_ice(cellMask(cell1))) then
-               totalGroundingLineDischargeEdge = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               distGroundingLineDischargeCell(cell2) = distGroundingLineDischargeCell(cell2) + distGroundingLineDischargeEdge
+               chnlGroundingLineDischargeCell(cell2) = chnlGroundingLineDischargeCell(cell2) + chnlGroundingLineDischargeEdge
                totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge
             elseif (li_mask_is_grounded_ice(cellMask(cell2))) then
-               totalGroundingLineDischargeEdge = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               distGroundingLineDischargeCell(cell1) = distGroundingLineDischargeCell(cell1) + distGroundingLineDischargeEdge
+               chnlGroundingLineDischargeCell(cell1) = chnlGroundingLineDischargeCell(cell1) + chnlGroundingLineDischargeEdge
                totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge
             endif
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1718,7 +1718,6 @@ module li_subglacial_hydro
       ! local variables
       !-----------------------------------------------------------------
       ! Pools pointers
-!!      type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: meshPool
       type (mpas_pool_type), pointer :: velocityPool
@@ -1730,7 +1729,8 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: rhoi
       real (kind=RKIND), pointer :: config_SGH_incipient_channel_width
       logical, pointer :: config_SGH_include_pressure_melt
-
+      real (kind=RKIND), pointer :: config_SGH_bed_roughness_max
+      real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), dimension(:), pointer :: channelArea
       real (kind=RKIND), dimension(:), pointer :: channelMelt
       real (kind=RKIND), dimension(:), pointer :: channelPressureFreeze
@@ -1747,26 +1747,37 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
+      real (kind=RKIND), dimension(:), pointer :: waterThickness
+      real (kind=RKIND), dimension(:), pointer :: waterPressure
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, pointer :: nVertLevels
-
-      integer, pointer :: nEdgesSolve
+      real (kind=RKIND), pointer :: config_SGH_max_chnl_lake_depth
+      character (len=StrKIND), pointer :: config_SGH_inhibit_chnls_on_lakes
+      real (kind=RKIND), dimension(:), pointer :: xCell
+      real (kind=RKIND), dimension(:), pointer :: yCell
+      real (kind=RKIND), dimension(:), pointer :: xEdge
+      real (kind=RKIND), dimension(:), pointer :: yEdge
+      integer, dimension(:), pointer :: cellMask
+      integer, pointer :: nEdgesSolve, nEdges
       integer :: iEdge, cell1, cell2
-
 
       err = 0
 
       ! Get pools things
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
-!      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_conduc_coeff', Kc)
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_alpha', alpha_c)
@@ -1774,10 +1785,8 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_chnl_creep_coefficient', creep_coeff)
       call mpas_pool_get_config(liConfigs, 'config_SGH_incipient_channel_width', config_SGH_incipient_channel_width)
       call mpas_pool_get_config(liConfigs, 'config_SGH_include_pressure_melt', config_SGH_include_pressure_melt)
-
       call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
-
       call mpas_pool_get_array(hydroPool, 'channelArea', channelArea)
       call mpas_pool_get_array(hydroPool, 'channelMelt', channelMelt)
       call mpas_pool_get_array(hydroPool, 'channelPressureFreeze', channelPressureFreeze)
@@ -1799,7 +1808,15 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
-
+      call mpas_pool_get_array(meshPool, 'xCell', xCell)
+      call mpas_pool_get_array(meshPool, 'yCell', yCell)
+      call mpas_pool_get_array(meshPool, 'xEdge', xEdge)
+      call mpas_pool_get_array(meshPool, 'yEdge', yEdge)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       ! Calculate terms needed for opening (melt) rate
 
       where(gradMagPhiEdge < 0.01_RKIND)
@@ -1867,9 +1884,31 @@ module li_subglacial_hydro
          channelOpeningRate = 0.0_RKIND
          channelClosingRate = 0.0_RKIND
       end where
+    
       channelChangeRate = channelOpeningRate - channelClosingRate
-
-
+     
+      totalGroundingLineDischargeCell(:) = 0.0_RKIND
+      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
+      do iEdge = 1, nEdgesSolve
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+         
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            ! We are looking for edges with 1 cell grounded ice and the
+            ! other cell floating ice or open ocean
+            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
+                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
+            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
+                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
+            endif
+         endif
+      enddo
    !--------------------------------------------------------------------
    end subroutine update_channel
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -551,6 +551,21 @@ module li_subglacial_hydro
          call mpas_timer_stop("halo updates")
       endif
 
+      ! =============
+      ! Calculate total grounding line discharges
+      ! =============
+      block => domain % blocklist
+      do while (associated(block))
+
+         call calc_gl_totals(block, err_tmp)
+         err = ior(err, err_tmp)
+
+         block => block % next
+      end do
+      call mpas_timer_start("halo updates")
+      call mpas_dmpar_field_halo_exch(domain, 'totalGroundingLineDischargeCell')
+      call mpas_dmpar_field_halo_exch(domain, 'totalGroundingLineDischargeEdge')
+      call mpas_timer_stop("halo updates")
 
       ! =============
       ! Update water layer thickness
@@ -1887,28 +1902,6 @@ module li_subglacial_hydro
     
       channelChangeRate = channelOpeningRate - channelClosingRate
      
-      totalGroundingLineDischargeCell(:) = 0.0_RKIND
-      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
-      do iEdge = 1, nEdgesSolve
-         cell1 = cellsOnEdge(1, iEdge)
-         cell2 = cellsOnEdge(2, iEdge)
-         
-         if (hydroMarineMarginMask(iEdge) == 1) then
-            ! We are looking for edges with 1 cell grounded ice and the
-            ! other cell floating ice or open ocean
-            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
-                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
-                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
-               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
-               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
-            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
-                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
-                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
-               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
-               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
-            endif
-         endif
-      enddo
    !--------------------------------------------------------------------
    end subroutine update_channel
 
@@ -2309,5 +2302,97 @@ module li_subglacial_hydro
 
    !--------------------------------------------------------------------
    end subroutine calc_hydro_mask
+
+!***********************************************************************
+!
+!  routine calc_gl_total
+!
+!> \brief   Calculate total grounding line discharge on edges and
+!           adjacent cells
+!> \author  Alex Hager
+!> \date    27 March 2024
+!> \details
+!-----------------------------------------------------------------------
+   subroutine calc_gl_totals(block, err)
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+      type (block_type), intent(inout) :: block    !< Input/Output: block object
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+      type (mpas_pool_type), pointer :: hydroPool
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: meshPool
+
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeCell
+      real (kind=RKIND), dimension(:), pointer :: totalGroundingLineDischargeEdge
+      real (kind=RKIND), dimension(:), pointer :: bedTopography
+      real (kind=RKIND), dimension(:), pointer :: channelDischarge
+      real (kind=RKIND), dimension(:), pointer :: waterFlux
+      real (kind=RKIND), dimension(:), pointer :: dvEdge
+      integer iEdge, cell1, cell2
+      integer, pointer :: nEdgesSolve
+      integer, dimension(:,:), pointer :: cellsOnEdge
+      integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: cellMask
+      real (kind=RKIND), pointer :: config_sea_level
+
+      call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+      call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+      
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeCell', totalGroundingLineDischargeCell)
+      call mpas_pool_get_array(hydroPool, 'totalGroundingLineDischargeEdge', totalGroundingLineDischargeEdge)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(hydroPool, 'channelDischarge', channelDischarge)
+      call mpas_pool_get_array(hydroPool, 'waterFlux', waterFlux)
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+      call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
+      call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
+
+      totalGroundingLineDischargeCell(:) = 0.0_RKIND
+      totalGroundingLineDischargeEdge(:) = 0.0_RKIND
+      
+      do iEdge = 1, nEdgesSolve
+         cell1 = cellsOnEdge(1, iEdge)
+         cell2 = cellsOnEdge(2, iEdge)
+         
+         if (hydroMarineMarginMask(iEdge) == 1) then
+            ! We are looking for edges with 1 cell grounded ice and the
+            ! other cell floating ice or open ocean
+            if ( (li_mask_is_grounded_ice(cellMask(cell1))) .and. &
+                 (li_mask_is_floating_ice(cellMask(cell2)) .or. &
+                 ((bedTopography(cell2) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell2)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) +abs( waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell2) = totalGroundingLineDischargeCell(cell2) + totalGroundingLineDischargeEdge(iEdge)
+            elseif ( (li_mask_is_grounded_ice(cellMask(cell2))) .and. &
+                     (li_mask_is_floating_ice(cellMask(cell1)) .or. &
+                     ((bedTopography(cell1) < config_sea_level) .and. (.not. li_mask_is_ice(cellMask(cell1)))) ) ) then
+               totalGroundingLineDischargeEdge(iEdge) = abs(channelDischarge(iEdge)) + abs(waterFlux(iEdge) * dvEdge(iEdge))
+               totalGroundingLineDischargeCell(cell1) = totalGroundingLineDischargeCell(cell1) + totalGroundingLineDischargeEdge(iEdge)
+            endif
+         endif
+      enddo
+   end subroutine calc_gl_totals
 
 end module li_subglacial_hydro


### PR DESCRIPTION
This PR adds a small subroutine to the hydro model that calculates a new variable, `totalGroundingLineDischargeCell`, that is needed to couple the hydro model to MPAS-Ocean. `totalGroundingLineDischargeCell` is the total volume flux (distributed + channelized; units: m3 s-1) entering each ocean cell adjacent to the grounding line. Distributed and channelized flow at each grounding line edge is summed into `totalGroundingLineDischargeEdge` and that value is extrapolated to the adjacent ocean cell. If multiple grounding line edges border the same ocean cell, then `totalGroundingLineDischargeEdge` values at all adjacent edges are summed to form `totalGroundingLineDischargeCell` for that cell.