### PR TITLE
Adjust diffusivity threshold for dtSGHdiffuBlock

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1208,7 +1208,7 @@ module li_subglacial_hydro
                dtSGHadvecBlock = min(dtSGHadvecBlock, 0.5_RKIND * dcEdge(iEdge) / abs(waterVelocity(iEdge)))
             endif
 
-            if (diffusivity(iEdge) > 0.0) then
+            if (diffusivity(iEdge) > 1e-12_RKIND) then
                ! Calculate diffusive CFL-limited time step
                dtSGHdiffuBlock = min(dtSGHdiffuBlock, 0.25_RKIND * dcEdge(iEdge)**2 / diffusivity(iEdge))
                ! Calculate pressure limited time step


### PR DESCRIPTION
Adjusts the minimum diffusivity used in calculation of dtSGHdiffuBlock from 0 to 1e-12. Fixes bug created from rounding error.