### PR TITLE
Remove icebergs in each RK stage

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -45,7 +45,8 @@ module li_calving
    !--------------------------------------------------------------------
 
    public :: li_calve_ice, li_restore_calving_front, li_apply_front_ablation_velocity, &
-             li_calculate_damage, li_finalize_damage_after_advection, li_flood_fill
+             li_calculate_damage, li_finalize_damage_after_advection, li_flood_fill, &
+             li_remove_icebergs
 
    !--------------------------------------------------------------------
    !
@@ -325,7 +326,7 @@ module li_calving
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
       ! now also remove any icebergs
-      call remove_icebergs(domain)
+      call li_remove_icebergs(domain)
 
       call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
 
@@ -4208,7 +4209,7 @@ module li_calving
    end subroutine calculate_calving_front_mask
 
 
-   subroutine remove_icebergs(domain)
+   subroutine li_remove_icebergs(domain)
       !-----------------------------------------------------------------
       ! input/output variables
       !-----------------------------------------------------------------
@@ -4362,7 +4363,7 @@ module li_calving
       call mpas_deallocate_scratch_field(growMaskField, single_block_in=.false.)
       call mpas_log_write("Iceberg-detection flood-fill complete. Removed $i iceberg cells.", intArgs=(/globalIcebergCellCount/))
       call mpas_timer_stop("iceberg detection")
-   end subroutine remove_icebergs
+   end subroutine li_remove_icebergs
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -29,7 +29,9 @@ module li_time_integration_fe_rk
    use mpas_log
 
    use li_advection
-   use li_calving, only: li_calve_ice, li_restore_calving_front, li_calculate_damage, li_finalize_damage_after_advection
+   use li_calving, only: li_calve_ice, li_restore_calving_front, &
+                         li_remove_icebergs, li_calculate_damage, &
+                         li_finalize_damage_after_advection
    use li_thermal, only: li_thermal_solver, li_enthalpy_to_temperature_kelvin
    use li_iceshelf_melt
    use li_diagnostic_vars
@@ -481,6 +483,11 @@ module li_time_integration_fe_rk
                call li_restore_calving_front(domain, err_tmp)
                err = ior(err, err_tmp)
             endif
+            ! We need to remove icebergs between RK stages because the
+            ! main calving routine is not called until after the RK loop.
+            ! This frequently results in icebergs that causes intermediate
+            ! RK stage velocity solves to fail.
+            call li_remove_icebergs(domain)
 
             call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
             err = ior(err, err_tmp)


### PR DESCRIPTION
Remove icebergs in each RK stage. When ice-shelves melt through in during an intermedite RK stage, they can leave behind icebergs that will cause the velocity solver to fail. So, we need to remove icebergs before each call to the velocity solver.