### PR TITLE
Debug diffusivity and waterVelocity timestep errors

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -152,7 +152,7 @@
                 <!-- state vars -->
 		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
 			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
-		<var name="waterThickness" type="real" dimensions="nCells Time" units="m"
+                <var name="waterThickness" type="real" dimensions="nCells Time" units="m" default_value="0.01"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"
                      description="water layer thickness in subglacial hydrology system from previous time step" />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2225,7 +2225,7 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', thickness)
+         call mpas_pool_get_array(hydroPool, 'thickness', thickness)
          
          effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
          effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -845,6 +845,7 @@ module li_subglacial_hydro
       integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
+      real(kind=RKIND), parameter :: SMALL_CONDUC = 1.0e-30_RKIND
       integer :: err_tmp
       
       err = 0
@@ -1078,6 +1079,10 @@ module li_subglacial_hydro
             endif
          enddo
       endif
+
+      where (effectiveConducEdge < SMALL_CONDUC)
+              effectiveConducEdge = 0.0_RKIND
+      end where
 
       ! calculate diffusivity on edges
       diffusivity(:) = rho_water * gravity * effectiveConducEdge(:) * waterThicknessEdge(:)


### PR DESCRIPTION
This is a small PR that fixes an issue with the timestep calculations that occurred when water velocities and/or diffusivities got too small (order 10^-300). This has mostly been an issue when `waterThickness` was missing an initial condition. Fixes were to impose a default initial condition for `waterThickness` if none exists, and to limit how small `effectiveConducEdge` can get before being forced to 0.0 