### PR TITLE
Ice Margin Boundary Condition Alterations

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -63,7 +63,7 @@ module li_subglacial_hydro
    real(kind=RKIND), parameter :: MIN_PHISLOPE_GL = 1e-10_RKIND
 
    !Undefined value
-   real(kind=RKIND), parameter :: UNDEFINED = 9.99e30_RKIND
+   real(kind=RKIND), parameter :: UNDEFINED = 0.0_RKIND
 
 !***********************************************************************
    contains

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -207,7 +207,9 @@ module li_subglacial_hydro
          call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
          
          waterPressure = max(0.0_RKIND, waterPressure)
-         waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
+         where (li_mask_is_grounded_ice(cellMask))
+            waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
+         end where
          
          ! set pressure and hydropotential correctly on ice-free land and in ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
@@ -1660,7 +1662,9 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
-      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
+      where (li_mask_is_grounded_ice(cellMask))
+         waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
+      end where
       
       do iCell = 1, nCells
         onMarineMargin = .false.

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -850,6 +850,7 @@ module li_subglacial_hydro
       integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
+      real(kind=RKIND), parameter :: SMALL_CONDUC = 1.0e-30_RKIND
       integer :: err_tmp
       
       err = 0

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1862,13 +1862,6 @@ module li_subglacial_hydro
          channelDischarge = 0.0_RKIND
       end where
 
-      ! Disable channels from forming if there is no sheet flux
-      ! TODO: Make a function of sheet dissipation threshold?
-      where (abs(waterFlux) <= 1e-10_RKIND)
-         channelArea = 0.0_RKIND
-         channelDischarge = 0.0_RKIND
-      end where
-
       channelVelocity = channelDischarge / (channelArea + 1.0e-12_RKIND)
 
       ! diffusivity used only to limit channel dt right now

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -110,6 +110,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
+      real (kind=RKIND), dimension(:), pointer :: hydropotential
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: tillMax
       real (kind=RKIND), pointer :: rhoi, rhoo
@@ -202,19 +203,23 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
          call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
+         call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
          call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
          
          waterPressure = max(0.0_RKIND, waterPressure)
          waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
          
-         ! set pressure correctly on ice-free land and in ocean
+         ! set pressure and hydropotential correctly on ice-free land and in ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          ! 
+         
          where ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
+            hydropotential = rho_water * gravity * bedTopography
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
+            hydropotential = 0.0_RKIND
          end where
         
          ! Initialize diagnostic pressure variables

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1642,7 +1642,7 @@ module li_subglacial_hydro
                    rho_water * gravity * deltatSGH / porosity + waterPressureOld
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
-         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
+         elsewhere ! should evaluate to ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
 
@@ -1652,7 +1652,7 @@ module li_subglacial_hydro
             waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
-         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
+         elsewhere ! should evaluate to ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -947,23 +947,22 @@ module li_subglacial_hydro
 
       ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
       do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1) .or. (hydroTerrestrialMarginMask(iEdge)==1) ) then
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge)))) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
                hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-               
+
             else ! cell1 is the cell outside the hydro domain
-            
+
                hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
                hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-              
+
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
-      
+
       ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
          if (waterFluxMask(iEdge) == 2) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -923,7 +923,7 @@ module li_subglacial_hydro
       ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
       do iEdge = 1, nEdges
          if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1)) then
+             (hydroMarineMarginMask(iEdge)==1) .or. (hydroTerrestrialMarginMask(iEdge)==1) ) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1631,6 +1631,7 @@ module li_subglacial_hydro
 
       where (li_mask_is_grounded_ice(cellMask))        
          waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
+                rho_water * gravity * deltatSGH / porosity + waterPressureOld
       elsewhere
          waterPressure = UNDEFINED ! zero waterPressure where no grounded ice 
       end where

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1823,6 +1823,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
+      real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
@@ -1868,6 +1869,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
+      call mpas_pool_get_array(hydroPool, 'waterThicknessEdgeUpwind', waterThicknessEdgeUpwind)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       ! Calculate terms needed for opening (melt) rate
 
@@ -1886,6 +1888,12 @@ module li_subglacial_hydro
       ! Note: an edge with only one grounded cell neighbor is called floating, so this logic retains channel vars
       ! on those edges to allow channel discharge across GL
       where (.not. ( (li_mask_is_grounded_ice(edgeMask)) .or. (hydroMarineMarginMask==1) ) )
+         channelArea = 0.0_RKIND
+         channelDischarge = 0.0_RKIND
+      end where
+
+      ! Similar to waterFlux, shut of channelDischarge if no water upstream. Prevents self-sustaining channels in the absence of distributed water
+      where (waterThicknessEdgeUpwind == 0.0_RKIND)
          channelArea = 0.0_RKIND
          channelDischarge = 0.0_RKIND
       end where

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1636,24 +1636,6 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
-      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
-      
-      do iCell = 1, nCells
-        onMarineMargin = .false.
-        do iEdge = 1, nEdgesOnCell(iCell)
-           if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
-              onMarineMargin = .true.
-              exit
-           endif
-        enddo
-        if (onMarineMargin) then
-           ! At marine margin, don't let water pressure fall below ocean pressure
-           ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
-           if (waterPressure(iCell) < rho_water * gravity * (config_sea_level - bedTopography(iCell))) then
-               waterPressure(iCell) = rho_water * gravity * (config_sea_level - bedTopography(iCell))
-           endif
-        endif
-      enddo
 
       waterPressureTendency = (waterPressure - waterPressureOld) / deltatSGH
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -844,7 +844,7 @@ module li_subglacial_hydro
       integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
-      real(kind=RKIND), parameter :: SMALL_CONDUC = 1.0e-30_RKIND
+      real (kind=RKIND), parameter :: MIN_PHISLOPE_GL = 1e-10_RKIND
       integer :: err_tmp
       
       err = 0
@@ -952,22 +952,22 @@ module li_subglacial_hydro
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                     if (hydroMarineMarginMask(iEdge) == 1) then
-                            if (hydropotentialBaseSlopeNormal(iEdge) > -1.0_RKIND) then
-                                 hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
+                            if (hydropotentialBaseSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
                             endif
-                            if (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND) then
-                                 hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
+                            if (hydropotentialSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
+                                 hydropotentialSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
                             endif
                     endif
 
             else ! cell1 is the cell outside the hydro domain
 
                     if (hydroMarineMarginMask(iEdge) == 1) then
-                            if (hydropotentialBaseSlopeNormal(iEdge) < 1.0_RKIND) then
-                                 hydropotentialBaseSlopeNormal(iEdge) = 1.0_RKIND
+                            if (hydropotentialBaseSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = MIN_PHISLOPE_GL
                             endif
-                            if (hydropotentialSlopeNormal(iEdge) < 1.0_RKIND) then
-                                 hydropotentialSlopeNormal(iEdge) = 1.0_RKIND
+                            if (hydropotentialSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
+                                 hydropotentialSlopeNormal(iEdge) = MIN_PHISLOPE_GL
                             endif
                     endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -206,9 +206,8 @@ module li_subglacial_hydro
          ! set pressure correctly under floating ice and open ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         where ( (li_mask_is_floating_ice(cellMask)) .or. &
-                 ( (.not. li_mask_is_ice(cellMask)) .and. (bedTopography < config_sea_level) ) )
-            waterPressure = rhoo * gravity * (config_sea_level - bedTopography)
+         where (.not. (li_mask_is_grounded_ice(cellMask)))
+            waterPressure = 0.0_RKIND
          end where
 
          ! Initialize diagnostic pressure variables
@@ -1617,14 +1616,11 @@ module li_subglacial_hydro
       select case (trim(config_SGH_pressure_calc))
       case ('cavity')
 
-         where (li_mask_is_floating_ice(cellMask))
-            waterPressure = rhoi * gravity * iceThicknessHydro
-         elsewhere (.not. li_mask_is_ice(cellMask))
-            waterPressure = 0.0_RKIND
-         elsewhere
-            waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
-               rho_water * gravity * deltatSGH / porosity + waterPressureOld
-         end where
+      where (li_mask_is_grounded_ice(cellMask))        
+         waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
+      elsewhere
+         waterPressure = 0.0_RKIND ! zero waterPressure where no grounded ice 
+      end where
 
       case ('overburden')
          where (li_mask_is_floating_ice(cellMask))
@@ -1738,15 +1734,14 @@ module li_subglacial_hydro
 
       effectivePressure = rhoi * gravity * iceThicknessHydro - waterPressure
          ! < this should evalute to 0 for floating ice if Pw set correctly there.
-      where (.not. li_mask_is_grounded_ice(cellmask))
+      where (.not. (li_mask_is_grounded_ice(cellMask)))
          effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
       end where
       
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
-      ! This is still correct under ice shelves/open ocean because waterPressure has been set appropriately there already.
-      ! Note this leads to a nonuniform hydropotential at sea level that is a function of the ocean depth.
-      ! That is what we want because we use this as a boundary condition on the subglacial system,
-      ! and we want the subglacial system to feel the pressure of the ocean column at its edge.
+      where (.not. (li_mask_is_grounded_ice(cellMask))) 
+         hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
+      end where      
 
       ! hydropotential with water thickness
       hydropotential = hydropotentialBase + rho_water * gravity * waterThickness

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -921,14 +921,10 @@ module li_subglacial_hydro
 
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
-      ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
-      ! but that is unrealistic.
-      ! So for all boundaries of the hydro system where outflow is occuring,
-      ! the hydropotential at the margin should be determined by the geometry
+      ! The hydropotential at the terrestrial margin should be determined by the geometry
       ! at the edge of the cell in a 1-sided sense.
       do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1)) then
+         if (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
@@ -958,9 +954,12 @@ module li_subglacial_hydro
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
                hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
                hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+               
             else ! cell1 is the cell outside the hydro domain
+            
                hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
                hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+              
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1732,7 +1732,7 @@ module li_subglacial_hydro
       end where
       
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
-      where (.not. (li_mask_is_grounded_ice(cellMask))) 
+      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < 0.0_RKIND)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
       end where      
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -219,7 +219,7 @@ module li_subglacial_hydro
          where ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
             hydropotential = rho_water * gravity * bedTopography
-         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
             hydropotential = 0.0_RKIND
          end where
@@ -1642,7 +1642,7 @@ module li_subglacial_hydro
                    rho_water * gravity * deltatSGH / porosity + waterPressureOld
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
-         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
 
@@ -1652,7 +1652,7 @@ module li_subglacial_hydro
             waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
-         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography <= config_sea_level))
             waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
 
@@ -1760,7 +1760,7 @@ module li_subglacial_hydro
       end where
       
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
-      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < config_sea_level)) 
+      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography <= config_sea_level)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential in ocean
       elsewhere ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography > config_sea_level))
          hydropotentialBase = rho_water * gravity * bedTopography ! for completeness, but won't matter with one-side slope calculations on terrestrial boundaries
@@ -1901,7 +1901,7 @@ module li_subglacial_hydro
          channelDischarge = 0.0_RKIND
       end where
 
-      ! Similar to waterFlux, shut of channelDischarge if no water upstream. Prevents self-sustaining channels in the absence of distributed water
+      ! Similar to waterFlux, shut off channelDischarge if no water upstream. Prevents self-sustaining channels in the absence of distributed water
       where (waterThicknessEdgeUpwind == 0.0_RKIND)
          channelArea = 0.0_RKIND
          channelDischarge = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -951,13 +951,25 @@ module li_subglacial_hydro
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+                    if (hydroMarineMarginMask(iEdge) == 1) then
+                            if (hydropotentialBaseSlopeNormal(iEdge) > -1.0_RKIND) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = -1.0_RKIND
+                            endif
+                            if (hydropotentialSlopeNormal(iEdge) > -1.0_RKIND) then
+                                 hydropotentialSlopeNormal(iEdge) = -1.0_RKIND
+                            endif
+                    endif
 
             else ! cell1 is the cell outside the hydro domain
 
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+                    if (hydroMarineMarginMask(iEdge) == 1) then
+                            if (hydropotentialBaseSlopeNormal(iEdge) < 1.0_RKIND) then
+                                 hydropotentialBaseSlopeNormal(iEdge) = 1.0_RKIND
+                            endif
+                            if (hydropotentialSlopeNormal(iEdge) < 1.0_RKIND) then
+                                 hydropotentialSlopeNormal(iEdge) = 1.0_RKIND
+                            endif
+                    endif
 
             endif ! which cell is icefree
          endif ! if edge of grounded ice

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -919,22 +919,6 @@ module li_subglacial_hydro
          waterPressureSlopeNormal(iEdge) = (waterPressureSmooth(cell2) - waterPressureSmooth(cell1)) / dcEdge(iEdge)
       end do
 
-      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
-      do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
-             (hydroMarineMarginMask(iEdge)==1) .or. (hydroTerrestrialMarginMask(iEdge)==1) ) then
-            cell1 = cellsOnEdge(1, iEdge)
-            cell2 = cellsOnEdge(2, iEdge)
-            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-            else ! cell1 is the cell outside the hydro domain
-               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
-               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
-            endif ! which cell is icefree
-         endif ! if edge of grounded ice
-      end do
-
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
       ! We also want to do this at marine margins because otherwise the offshore topography can create a barrier to flow,
@@ -965,7 +949,23 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
-      ! zero gradients at edges that are marked as no flux. These should be applied at boundaries of the mesh.
+      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
+      do iEdge = 1, nEdges
+         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) .or. &
+             (hydroMarineMarginMask(iEdge)==1) .or. (hydroTerrestrialMarginMask(iEdge)==1) ) then
+            cell1 = cellsOnEdge(1, iEdge)
+            cell2 = cellsOnEdge(2, iEdge)
+            if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = min(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            else ! cell1 is the cell outside the hydro domain
+               hydropotentialBaseSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialBaseSlopeNormal(iEdge))
+               hydropotentialSlopeNormal(iEdge) = max(0.0_RKIND, hydropotentialSlopeNormal(iEdge))
+            endif ! which cell is icefree
+         endif ! if edge of grounded ice
+      end do
+      
+      ! zero gradients at boundaries of the mesh
       do iEdge = 1, nEdges
          if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1640,24 +1640,18 @@ module li_subglacial_hydro
       waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
       
       do iCell = 1, nCells
-        if ( li_mask_is_floating_ice(cellMask(iCell)) .or. &
-             ((.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) ) then
-           ! set pressure correctly under floating ice and open ocean
-           waterPressure(iCell) = rhoo * gravity * (config_sea_level - bedTopography(iCell))
-        else
-           onMarineMargin = .false.
-           do iEdge = 1, nEdgesOnCell(iCell)
-              if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
-                 onMarineMargin = .true.
-                 exit
-              endif
-           enddo
-           if (onMarineMargin) then
-              ! At marine margin, don't let water pressure fall below ocean pressure
-              ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
-              if (waterPressure(iCell) < rhoo * gravity * (config_sea_level - bedTopography(iCell))) then
-                  waterPressure(iCell) = rhoo * gravity * (config_sea_level - bedTopography(iCell))
-              endif
+        onMarineMargin = .false.
+        do iEdge = 1, nEdgesOnCell(iCell)
+           if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
+              onMarineMargin = .true.
+              exit
+           endif
+        enddo
+        if (onMarineMargin) then
+           ! At marine margin, don't let water pressure fall below ocean pressure
+           ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
+           if (waterPressure(iCell) < rho_water * gravity * (config_sea_level - bedTopography(iCell))) then
+               waterPressure(iCell) = rho_water * gravity * (config_sea_level - bedTopography(iCell))
            endif
         endif
       enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -59,6 +59,12 @@ module li_subglacial_hydro
    ! Minimum gradMagPhiBaseEdge and gradMagPhiEdge allowed before all dependent variables are zeroed out
    real(kind=RKIND), parameter :: SMALL_GRADPHI = 1.0e-6_RKIND
 
+   !Minimum outflowing hydropotential slope applied at grounding line
+   real(kind=RKIND), parameter :: MIN_PHISLOPE_GL = 1e-10_RKIND
+
+   !Undefined value
+   real(kind=RKIND), parameter :: UNDEFINED = 9.99e30_RKIND
+
 !***********************************************************************
    contains
 
@@ -844,7 +850,6 @@ module li_subglacial_hydro
       integer :: i, j, iVertex, iCell
       real (kind=RKIND) :: velSign
       integer :: numGroundedCells
-      real (kind=RKIND), parameter :: MIN_PHISLOPE_GL = 1e-10_RKIND
       integer :: err_tmp
       
       err = 0
@@ -923,6 +928,7 @@ module li_subglacial_hydro
       ! hydropotential gradients and unstable channel growth.
       ! The hydropotential at the terrestrial margin should be determined by the geometry
       ! at the edge of the cell in a 1-sided sense.
+      ! This one-sided implementation also creates outflowing conditions at terrestrial boundary
       do iEdge = 1, nEdges
          if (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) then
             cell1 = cellsOnEdge(1, iEdge)
@@ -945,37 +951,34 @@ module li_subglacial_hydro
          endif ! if edge of grounded ice
       end do
 
-      ! At boundaries of hydro domain, disallow inflow.  Allow outflow if hydropotential gradient requires it.
+      ! Disallow inflow from the marine margin by imposing a minimum outflowing hydropotential gradient at the grounding line.
       do iEdge = 1, nEdges
-         if ( (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge)))) then
+         if ( hydroMarineMarginMask(iEdge) == 1) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the cell outside the hydro domain
-                    if (hydroMarineMarginMask(iEdge) == 1) then
-                            if (hydropotentialBaseSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
-                                 hydropotentialBaseSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
-                            endif
-                            if (hydropotentialSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
-                                 hydropotentialSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
-                            endif
-                    endif
+               
+               if (hydropotentialBaseSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
+                  hydropotentialBaseSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
+               endif
+               if (hydropotentialSlopeNormal(iEdge) > -MIN_PHISLOPE_GL) then
+                  hydropotentialSlopeNormal(iEdge) = -MIN_PHISLOPE_GL
+               endif
 
             else ! cell1 is the cell outside the hydro domain
 
-                    if (hydroMarineMarginMask(iEdge) == 1) then
-                            if (hydropotentialBaseSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
-                                 hydropotentialBaseSlopeNormal(iEdge) = MIN_PHISLOPE_GL
-                            endif
-                            if (hydropotentialSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
-                                 hydropotentialSlopeNormal(iEdge) = MIN_PHISLOPE_GL
-                            endif
-                    endif
+               if (hydropotentialBaseSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
+                  hydropotentialBaseSlopeNormal(iEdge) = MIN_PHISLOPE_GL
+               endif
+               if (hydropotentialSlopeNormal(iEdge) < MIN_PHISLOPE_GL) then
+                  hydropotentialSlopeNormal(iEdge) = MIN_PHISLOPE_GL
+               endif
 
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
 
-      ! zero gradients at boundaries of the mesh
+      ! zero gradients along zero flux boundaries
       do iEdge = 1, nEdges
          if (waterFluxMask(iEdge) == 2) then
             hydropotentialBaseSlopeNormal(iEdge) = 0.0_RKIND
@@ -1629,14 +1632,14 @@ module li_subglacial_hydro
       where (li_mask_is_grounded_ice(cellMask))        
          waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
       elsewhere
-         waterPressure = 0.0_RKIND ! zero waterPressure where no grounded ice 
+         waterPressure = UNDEFINED ! zero waterPressure where no grounded ice 
       end where
 
       case ('overburden')
          where (li_mask_is_floating_ice(cellMask))
             waterPressure = rhoi * gravity * iceThicknessHydro
          elsewhere (.not. li_mask_is_ice(cellMask))
-            waterPressure = 0.0_RKIND
+            waterPressure = UNDEFINED
          elsewhere
             waterPressure = rhoi * gravity * iceThicknessHydro
          end where
@@ -1726,7 +1729,7 @@ module li_subglacial_hydro
       
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
       where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < 0.0_RKIND)) 
-         hydropotentialBase = 0.0_RKIND !zero hydropotential where no grounded ice
+         hydropotentialBase = 0.0_RKIND !zero hydropotential in ocean
       end where      
 
       ! hydropotential with water thickness

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1655,6 +1655,24 @@ module li_subglacial_hydro
       end select
 
       waterPressure = max(0.0_RKIND, waterPressure)
+      waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
+      
+      do iCell = 1, nCells
+        onMarineMargin = .false.
+        do iEdge = 1, nEdgesOnCell(iCell)
+           if (hydroMarineMarginMask(edgesOnCell(iEdge, iCell)) == 1) then
+              onMarineMargin = .true.
+              exit
+           endif
+        enddo
+        if (onMarineMargin) then
+           ! At marine margin, don't let water pressure fall below ocean pressure
+           ! TODO: Not sure if this should include the water layer thickness term.  Leaving it off.
+           if (waterPressure(iCell) < rho_water * gravity * (config_sea_level - bedTopography(iCell))) then
+               waterPressure(iCell) = rho_water * gravity * (config_sea_level - bedTopography(iCell))
+           endif
+        endif
+      enddo
 
       waterPressureTendency = (waterPressure - waterPressureOld) / deltatSGH
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -62,9 +62,6 @@ module li_subglacial_hydro
    !Minimum outflowing hydropotential slope applied at grounding line
    real(kind=RKIND), parameter :: MIN_PHISLOPE_GL = 1e-10_RKIND
 
-   !Undefined value
-   real(kind=RKIND), parameter :: UNDEFINED = 0.0_RKIND
-
 !***********************************************************************
    contains
 
@@ -209,13 +206,17 @@ module li_subglacial_hydro
          
          waterPressure = max(0.0_RKIND, waterPressure)
          waterPressure = min(waterPressure, rhoi * gravity * iceThicknessHydro)
-         ! set pressure correctly under floating ice and open ocean
+         
+         ! set pressure correctly on ice-free land and in ocean
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         where (.not. (li_mask_is_grounded_ice(cellMask)))
+         ! 
+         where ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
             waterPressure = 0.0_RKIND
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+            waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
-
+        
          ! Initialize diagnostic pressure variables
          call calc_pressure_diag_vars(block, err_tmp)
          err = ior(err, err_tmp)
@@ -826,6 +827,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterFluxDiffu
       real (kind=RKIND), dimension(:), pointer :: waterPressureSmooth
       integer, dimension(:), pointer :: hydroMarineMarginMask
+      integer, dimension(:), pointer :: hydroTerrestrialMarginMask
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
@@ -902,6 +904,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'waterFluxDiffu', waterFluxDiffu)
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
+      call mpas_pool_get_array(hydroPool, 'hydroTerrestrialMarginMask', hydroTerrestrialMarginMask)
       call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(hydroPool, 'waterPressureSmooth', waterPressureSmooth) 
       
@@ -928,26 +931,23 @@ module li_subglacial_hydro
       ! At terrestrial margin, ignore the downslope bed topography gradient.  Including it can lead to unrealistically large
       ! hydropotential gradients and unstable channel growth.
       ! The hydropotential at the terrestrial margin should be determined by the geometry
-      ! at the edge of the cell in a 1-sided sense.
+      ! at the edge of the cell in a 1-sided sense. For hydropotentialBase = rho*g*Zb + Pw, this means hydropotentialBaseSlopeNormal
+      ! at the terrestrial margin is equal to Pw/dcEdge. 
       ! This one-sided implementation also creates outflowing conditions at terrestrial boundary
       do iEdge = 1, nEdges
-         if (li_mask_is_margin(edgeMask(iEdge)) .and. li_mask_is_grounded_ice(edgeMask(iEdge))) then
+         if (hydroTerrestrialMarginMask(iEdge) == 1) then
             cell1 = cellsOnEdge(1, iEdge)
             cell2 = cellsOnEdge(2, iEdge)
             if (li_mask_is_grounded_ice(cellMask(cell1))) then ! cell2 is the icefree cell - replace phi there with cell1 Phig
-               hydropotentialBaseSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
-                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
-                  hydropotentialBase(cell1)) / dcEdge(iEdge)
-               hydropotentialSlopeNormal(iEdge) = (rho_water * gravity * bedTopography(cell1) + &
-                  max(rhoo * gravity * (config_sea_level - bedTopography(cell1)), 0.0_RKIND) - &
-                  hydropotential(cell1)) / dcEdge(iEdge)
+               
+               hydropotentialBaseSlopeNormal(iEdge) = - waterPressure(cell1) / dcEdge(iEdge)
+               hydropotentialSlopeNormal(iEdge) = - (rho_water * gravity * waterThickness(cell1) + waterPressure(cell1)) / dcEdge(iEdge)
+
             else ! cell1 is the icefree cell - replace phi there with cell2 Phig
-               hydropotentialBaseSlopeNormal(iEdge) = (hydropotentialBase(cell2) - &
-                  ( rho_water * gravity * bedTopography(cell2) + &
-                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
-               hydropotentialSlopeNormal(iEdge) = (hydropotential(cell2) - &
-                  ( rho_water * gravity * bedTopography(cell2) + &
-                    max(rhoo * gravity * (config_sea_level - bedTopography(cell2)), 0.0_RKIND) ) ) / dcEdge(iEdge)
+                  
+               hydropotentialBaseSlopeNormal(iEdge) = waterPressure(cell2) / dcEdge(iEdge) 
+               hydropotentialSlopeNormal(iEdge) = (rho_water * gravity * waterThickness(cell2) + waterPressure(cell2)) / dcEdge(iEdge)
+
             endif ! which cell is icefree
          endif ! if edge of grounded ice
       end do
@@ -1630,20 +1630,23 @@ module li_subglacial_hydro
       select case (trim(config_SGH_pressure_calc))
       case ('cavity')
 
-      where (li_mask_is_grounded_ice(cellMask))        
-         waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
-                rho_water * gravity * deltatSGH / porosity + waterPressureOld
-      elsewhere
-         waterPressure = UNDEFINED ! zero waterPressure where no grounded ice 
-      end where
+         where (li_mask_is_grounded_ice(cellMask))        
+            waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
+                   rho_water * gravity * deltatSGH / porosity + waterPressureOld
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
+            waterPressure = 0.0_RKIND
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+            waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
+         end where
 
       case ('overburden')
-         where (li_mask_is_floating_ice(cellMask))
+
+         where (li_mask_is_grounded_ice(cellMask))         
             waterPressure = rhoi * gravity * iceThicknessHydro
-         elsewhere (.not. li_mask_is_ice(cellMask))
-            waterPressure = UNDEFINED
-         elsewhere
-            waterPressure = rhoi * gravity * iceThicknessHydro
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
+            waterPressure = 0.0_RKIND
+         elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography < config_sea_level))
+            waterPressure = gravity * rhoo * (config_sea_level - bedTopography)
          end where
 
       case default
@@ -1730,8 +1733,10 @@ module li_subglacial_hydro
       end where
       
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
-      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < 0.0_RKIND)) 
+      where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography < config_sea_level)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential in ocean
+      elsewhere ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography > config_sea_level))
+         hydropotentialBase = rho_water * gravity * bedTopography ! for completeness, but won't matter with one-side slope calculations on terrestrial boundaries
       end where      
 
       ! hydropotential with water thickness


### PR DESCRIPTION
Makes changes to the boundary conditions at the grounding line to improve stability in ice dynamics-hydrology coupled runs. Most problems were arising because of very weak gradients at the grounding line formed from a thinning glacier. The primary changes in this PR are: 1) zeroing out `hydropotential` and enforcing a hydrostatic `waterPressure` in the ocean, 2) instating a small outflowing condition at grounding line edges (instead of zeroing out `channelArea` and `channelDischarge` to prevent inflow). An additional change ensures no channels form when there is no water in the upstream cell (done to avoid instabilities).

This PR is a compilation of cherry-picked commits originally made on a separate mega-branch ([https://github.com/MALI-Dev/E3SM/tree/alexolinhager/chnlInstabilityDebugging]). The commits in this PR have been tested on the Thwaites coupled domain, as well as within the full integration suite. As expected, the PR passes all integration suite tests, except for the baseline comparison of the Humboldt hydro case (changes only apply to marine termini). The changes here are very minor and only affect `waterPressure` and `hydropotential` near the grounding line. A coupled run on Thwaites glacier was successfully ran on this PR for 300 years and the subglacial discharge system behaved as expected.