### PR TITLE
Average effectivePressure over hydrology subcycle

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -180,8 +180,8 @@
                 <!-- convenience variables -->
                 <var name="effectivePressureSGH" type="real" dimensions="nCells Time" units="Pa"
                         description="effective ice pressure in subglacial hydrology system" />
-                <var name="effectivePressure" type="real" dimensions"nCells Time" units="Pa" packages="higherOrderVelocity"
-                        description="effectivePressureSGH averaged over timestepping interval. This is the version of effective pressure that is passed to the coupled dynamics model."/>
+                <var name="effectivePressure" type="real" dimensions="nCells Time" units="Pa" packages="higherOrderVelocity"
+                        description="Effective pressure used in basal friction calculation.  If subglacial hydrology model is active, this will be effectivePressureSGH averaged over the subglacial hydrology model timestepping subcycles. If subglacial hydrology model is inactive, this will come from a file or a parameterization."/>
                 <var name="hydropotential" type="real" dimensions="nCells Time" units="Pa"
                      description="hydropotential in subglacial hydrology system" />
                 <var name="waterFlux" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"

--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -178,8 +178,10 @@
                 <var name="frictionAngle" type="real" dimensions="nCells Time" units="None"
                      description="subglacial till friction angle" />
                 <!-- convenience variables -->
-                <var name="effectivePressure" type="real" dimensions="nCells Time" units="Pa" packages="higherOrderVelocity"
-                     description="effective ice pressure in subglacial hydrology system" />
+                <var name="effectivePressureSGH" type="real" dimensions="nCells Time" units="Pa"
+                        description="effective ice pressure in subglacial hydrology system" />
+                <var name="effectivePressure" type="real" dimensions"nCells Time" units="Pa" packages="higherOrderVelocity"
+                        description="effectivePressureSGH averaged over timestepping interval. This is the version of effective pressure that is passed to the coupled dynamics model."/>
                 <var name="hydropotential" type="real" dimensions="nCells Time" units="Pa"
                      description="hydropotential in subglacial hydrology system" />
                 <var name="waterFlux" type="real" dimensions="nEdges Time" units="m{^2} s^{-1}"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -316,6 +316,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellX
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellY
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
+      real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), allocatable :: cellJunk
       integer, dimension(:), pointer :: nEdgesOnCell
       integer, dimension(:,:), pointer :: edgesOnCell
@@ -323,6 +325,7 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltatSGH
+      real (kind=RKIND), pointer :: deltatSGHaccumulated
       real (kind=RKIND), pointer :: masterDeltat
       real (kind=RKIND), pointer :: Cd
       real (kind=RKIND), pointer :: tillMax
@@ -383,6 +386,18 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'deltat', masterDeltat)
       timeLeft = masterDeltat  ! in seconds
       numSubCycles = 0
+
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+         effectivePressure(:) = 0.0_RKIND
+         deltatSGHaccumulated = 0.0_RKIND
+
+         block => block % next
+      end do
+
+
       ! =============
       ! =============
       ! =============
@@ -682,7 +697,19 @@ module li_subglacial_hydro
       call mpas_dmpar_field_halo_exch(domain, 'waterPressureSmooth')
       call mpas_timer_stop("halo updates")
 
+      !Average effectivePressureSGH over coupling interval for use in dynamics model 
+      block => domain % blocklist
+      do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+         call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
+         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+         call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
 
+         effectivePressure = (effectivePressure * deltatSGHaccumulated + effectivePressureSGH) / (deltatSGHaccumulated + deltatSGH)
+         deltatSGHaccumulated = deltatSGHaccumulated + deltatSGH
+         
+         block => block % next
+      end do
       ! =============
       ! =============
       ! =============
@@ -1536,7 +1563,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterPressureOld
       real (kind=RKIND), dimension(:), pointer :: waterPressureTendency
       real (kind=RKIND), dimension(:), pointer :: waterThickness
-      real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
       real (kind=RKIND), dimension(:), pointer :: zeroOrderSum
       real (kind=RKIND), dimension(:), pointer :: closingRate
       real (kind=RKIND), dimension(:), pointer :: openingRate
@@ -1595,7 +1622,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
       call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
 
-      call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+      call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(hydroPool, 'waterPressureOld', waterPressureOld)
       call mpas_pool_get_array(hydroPool, 'waterPressureTendency', waterPressureTendency)
@@ -1625,8 +1652,8 @@ module li_subglacial_hydro
       openingRate = max(0.0_RKIND, openingRate)
 
       closingRate(:) = creepCoeff * flowParamA(nVertLevels, :) * &
-              effectivePressure(:)**3 * waterThickness(:)
-!      closingRate(:) = waterThickness(:) * effectivePressure(:) / 1.0e13_RKIND
+              effectivePressureSGH(:)**3 * waterThickness(:)
+!      closingRate(:) = waterThickness(:) * effectivePressureSGH(:) / 1.0e13_RKIND
 !          ! Hewitt 2011 creep closure form.  Denominator is ice viscosity
 
       zeroOrderSum = closingRate - openingRate + (basalMeltInput + externalWaterInput) / rho_water - &
@@ -1729,7 +1756,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBase
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: hydropotential
-      real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: config_sea_level
@@ -1744,7 +1771,7 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
 
-      call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+      call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
@@ -1753,12 +1780,12 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
 
-      effectivePressure = rhoi * gravity * iceThicknessHydro - waterPressure
+      effectivePressureSGH = rhoi * gravity * iceThicknessHydro - waterPressure
          ! < this should evalute to 0 for floating ice if Pw set correctly there.
       where (.not. (li_mask_is_grounded_ice(cellMask)))
-         effectivePressure = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
+         effectivePressureSGH = 0.0_RKIND  ! zero effective pressure where no ice to avoid confusion
       end where
-      
+    
       hydropotentialBase = rho_water * gravity * bedTopography + waterPressure
       where ((.not. li_mask_is_grounded_ice(cellMask)) .and. (bedTopography <= config_sea_level)) 
          hydropotentialBase = 0.0_RKIND !zero hydropotential in ocean
@@ -1830,7 +1857,7 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: channelChangeRate
       real (kind=RKIND), dimension(:), pointer :: flowParamAChannel
       real (kind=RKIND), dimension(:), pointer :: channelEffectivePressure
-      real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
       real (kind=RKIND), dimension(:), pointer :: channelDiffusivity
       real (kind=RKIND), dimension(:), pointer :: waterThicknessEdgeUpwind
       integer, dimension(:), pointer :: waterFluxMask
@@ -1874,7 +1901,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'channelEffectivePressure', channelEffectivePressure)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
-      call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+      call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(hydroPool, 'channelDiffusivity', channelDiffusivity)
@@ -1938,7 +1965,7 @@ module li_subglacial_hydro
 
          ! Not sure if these ought to be upwind average, but using centered
          flowParamAChannel(iEdge) = 0.5_RKIND * (flowParamA(nVertLevels, cell1) + flowParamA(nVertLevels, cell2) )
-         channelEffectivePressure(iEdge) = 0.5_RKIND * (effectivePressure(cell1) + effectivePressure(cell2))
+         channelEffectivePressure(iEdge) = 0.5_RKIND * (effectivePressureSGH(cell1) + effectivePressureSGH(cell2))
       end do
       channelClosingRate(:) = creep_coeff * channelArea(:) * flowParamAChannel(:) * channelEffectivePressure(:)**3
 
@@ -2229,7 +2256,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: geometryPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: effectivePressure
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), pointer :: rhoi, rhoo
 
@@ -2243,11 +2270,11 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+         call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
          call mpas_pool_get_array(hydroPool, 'thickness', thickness)
          
-         effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
-         effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
+         effectivePressureSGH = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
+         effectivePressureSGH = max(effectivePressureSGH, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
 
          block => block % next
       end do

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -325,7 +325,6 @@ module li_subglacial_hydro
       integer, dimension(:,:), pointer :: edgeSignOnCell
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: deltatSGH
-      real (kind=RKIND), pointer :: deltatSGHaccumulated
       real (kind=RKIND), pointer :: masterDeltat
       real (kind=RKIND), pointer :: Cd
       real (kind=RKIND), pointer :: tillMax
@@ -333,6 +332,7 @@ module li_subglacial_hydro
       integer, pointer :: nCells
       integer :: iCell, iEdge, iEdgeOnCell
       real (kind=RKIND) :: timeLeft ! subcycling time remaining until master dt is reached
+      real (kind=RKIND) :: deltatSGHaccumulated
       integer :: numSubCycles ! number of subcycles
       integer :: err_tmp
 
@@ -389,9 +389,10 @@ module li_subglacial_hydro
 
       block => domain % blocklist
       do while (associated(block))
+        
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
-         effectivePressure(:) = 0.0_RKIND
+         effectivePressure = 0.0_RKIND
          deltatSGHaccumulated = 0.0_RKIND
 
          block => block % next
@@ -700,16 +701,19 @@ module li_subglacial_hydro
       !Average effectivePressureSGH over coupling interval for use in dynamics model 
       block => domain % blocklist
       do while (associated(block))
+        
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
          call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)
 
-         effectivePressure = (effectivePressure * deltatSGHaccumulated + effectivePressureSGH) / (deltatSGHaccumulated + deltatSGH)
-         deltatSGHaccumulated = deltatSGHaccumulated + deltatSGH
-         
+         effectivePressure = (effectivePressure * deltatSGHaccumulated + effectivePressureSGH * deltatSGH) / (deltatSGHaccumulated + deltatSGH)
+   
          block => block % next
       end do
+
+      deltatSGHaccumulated = deltatSGHaccumulated + deltatSGH
+      
       ! =============
       ! =============
       ! =============

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2260,7 +2260,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: hydroPool
       type (mpas_pool_type), pointer :: geometryPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
+      real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), pointer :: rhoi, rhoo
 
@@ -2274,11 +2274,11 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-         call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
+         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
          call mpas_pool_get_array(hydroPool, 'thickness', thickness)
          
-         effectivePressureSGH = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
-         effectivePressureSGH = max(effectivePressureSGH, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
+         effectivePressure = rhoi * gravity * thickness - rhoi * gravity * max(0.0_RKIND,  -1.0_RKIND * rhoo/rhoi * bedTopography)
+         effectivePressure = max(effectivePressure, 0.0_RKIND) ! This is just to zero out N in the open ocean to avoid confusion
 
          block => block % next
       end do


### PR DESCRIPTION
This PR defines a new variable, effectivePressureSGH, that is identical to the previous effectivePressure variable. effectivePressureSGH is calculated every hydrology timestep and is only used by the hydrology model. effectivePressure is now redefined as the average effectivePressureSGH throughout a dynamics coupling interval, and is only used by the dynamics model when running in a coupled configuration. The purpose of this PR is to increase stability when coupling the hydrology and dynamics models by making the dynamics model respond to the effectivePressure field throughout the hydrology subcycle, instead of an arbitrary sampling at its last timestep. This reduces the likelihood of pressure waves building resonance between the two model components.