### PR TITLE
Updates to ocean thermal forcing extrapolation to generalize ocean mask to 3d and diagnosing face melting errors with new mask

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -810,6 +810,7 @@
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
                         <var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />  <!-- CAS 8/16/2024 -->
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -915,7 +916,8 @@
 			<var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		        <!-- these variables are just for the ocean thermal forcing re-extrapolation scheme -->
-			<var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" /> <!-- CAS 8/16/2024 -->
 			<var name="validOceanMask" packages="extrapOceanData" />
 			<var name="validOceanMaskOrig" packages="extrapOceanData" />
 			<var name="availOceanMask" packages="extrapOceanData" />
@@ -1688,6 +1690,10 @@ is the value of that variable from the *previous* time level!
         <var_struct name="extrapOceanData" time_levs="1" packages="extrapOceanData">
                 <var name="origOceanMaskHoriz" type="integer" dimensions="nCells" units="none"
                      description="2D mask for original valid ocean data (e.g., ISMIP6 original TF data)"
+                />
+                <!-- CAS 8/16/2024 -->
+                <var name="orig3dOceanCavityMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
+                     description="3D mask for original valid ocean data that includes cavities (e.g., SORRM original TF data)"
                 />
                 <var name="validOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
                      description="3D mask for indicating where ocean data is present (i.e., seed mask)"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -809,7 +809,8 @@
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
-                        <var name="orig3dOceanMask" packages="extrapOceanData" />
+			<!-- this variable just for ocean extrapolation -->
+                        <var name="orig3dOceanMask" packages="extrapOceanData"/>
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -1689,25 +1690,24 @@ is the value of that variable from the *previous* time level!
                      description="3D mask of original valid ocean data.  Because it is 3d, it can include the ocean domain inside ice-shelf cavities."
                 />
                 <var name="validOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
-                     description="3D mask for indicating where ocean data is present (i.e., seed mask)"
+                     description="3D mask for indicating where ocean data is present (i.e., seed mask).  Initially this is equal to orig3dOceanMask but it grows as the ocean extrapolation scheme iterates.  It indicates anywhere that valid ocean data is present, whether that is the original ocean data or where it has been extrapolated."
                 />
                 <var name="availOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
-                     description="3D mask for indicating where ocean data can be flood-filled (i.e., grow mask)"
+                     description="3D mask for indicating where ocean data can be flood-filled (i.e., grow mask).  These are the locations into which the ocean data can possibly be expanded.  It is defined as cells below sea level connected to the open ocean and shallower than the first ocean layer below the bed.  It remains constant as the extrapolation scheme iterates."
                 />
                 <var name="seedOceanMaskHoriz" type="integer" dimensions="nCells Time" units="none"
-                     description="seedmask for horizontal floodfill"
+                     description="seedmask for horizontal floodfill used to determine the over-extrapolation region into grounded ice.  It is defined by cells below sea level that are not occupied by grounded ice.  The only purpose is for calculating availOceanMask."
                 />
                 <var name="growOceanMaskHoriz" type="integer" dimensions="nCells Time" units="none"
-                     description="growmask for horizontal floodfill"
-                />
-                <var name="seedOceanMaskHorizInit" type="integer" dimensions="nCells Time" units="none"
-                     description="initial 2D seedMask before the over-extrapolation, for benchmark/debug purpose"
+                     description="growmask for horizontal floodfill used to determine the over-extrapolaton region into grounded ice.  It is initialized as cells where bedTopography is below sea level and represents all the cells that seedOceanMaskHoriz could fill into.  The only purpose is for calculating availOceanMask."
                 />
                 <var name="TFoceanOld" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
                      default_value="1.0"
+                     description="A copy of TFocean used during iteration of the extrapolation scheme."
                 />
                 <var name="TFocean" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
                      default_value="0.0"
+                     description="The extrapolated version of ismip6shelfMelt_3dThermalForcing.  This is the result of the extrapolation scheme, but the result is assigned to ismip6shelfMelt_3dThermalForcing (replacing the initial value) so this field does not typically need to be output.  This field gets updated on each iteration of the extrapolation scheme."
                 />
         </var_struct>
 <!-- ================ -->

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -917,13 +917,6 @@
 			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		        <!-- these variables are just for the ocean thermal forcing re-extrapolation scheme -->
                         <var name="orig3dOceanMask" packages="extrapOceanData" />
-			<var name="validOceanMask" packages="extrapOceanData" />
-			<var name="availOceanMask" packages="extrapOceanData" />
-			<var name="growOceanMaskHoriz" packages="extrapOceanData" />
-			<var name="seedOceanMaskHoriz" packages="extrapOceanData" />
-			<var name="seedOceanMaskHorizInit" packages="extrapOceanData" />
-			<var name="TFoceanOld" packages="extrapOceanData" />
-			<var name="TFocean" packages="extrapOceanData" />
 		</stream>
 
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -809,8 +809,7 @@
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
-                        <var name="origOceanMaskHoriz" packages="extrapOceanData" />
-                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />  <!-- CAS 8/16/2024 -->
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -916,8 +915,7 @@
 			<var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		        <!-- these variables are just for the ocean thermal forcing re-extrapolation scheme -->
-                        <var name="origOceanMaskHoriz" packages="extrapOceanData" />
-                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" /> <!-- CAS 8/16/2024 -->
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />
 			<var name="validOceanMask" packages="extrapOceanData" />
 			<var name="validOceanMaskOrig" packages="extrapOceanData" />
 			<var name="availOceanMask" packages="extrapOceanData" />
@@ -1688,10 +1686,6 @@ is the value of that variable from the *previous* time level!
 
     <!-- Variables related to the ocean-forcing re-extrapolation -->
         <var_struct name="extrapOceanData" time_levs="1" packages="extrapOceanData">
-                <var name="origOceanMaskHoriz" type="integer" dimensions="nCells" units="none"
-                     description="2D mask for original valid ocean data (e.g., ISMIP6 original TF data)"
-                />
-                <!-- CAS 8/16/2024 -->
                 <var name="orig3dOceanCavityMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
                      description="3D mask for original valid ocean data that includes cavities (e.g., SORRM original TF data)"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -809,7 +809,7 @@
 			<!-- these variables just for ISMIP6 grounded glacier forcing -->
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
-                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />
+                        <var name="orig3dOceanMask" packages="extrapOceanData" />
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -915,9 +915,8 @@
 			<var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		        <!-- these variables are just for the ocean thermal forcing re-extrapolation scheme -->
-                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />
+                        <var name="orig3dOceanMask" packages="extrapOceanData" />
 			<var name="validOceanMask" packages="extrapOceanData" />
-			<var name="validOceanMaskOrig" packages="extrapOceanData" />
 			<var name="availOceanMask" packages="extrapOceanData" />
 			<var name="growOceanMaskHoriz" packages="extrapOceanData" />
 			<var name="seedOceanMaskHoriz" packages="extrapOceanData" />
@@ -1686,14 +1685,11 @@ is the value of that variable from the *previous* time level!
 
     <!-- Variables related to the ocean-forcing re-extrapolation -->
         <var_struct name="extrapOceanData" time_levs="1" packages="extrapOceanData">
-                <var name="orig3dOceanCavityMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
-                     description="3D mask for original valid ocean data that includes cavities (e.g., SORRM original TF data)"
+                <var name="orig3dOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
+                     description="3D mask of original valid ocean data.  Because it is 3d, it can include the ocean domain inside ice-shelf cavities."
                 />
                 <var name="validOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
                      description="3D mask for indicating where ocean data is present (i.e., seed mask)"
-                />
-                <var name="validOceanMaskOrig" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
-                     description="3D mask for indicating where original ocean data is present"
                 />
                 <var name="availOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
                      description="3D mask for indicating where ocean data can be flood-filled (i.e., grow mask)"

--- a/components/mpas-albany-landice/src/mode_forward/Makefile
+++ b/components/mpas-albany-landice/src/mode_forward/Makefile
@@ -82,7 +82,7 @@ mpas_li_velocity_external.o: Interface_velocity_solver.o
 
 mpas_li_bedtopo.o: mpas_li_advection.o
 
-mpas_li_ocean_extrap.o:
+mpas_li_ocean_extrap.o: mpas_li_calving.o
 
 Interface_velocity_solver.o:
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1386,6 +1386,7 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
+      real (kind=RKIND), pointer :: invalid_value_TF    ! CAS 8/20/2024
       integer, pointer :: nCells, nISMIP6OceanLayers
       integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
       real (kind=RKIND) :: waterDepth
@@ -1402,7 +1403,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_deltaT
       real (kind=RKIND), dimension(:), pointer :: zOcean
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
+      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell, indexToCellID ! CAS 8/22/2024
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
       real (kind=RKIND), pointer :: B ! param B
@@ -1425,6 +1426,7 @@ module li_iceshelf_melt
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
+      call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF) ! CAS 8/20/2024 
 
       ! Get melt parameters
       call mpas_pool_get_config(liConfigs, 'config_beta_ocean_thermal_forcing', betaTF)
@@ -1452,6 +1454,7 @@ module li_iceshelf_melt
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID) ! CAS 8/22/2024
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
@@ -1461,6 +1464,8 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'dtFaceMeltingCFLratio', dtFaceMeltingCFLratio)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
+            call mpas_log_write("config_use_3d_thermal_forcing_for_face_melt is .true.")
+
             call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
@@ -1477,14 +1482,30 @@ module li_iceshelf_melt
                      enddo
                      ! If bed is shallower than first layer, use TF from the first layer.
                      ! If bed is deeper than the bottomg ocean layer, use TF from the bottom layer.
-                     if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
-                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     !if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
+                     !   TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
                      ! For all other bed depths, interpolate linearly between layers above and below bed depth.
+                     !else
+                     !   TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
+                     !                      (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
+                     !                      (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
+                     !endif
+
+                     if ( kk == 1 ) then
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
                      else
-                        TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
-                                           (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
-                                           (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
                      endif
+                     
+                     ! check if any invalid TFocean value is used for calculating face melting speed
+                     if ( (TFocean(iCell) == invalid_value_TF) .or. (TFocean(iCell) > 1.0e1) ) then
+                        call mpas_log_write("grounded_face_melt_ismip6: Invalid value for TFocean. " // &
+                             "TFocean(iCell)=$r zOcean(kk)=$r bedTopography(iCell)=$r kk=$i indexToCellID=$i", MPAS_LOG_ERR, &
+                             intArgs=(/kk, indexToCellID(iCell)/), &
+                             realArgs=(/TFocean(iCell), zOcean(kk), bedTopography(iCell)/) )
+                        err = ior(err, 1)
+                     endif
+
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1386,7 +1386,6 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
-      real (kind=RKIND), pointer :: invalid_value_TF    ! CAS 8/20/2024
       integer, pointer :: nCells, nISMIP6OceanLayers
       integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
       real (kind=RKIND) :: waterDepth
@@ -1403,7 +1402,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_deltaT
       real (kind=RKIND), dimension(:), pointer :: zOcean
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell, indexToCellID ! CAS 8/22/2024
+      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
       real (kind=RKIND), pointer :: B ! param B
@@ -1426,7 +1425,6 @@ module li_iceshelf_melt
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
-      call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF) ! CAS 8/20/2024 
 
       ! Get melt parameters
       call mpas_pool_get_config(liConfigs, 'config_beta_ocean_thermal_forcing', betaTF)
@@ -1454,7 +1452,6 @@ module li_iceshelf_melt
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID) ! CAS 8/22/2024
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
@@ -1464,8 +1461,6 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'dtFaceMeltingCFLratio', dtFaceMeltingCFLratio)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
-            call mpas_log_write("config_use_3d_thermal_forcing_for_face_melt is .true.")
-
             call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
@@ -1482,30 +1477,14 @@ module li_iceshelf_melt
                      enddo
                      ! If bed is shallower than first layer, use TF from the first layer.
                      ! If bed is deeper than the bottomg ocean layer, use TF from the bottom layer.
-                     !if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
-                     !   TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
-                     ! For all other bed depths, interpolate linearly between layers above and below bed depth.
-                     !else
-                     !   TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
-                     !                      (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
-                     !                      (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
-                     !endif
-
-                     if ( kk == 1 ) then
+                     if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
                         TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     ! For all other bed depths, interpolate linearly between layers above and below bed depth.
                      else
-                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
+                        TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
+                                           (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
+                                           (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
                      endif
-                     
-                     ! check if any invalid TFocean value is used for calculating face melting speed
-                     if ( (TFocean(iCell) == invalid_value_TF) .or. (TFocean(iCell) > 1.0e1) ) then
-                        call mpas_log_write("grounded_face_melt_ismip6: Invalid value for TFocean. " // &
-                             "TFocean(iCell)=$r zOcean(kk)=$r bedTopography(iCell)=$r kk=$i indexToCellID=$i", MPAS_LOG_ERR, &
-                             intArgs=(/kk, indexToCellID(iCell)/), &
-                             realArgs=(/TFocean(iCell), zOcean(kk), bedTopography(iCell)/) )
-                        err = ior(err, 1)
-                     endif
-
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -64,6 +64,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine li_ocean_extrap_solve(domain, err)
+      use li_calving, only: li_flood_fill
 
       !-----------------------------------------------------------------
       ! input variables
@@ -89,6 +90,7 @@ contains
       real (kind=RKIND) :: layerTop
       real (kind=RKIND), dimension(:,:), pointer :: TFocean, TFoceanOld
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
+      real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:), pointer :: origOceanMaskHoriz
       integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
@@ -100,6 +102,9 @@ contains
       integer, dimension(:,:), pointer :: cellsOnCell
       integer :: iCell, jCell, iLayer, iNeighbor, iter, err_tmp
       integer :: GlobalLoopCount, newMaskCountGlobal
+      type (field1dInteger), pointer :: seedMaskField
+      type (field1dInteger), pointer :: growMaskField
+      integer, dimension(:), pointer :: connectedMarineMask, growMask !masks to pass to flood-fill routine
 
       ! No init is needed.
       err = 0
@@ -180,36 +185,79 @@ contains
          enddo
          deallocate(seedOceanMaskHorizOld)
 
+         ! Calculate mask of connected ocean
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
+         call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
+         call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
+         connectedMarineMask => seedMaskField % array
+         connectedmarineMask(:) = 0
+         call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
+         call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
+         growMask => growMaskField % array
+         growMask(:) = 0
+
+         do iCell = 1, nCells
+            ! seedMask = open ocean cells in contact with the domain boundary
+            if ((bedTopography(iCell) < config_sea_level) .and. (thickness(iCell) == 0.0_RKIND)) then
+               do iNeighbor = 1, nEdgesOnCell(iCell)
+                  if (cellsOnCell(iNeighbor, iCell) == nCells + 1) then
+                     connectedMarineMask(iCell) = 1
+                     exit  ! no need to keep checking neighbors
+                  endif
+               enddo
+            endif
+            ! growMask - all marine cells
+            if (bedTopography(iCell) < config_sea_level) then
+               growMask(iCell) = 1
+            endif
+         enddo
+         ! now create mask of all marine locations connected to open ocean - to be used below to screen out lakes
+         call li_flood_fill(connectedMarineMask, growMask, domain)
+
          ! make it a 3D mask based on the topography (loop through nISMIP6OceanLayers)
          call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
+         call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', ismip6shelfMelt_zOcean)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zBndsOcean', ismip6shelfMelt_zBndsOcean)
+         ! check for valid data
+         do iLayer = 1, nISMIP6OceanLayers
+            if (ismip6shelfMelt_zOcean(iLayer) >= 0.0_RKIND) then
+               call mpas_log_write("ismip6shelfMelt_zOcean has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zOcean(iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+            if ((ismip6shelfMelt_zBndsOcean(1,iLayer) > 0.0_RKIND) .or. &
+                    (ismip6shelfMelt_zBndsOcean(1,iLayer) < ismip6shelfMelt_zOcean(iLayer))) then
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(1,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zBndsOcean(1,iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+            if ((ismip6shelfMelt_zBndsOcean(2,iLayer) >= 0.0_RKIND) .or. &
+                    (ismip6shelfMelt_zBndsOcean(2,iLayer) > ismip6shelfMelt_zOcean(iLayer))) then
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(2,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zBndsOcean(2,iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+         enddo
          availOceanMask(:,:) = 0
          validOceanMask(:,:) = 0
          do iCell = 1, nCells
             do iLayer = 1, nISMIP6OceanLayers
                layerTop = ismip6shelfMelt_zBndsOcean(1, iLayer)
-               if ( (seedOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-                  availOceanMask(iLayer,iCell) = 1
+               if ( (seedOceanMaskHoriz(iCell) == 1) .and. (connectedMarineMask(iCell) == 1)) then
+                  if (bedTopography(iCell) < layerTop) then
+                     availOceanMask(iLayer,iCell) = 1
+                  else
+                     ! keep the first layer below the seafloor in the region to be filled
+                     ! this ensures linear interpolation from above and below the seafloor is possible
+                     availOceanMask(iLayer,iCell) = 1
+                     exit  ! stop looping over levels after we've included the first level below the seafloor
+                  endif
                endif
             enddo
          enddo
-         
+
          ! CAS 8/16/2024 Hijacking Holly's code to test using the 3D SORRM cavity TF field. We set 3d valid ocean mask to original 3d ocean cavity mask.
-         ! We don't need to loop through the layers if we're using a 3d mask already
-         validOceanMask(:,:) = orig3dOceanCavityMask(:,:) 
-
-         !      if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-         !         validOceanMask(iLayer,iCell) = 1
-         !      endif
-         !   enddo
-         !enddo
-
-         call mpas_log_write('==HH==: updating halos for the avail/valid ocean masks')
-         ! Update halos
-         call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'availOceanMask')
-         call mpas_dmpar_field_halo_exch(domain, 'validOceanMask')
-         call mpas_timer_stop("halo updates")
+         validOceanMask(:,:) = orig3dOceanCavityMask(:,:)
 
          ! save the initial validOceanMask
          validOceanMaskOrig(:,:) = validOceanMask(:,:)
@@ -217,14 +265,23 @@ contains
          ! initialize the TF field
          TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
          ! initialize the invalid data locations with fill value
-         ! CAS 8/19/2024 Changed availOceanMask in the if check to validOceanMask. We want to make sure all invalid values outside the validOceanMask are set to the invalid_value_TF
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
-               if ( validOceanMask(iLayer,iCell) == 0 ) then
+               if ((connectedMarineMask(iCell) == 0) .and. (bedTopography(iCell) < config_sea_level)) then
+                  ! Don't assign invalid value to lakes/inland seas disconnected from global ocean
+                  ! Let them retain the existing value:
+                  ! This will take on the valid ocean data value where it exists or
+                  ! zero where valid ocean data does not exist
+               elseif (validOceanMask(iLayer,iCell) == 0) then
+                  ! everywhere else where valid ocean data does not exist, insert invalid value outside of validOceanMask
                   TFocean(iLayer,iCell) = invalid_value_TF
                endif
             enddo
          enddo
+
+         ! deallocate scratch fields used for flood fill
+         call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
+         call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
 
          ! flood-fill the valid ocean mask and TF field through
          ! horizontal and vertial extrapolation

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -91,6 +91,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:), pointer :: origOceanMaskHoriz
+      integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
       integer, dimension(:,:), pointer :: validOceanMask, validOceanMaskOrig, availOceanMask !masks to pass to flood-fill routine
       integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz, seedOceanMaskHorizInit
       integer, dimension(:), allocatable :: seedOceanMaskHorizOld
@@ -127,6 +128,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
          call mpas_pool_get_array(extrapOceanDataPool, 'origOceanMaskHoriz', origOceanMaskHoriz)
+         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanCavityMask', orig3dOceanCavityMask) ! CAS 8/16/2024
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMask', validOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMaskOrig', validOceanMaskOrig)
          call mpas_pool_get_array(extrapOceanDataPool, 'availOceanMask', availOceanMask)
@@ -189,11 +191,25 @@ contains
                if ( (seedOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
                   availOceanMask(iLayer,iCell) = 1
                endif
-               if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-                  validOceanMask(iLayer,iCell) = 1
-               endif
             enddo
          enddo
+         
+         ! CAS 8/16/2024 Hijacking Holly's code to test using the 3D SORRM cavity TF field. We set 3d valid ocean mask to original 3d ocean cavity mask.
+         ! We don't need to loop through the layers if we're using a 3d mask already
+         validOceanMask(:,:) = orig3dOceanCavityMask(:,:) 
+
+         !      if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
+         !         validOceanMask(iLayer,iCell) = 1
+         !      endif
+         !   enddo
+         !enddo
+
+         call mpas_log_write('==HH==: updating halos for the avail/valid ocean masks')
+         ! Update halos
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'availOceanMask')
+         call mpas_dmpar_field_halo_exch(domain, 'validOceanMask')
+         call mpas_timer_stop("halo updates")
 
          ! save the initial validOceanMask
          validOceanMaskOrig(:,:) = validOceanMask(:,:)
@@ -201,9 +217,10 @@ contains
          ! initialize the TF field
          TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
          ! initialize the invalid data locations with fill value
+         ! CAS 8/19/2024 Changed availOceanMask in the if check to validOceanMask. We want to make sure all invalid values outside the validOceanMask are set to the invalid_value_TF
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
-               if ( availOceanMask(iLayer,iCell) == 0 ) then
+               if ( validOceanMask(iLayer,iCell) == 0 ) then
                   TFocean(iLayer,iCell) = invalid_value_TF
                endif
             enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -384,6 +384,7 @@ contains
       integer :: iCell, jCell, iLayer, iNeighbor, iter
       integer :: localLoopCount
       integer :: nValidNeighb, newValidCount, newMaskCountLocalAccum, newMaskCountGlobal
+      integer :: newMaskCountTotal
 
       err = 0
 
@@ -413,6 +414,7 @@ contains
 
       ! initialize the local loop and count for validOceanMask
       localLoopCount = 0
+      newMaskCountTotal = 0
       newMaskCountGlobal = 1
       call mpas_log_write('Weight given to the cell with valid data from extrapolation: $r', realArgs=(/weightCell/))
       do while ( newMaskCountGlobal > 0 )
@@ -474,15 +476,16 @@ contains
 
          ! update count of cells added to mask globally
          call mpas_dmpar_sum_int(domain % dminfo, newMaskCountLocalAccum, newMaskCountGlobal)
-         call mpas_log_write('Horizontal extrap: Added total $i new cells to validOceanMask', intArgs=(/newMaskCountGlobal/))
+         newMaskCountTotal = newMaskCountTotal + newMaskCountGlobal
+         !call mpas_log_write('Horizontal extrap: Added total $i new cells to validOceanMask', intArgs=(/newMaskCountGlobal/))
       enddo
-      call mpas_log_write('Horizontal extrapolation done after $i loops', intArgs=(/localLoopCount/))
+      call mpas_log_write('Horizontal extrapolation done after $i iterations.  Added total of $i cells across all processors', &
+              intArgs=(/localLoopCount, newMaskCountTotal/))
       deallocate(validOceanMaskOld)
-
-
 
    end subroutine horizontal_extrapolation
 !-----------------------------------------------------------------------
+
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -94,7 +94,7 @@ contains
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:,:), pointer :: orig3dOceanMask
       integer, dimension(:,:), pointer :: validOceanMask, availOceanMask !masks to pass to flood-fill routine
-      integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz, seedOceanMaskHorizInit
+      integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz
       integer, dimension(:), allocatable :: seedOceanMaskHorizOld
       integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers, nCellsExtra
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
@@ -136,7 +136,6 @@ contains
          call mpas_pool_get_array(extrapOceanDataPool, 'availOceanMask', availOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'seedOceanMaskHoriz', seedOceanMaskHoriz)
          call mpas_pool_get_array(extrapOceanDataPool, 'growOceanMaskHoriz', growOceanMaskHoriz)
-         call mpas_pool_get_array(extrapOceanDataPool, 'seedOceanMaskHorizInit', seedOceanMaskHorizInit)
          call mpas_pool_get_array(extrapOceanDataPool, 'TFoceanOld', TFoceanOld)
          call mpas_pool_get_array(extrapOceanDataPool, 'TFocean', TFocean)
          call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -92,8 +92,8 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
-      integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
-      integer, dimension(:,:), pointer :: validOceanMask, validOceanMaskOrig, availOceanMask !masks to pass to flood-fill routine
+      integer, dimension(:,:), pointer :: orig3dOceanMask
+      integer, dimension(:,:), pointer :: validOceanMask, availOceanMask !masks to pass to flood-fill routine
       integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz, seedOceanMaskHorizInit
       integer, dimension(:), allocatable :: seedOceanMaskHorizOld
       integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers, nCellsExtra
@@ -131,9 +131,8 @@ contains
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
-         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanCavityMask', orig3dOceanCavityMask)
+         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanMask', orig3dOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMask', validOceanMask)
-         call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMaskOrig', validOceanMaskOrig)
          call mpas_pool_get_array(extrapOceanDataPool, 'availOceanMask', availOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'seedOceanMaskHoriz', seedOceanMaskHoriz)
          call mpas_pool_get_array(extrapOceanDataPool, 'growOceanMaskHoriz', growOceanMaskHoriz)
@@ -259,11 +258,8 @@ contains
             enddo
          enddo
 
-         ! CAS 8/16/2024 Hijacking Holly's code to test using the 3D SORRM cavity TF field. We set 3d valid ocean mask to original 3d ocean cavity mask.
-         validOceanMask(:,:) = orig3dOceanCavityMask(:,:)
-
-         ! save the initial validOceanMask
-         validOceanMaskOrig(:,:) = validOceanMask(:,:)
+         ! Make a copy of original mask to use for extending the mask during extrapolation
+         validOceanMask(:,:) = orig3dOceanMask(:,:)
 
          ! initialize the TF field
          TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
@@ -303,7 +299,7 @@ contains
             endif
             ! call the horizontal extrapolation routine
             call mpas_timer_start("horizontal scheme")
-            call horizontal_extrapolation(domain, availOceanMask, validOceanMask, validOceanMaskOrig, TFocean, err_tmp)
+            call horizontal_extrapolation(domain, availOceanMask, validOceanMask, orig3dOceanMask, TFocean, err_tmp)
             err = ior(err, err_tmp)
             call mpas_timer_stop("horizontal scheme")
             ! call the vertical extrapolation routine

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -92,7 +92,6 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
-      integer, dimension(:), pointer :: origOceanMaskHoriz
       integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
       integer, dimension(:,:), pointer :: validOceanMask, validOceanMaskOrig, availOceanMask !masks to pass to flood-fill routine
       integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz, seedOceanMaskHorizInit
@@ -132,8 +131,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
-         call mpas_pool_get_array(extrapOceanDataPool, 'origOceanMaskHoriz', origOceanMaskHoriz)
-         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanCavityMask', orig3dOceanCavityMask) ! CAS 8/16/2024
+         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanCavityMask', orig3dOceanCavityMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMask', validOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMaskOrig', validOceanMaskOrig)
          call mpas_pool_get_array(extrapOceanDataPool, 'availOceanMask', availOceanMask)
@@ -190,7 +188,7 @@ contains
          call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
          call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
          connectedMarineMask => seedMaskField % array
-         connectedmarineMask(:) = 0
+         connectedMarineMask(:) = 0
          call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
          call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
          growMask => growMaskField % array
@@ -223,23 +221,28 @@ contains
             if (ismip6shelfMelt_zOcean(iLayer) >= 0.0_RKIND) then
                call mpas_log_write("ismip6shelfMelt_zOcean has invalid value of $r in layer $i", MPAS_LOG_ERR, &
                        realArgs=(/ismip6shelfMelt_zOcean(iLayer)/), intArgs=(/iLayer/))
+               call mpas_log_write("ismip6shelfMelt_zOcean must have negative values because they represent " // &
+                                   "depths below sea level.", MPAS_LOG_ERR)
                err = ior(err, 1)
             endif
             if ((ismip6shelfMelt_zBndsOcean(1,iLayer) > 0.0_RKIND) .or. &
                     (ismip6shelfMelt_zBndsOcean(1,iLayer) < ismip6shelfMelt_zOcean(iLayer))) then
                call mpas_log_write("ismip6shelfMelt_zBndsOcean(1,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
                        realArgs=(/ismip6shelfMelt_zBndsOcean(1,iLayer)/), intArgs=(/iLayer/))
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(1,:) must be less than or equal to zero " // & 
+                                   "because it represents the upper bound of an ocean layer", MPAS_LOG_ERR)
                err = ior(err, 1)
             endif
             if ((ismip6shelfMelt_zBndsOcean(2,iLayer) >= 0.0_RKIND) .or. &
                     (ismip6shelfMelt_zBndsOcean(2,iLayer) > ismip6shelfMelt_zOcean(iLayer))) then
                call mpas_log_write("ismip6shelfMelt_zBndsOcean(2,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
                        realArgs=(/ismip6shelfMelt_zBndsOcean(2,iLayer)/), intArgs=(/iLayer/))
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(2,:) must be less than zero " // & 
+                                   "because it represents the lower bound of an ocean layer", MPAS_LOG_ERR)
                err = ior(err, 1)
             endif
          enddo
          availOceanMask(:,:) = 0
-         validOceanMask(:,:) = 0
          do iCell = 1, nCells
             do iLayer = 1, nISMIP6OceanLayers
                layerTop = ismip6shelfMelt_zBndsOcean(1, iLayer)


### PR DESCRIPTION
This PR makes improvements to the ocean extrapolation module:
* The ocean extrapolation code was originally written to take in a 2d ocean mask `origOceanMaskHoriz` that is projected down through the ocean layers to create a 3d `validOceanMask`. We instead generalize the code to take in as input a 3d mask called `orig3dOceanMask` that `validOceanMask` is set to. We also update a typo that makes sure that locations outside the `validOceanMask` (and not the `availOceanMask`) are set to the `invalid_value_TF` value.
* TFocean is initialized with invalid TF values. 
* Unnecessary restart fields are removed.
* A flood fill has been added to only consider as valid regions to extrapolate into locations below sea level that are connected to the open ocean
* Checks are added on the ismip6shelfMelt_zBndsOcean field to make sure it was input.

With these changes, the ocean extrapolation module works properly with TF data interpolated from MPAS-Ocean, which differs from ISMIP6 TF data in that valid data does not exist everywhere when input.