### PR TITLE
Add temperature and salinity to ocean extrapolation

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -810,6 +810,7 @@
 			<var name="ismip6Runoff" packages="ismip6GroundedFaceMelt" />
 			<var name="ismip6_2dThermalForcing" packages="ismip6GroundedFaceMelt" />
                         <var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" />  <!-- CAS 8/16/2024 -->
 		</stream>
 
 <!-- An alternate way to allow the HO variables to exist in a separate file.
@@ -915,7 +916,8 @@
 			<var name="ismip6_2dThermalForcingCurrent" packages="ismip6GroundedFaceMelt" />
 			<var name="forcingTimeStamp" packages="ismip6GroundedFaceMelt" />
 		        <!-- these variables are just for the ocean thermal forcing re-extrapolation scheme -->
-			<var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="origOceanMaskHoriz" packages="extrapOceanData" />
+                        <var name="orig3dOceanCavityMask" packages="extrapOceanData" /> <!-- CAS 8/16/2024 -->
 			<var name="validOceanMask" packages="extrapOceanData" />
 			<var name="validOceanMaskOrig" packages="extrapOceanData" />
 			<var name="availOceanMask" packages="extrapOceanData" />
@@ -1688,6 +1690,10 @@ is the value of that variable from the *previous* time level!
         <var_struct name="extrapOceanData" time_levs="1" packages="extrapOceanData">
                 <var name="origOceanMaskHoriz" type="integer" dimensions="nCells" units="none"
                      description="2D mask for original valid ocean data (e.g., ISMIP6 original TF data)"
+                />
+                <!-- CAS 8/16/2024 -->
+                <var name="orig3dOceanCavityMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
+                     description="3D mask for original valid ocean data that includes cavities (e.g., SORRM original TF data)"
                 />
                 <var name="validOceanMask" type="integer" dimensions="nISMIP6OceanLayers nCells Time" units="none"
                      description="3D mask for indicating where ocean data is present (i.e., seed mask)"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -454,15 +454,15 @@
 			    possible_values="any non-negative value"
 		/>
 		<nml_option name="config_ocean_data_extrapolation" type="logical" default_value=".false." units="unitless"
-			    description="If true, extrapolate ocean data (temperature, salinity, thermal forcing) from external source into underneath the ice draft."
+			    description="If true, extrapolate ocean data (temperature and salinity, or thermal forcing) from external source into underneath the ice draft."
 			    possible_values=".true. or .false."
-		/>
-		<nml_option name="config_ocean_data_extrap_ncells_extra" type="integer" default_value="10" units="unitless"
+                />
+                <nml_option name="config_recalculate_thermal_forcing" type="logical" defaualt_value=".false." units="unitless"
+                            description="If true, ocean temperature and salinity are extrapolated under ice drafts and to glacier termini, where thermal forcing is then calculated according to options inconfig_thermal_forcing_param_type. If false, MALI will look for an external thermal forcing field to extrapolate instead, and the subsequent 2d thermal forcing field will be defined at the grounding line. Option is only valid if config_ocean_data_extrapolation is true."
+                            possible_values=".true. or .false."
+                />
+                <nml_option name="config_ocean_data_extrap_ncells_extra" type="integer" default_value="10" units="unitless"
 			    description="number of extra cells for over-extrapolation into grounded ice" possible_values="any non-negative value"
-		/>
-	        <nml_option name="config_invalid_value_TF" type="real" default_value="1.0e36" units="unitless"
-			    description="value assigned to indicate invalid thermal forcing value when config_ocean_data_extrapolation is set to true"
-			    possible_values="Any real value"
 		/>
 		<nml_option name="config_weight_value_cell" type="real" default_value="0.9" units="unitless"
 			    description="weight used to smooth horizontal extrapolation of ocean data field. Value close to 1 implies more weight of the current cell value versus the averaged value of the neighbouring cells around the cell"
@@ -924,8 +924,6 @@
 			<var name="growOceanMaskHoriz" packages="extrapOceanData" />
 			<var name="seedOceanMaskHoriz" packages="extrapOceanData" />
 			<var name="seedOceanMaskHorizInit" packages="extrapOceanData" />
-			<var name="TFoceanOld" packages="extrapOceanData" />
-			<var name="TFocean" packages="extrapOceanData" />
 		</stream>
 
 
@@ -1713,11 +1711,11 @@ is the value of that variable from the *previous* time level!
                 <var name="seedOceanMaskHorizInit" type="integer" dimensions="nCells Time" units="none"
                      description="initial 2D seedMask before the over-extrapolation, for benchmark/debug purpose"
                 />
-                <var name="TFoceanOld" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
-                     default_value="1.0"
+                <var name="MPAS_3dOceanTemperature" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
+                        description="MPAS-Ocean potential temperature to be extrapolated to all grounding lines if config_recalcuate_thermal_forcing is true."
                 />
-                <var name="TFocean" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="deg. C"
-                     default_value="0.0"
+                <var name="MPAS_3dOceanSalinity" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="g/kg"
+                        description="MPAS-Ocean salinity to be extrapolated to all grounding lines if config_recalcuate_thermal_forcing is true."
                 />
         </var_struct>
 <!-- ================ -->

--- a/components/mpas-albany-landice/src/mode_forward/Makefile
+++ b/components/mpas-albany-landice/src/mode_forward/Makefile
@@ -82,7 +82,7 @@ mpas_li_velocity_external.o: Interface_velocity_solver.o
 
 mpas_li_bedtopo.o: mpas_li_advection.o
 
-mpas_li_ocean_extrap.o:
+mpas_li_ocean_extrap.o: mpas_li_calving.o
 
 Interface_velocity_solver.o:
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1386,6 +1386,7 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
+      real (kind=RKIND), pointer :: invalid_value_TF    ! CAS 8/20/2024
       integer, pointer :: nCells, nISMIP6OceanLayers
       integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
       real (kind=RKIND) :: waterDepth
@@ -1402,7 +1403,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_deltaT
       real (kind=RKIND), dimension(:), pointer :: zOcean
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
+      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell, indexToCellID ! CAS 8/22/2024
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
       real (kind=RKIND), pointer :: B ! param B
@@ -1425,6 +1426,7 @@ module li_iceshelf_melt
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
+      call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF) ! CAS 8/20/2024 
 
       ! Get melt parameters
       call mpas_pool_get_config(liConfigs, 'config_beta_ocean_thermal_forcing', betaTF)
@@ -1452,6 +1454,7 @@ module li_iceshelf_melt
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
+         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID) ! CAS 8/22/2024
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
@@ -1461,6 +1464,8 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'dtFaceMeltingCFLratio', dtFaceMeltingCFLratio)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
+            call mpas_log_write("config_use_3d_thermal_forcing_for_face_melt is .true.")
+
             call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
@@ -1477,14 +1482,30 @@ module li_iceshelf_melt
                      enddo
                      ! If bed is shallower than first layer, use TF from the first layer.
                      ! If bed is deeper than the bottomg ocean layer, use TF from the bottom layer.
-                     if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
-                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     !if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
+                     !   TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
                      ! For all other bed depths, interpolate linearly between layers above and below bed depth.
+                     !else
+                     !   TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
+                     !                      (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
+                     !                      (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
+                     !endif
+
+                     if ( kk == 1 ) then
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
                      else
-                        TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
-                                           (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
-                                           (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
+                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
                      endif
+                     
+                     ! check if any invalid TFocean value is used for calculating face melting speed
+                     if ( (TFocean(iCell) == invalid_value_TF) .or. (TFocean(iCell) > 1.0e1) ) then
+                        call mpas_log_write("grounded_face_melt_ismip6: Invalid value for TFocean. " // &
+                             "TFocean(iCell)=$r zOcean(kk)=$r bedTopography(iCell)=$r kk=$i indexToCellID=$i", MPAS_LOG_ERR, &
+                             intArgs=(/kk, indexToCellID(iCell)/), &
+                             realArgs=(/TFocean(iCell), zOcean(kk), bedTopography(iCell)/) )
+                        err = ior(err, 1)
+                     endif
+
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1386,7 +1386,6 @@ module li_iceshelf_melt
       !-----------------------------------------------------------------
       integer :: iCell, iNeighbor, iEdge, nEmptyNeighbors
       real (kind=RKIND), pointer :: rhoi
-      real (kind=RKIND), pointer :: invalid_value_TF    ! CAS 8/20/2024
       integer, pointer :: nCells, nISMIP6OceanLayers
       integer, dimension(:,:), pointer :: cellsOnCell, edgesOnCell
       real (kind=RKIND) :: waterDepth
@@ -1403,7 +1402,7 @@ module li_iceshelf_melt
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_deltaT
       real (kind=RKIND), dimension(:), pointer :: zOcean
       real (kind=RKIND), dimension(:), pointer :: areaCell
-      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell, indexToCellID ! CAS 8/22/2024
+      integer, dimension(:), pointer :: cellMask, edgeMask, nEdgesOnCell
       real (kind=RKIND), pointer :: aSubglacial ! param A
       real (kind=RKIND), pointer :: alphaSubglacial ! param alpha
       real (kind=RKIND), pointer :: B ! param B
@@ -1426,7 +1425,6 @@ module li_iceshelf_melt
       ! Get sea level, bedTopography, ice density
       call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', seaLevel)
-      call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF) ! CAS 8/20/2024 
 
       ! Get melt parameters
       call mpas_pool_get_config(liConfigs, 'config_beta_ocean_thermal_forcing', betaTF)
@@ -1454,7 +1452,6 @@ module li_iceshelf_melt
          call mpas_pool_get_array(meshPool, 'nEdgesOnCell', nEdgesOnCell)
          call mpas_pool_get_array(meshPool, 'cellsOnCell', cellsOnCell)
          call mpas_pool_get_array(meshPool, 'edgesOnCell', edgesOnCell)
-         call mpas_pool_get_array(meshPool, 'indexToCellID', indexToCellID) ! CAS 8/22/2024
          call mpas_pool_get_array(geometryPool, 'thickness', thickness)
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'faceMeltingThickness', faceMeltingThickness)
@@ -1464,8 +1461,6 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'dtFaceMeltingCFLratio', dtFaceMeltingCFLratio)
 
          if ( config_use_3d_thermal_forcing_for_face_melt ) then
-            call mpas_log_write("config_use_3d_thermal_forcing_for_face_melt is .true.")
-
             call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
@@ -1482,30 +1477,14 @@ module li_iceshelf_melt
                      enddo
                      ! If bed is shallower than first layer, use TF from the first layer.
                      ! If bed is deeper than the bottomg ocean layer, use TF from the bottom layer.
-                     !if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
-                     !   TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
-                     ! For all other bed depths, interpolate linearly between layers above and below bed depth.
-                     !else
-                     !   TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
-                     !                      (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
-                     !                      (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
-                     !endif
-
-                     if ( kk == 1 ) then
+                     if ( (kk == 1) .or. ( (kk == nISMIP6OceanLayers) .and. (zOcean(kk) >= bedTopography(iCell)) ) ) then
                         TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk, iCell) + ismip6shelfMelt_deltaT(iCell)
+                     ! For all other bed depths, interpolate linearly between layers above and below bed depth.
                      else
-                        TFocean(iCell) = ismip6shelfMelt_3dThermalForcing(kk-1, iCell) + ismip6shelfMelt_deltaT(iCell)
+                        TFocean(iCell) = ( (zOcean(kk-1) - bedTopography(iCell)) * ismip6shelfMelt_3dThermalForcing(kk, iCell) + &
+                                           (bedTopography(iCell) - zOcean(kk)) * ismip6shelfMelt_3dThermalForcing(kk-1, iCell) ) / &
+                                           (zOcean(kk-1) - zOcean(kk)) + ismip6shelfMelt_deltaT(iCell)
                      endif
-                     
-                     ! check if any invalid TFocean value is used for calculating face melting speed
-                     if ( (TFocean(iCell) == invalid_value_TF) .or. (TFocean(iCell) > 1.0e1) ) then
-                        call mpas_log_write("grounded_face_melt_ismip6: Invalid value for TFocean. " // &
-                             "TFocean(iCell)=$r zOcean(kk)=$r bedTopography(iCell)=$r kk=$i indexToCellID=$i", MPAS_LOG_ERR, &
-                             intArgs=(/kk, indexToCellID(iCell)/), &
-                             realArgs=(/TFocean(iCell), zOcean(kk), bedTopography(iCell)/) )
-                        err = ior(err, 1)
-                     endif
-
                endif
             end do
          endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -64,6 +64,7 @@ contains
 !-----------------------------------------------------------------------
 
    subroutine li_ocean_extrap_solve(domain, err)
+      use li_calving, only: li_flood_fill
 
       !-----------------------------------------------------------------
       ! input variables
@@ -89,6 +90,7 @@ contains
       real (kind=RKIND) :: layerTop
       real (kind=RKIND), dimension(:,:), pointer :: TFocean, TFoceanOld
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
+      real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:), pointer :: origOceanMaskHoriz
       integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
@@ -100,6 +102,9 @@ contains
       integer, dimension(:,:), pointer :: cellsOnCell
       integer :: iCell, jCell, iLayer, iNeighbor, iter, err_tmp
       integer :: GlobalLoopCount, newMaskCountGlobal
+      type (field1dInteger), pointer :: seedMaskField
+      type (field1dInteger), pointer :: growMaskField
+      integer, dimension(:), pointer :: connectedMarineMask, growMask !masks to pass to flood-fill routine
 
       ! No init is needed.
       err = 0
@@ -180,36 +185,79 @@ contains
          enddo
          deallocate(seedOceanMaskHorizOld)
 
+         ! Calculate mask of connected ocean
+         call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
+         call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
+         call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
+         connectedMarineMask => seedMaskField % array
+         connectedmarineMask(:) = 0
+         call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
+         call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
+         growMask => growMaskField % array
+         growMask(:) = 0
+
+         do iCell = 1, nCells
+            ! seedMask = open ocean cells in contact with the domain boundary
+            if ((bedTopography(iCell) < config_sea_level) .and. (thickness(iCell) == 0.0_RKIND)) then
+               do iNeighbor = 1, nEdgesOnCell(iCell)
+                  if (cellsOnCell(iNeighbor, iCell) == nCells + 1) then
+                     connectedMarineMask(iCell) = 1
+                     exit  ! no need to keep checking neighbors
+                  endif
+               enddo
+            endif
+            ! growMask - all marine cells
+            if (bedTopography(iCell) < config_sea_level) then
+               growMask(iCell) = 1
+            endif
+         enddo
+         ! now create mask of all marine locations connected to open ocean - to be used below to screen out lakes
+         call li_flood_fill(connectedMarineMask, growMask, domain)
+
          ! make it a 3D mask based on the topography (loop through nISMIP6OceanLayers)
          call mpas_pool_get_dimension(meshPool, 'nISMIP6OceanLayers', nISMIP6OceanLayers)
+         call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', ismip6shelfMelt_zOcean)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zBndsOcean', ismip6shelfMelt_zBndsOcean)
+         ! check for valid data
+         do iLayer = 1, nISMIP6OceanLayers
+            if (ismip6shelfMelt_zOcean(iLayer) >= 0.0_RKIND) then
+               call mpas_log_write("ismip6shelfMelt_zOcean has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zOcean(iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+            if ((ismip6shelfMelt_zBndsOcean(1,iLayer) > 0.0_RKIND) .or. &
+                    (ismip6shelfMelt_zBndsOcean(1,iLayer) < ismip6shelfMelt_zOcean(iLayer))) then
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(1,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zBndsOcean(1,iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+            if ((ismip6shelfMelt_zBndsOcean(2,iLayer) >= 0.0_RKIND) .or. &
+                    (ismip6shelfMelt_zBndsOcean(2,iLayer) > ismip6shelfMelt_zOcean(iLayer))) then
+               call mpas_log_write("ismip6shelfMelt_zBndsOcean(2,:) has invalid value of $r in layer $i", MPAS_LOG_ERR, &
+                       realArgs=(/ismip6shelfMelt_zBndsOcean(2,iLayer)/), intArgs=(/iLayer/))
+               err = ior(err, 1)
+            endif
+         enddo
          availOceanMask(:,:) = 0
          validOceanMask(:,:) = 0
          do iCell = 1, nCells
             do iLayer = 1, nISMIP6OceanLayers
                layerTop = ismip6shelfMelt_zBndsOcean(1, iLayer)
-               if ( (seedOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-                  availOceanMask(iLayer,iCell) = 1
+               if ( (seedOceanMaskHoriz(iCell) == 1) .and. (connectedMarineMask(iCell) == 1)) then
+                  if (bedTopography(iCell) < layerTop) then
+                     availOceanMask(iLayer,iCell) = 1
+                  else
+                     ! keep the first layer below the seafloor in the region to be filled
+                     ! this ensures linear interpolation from above and below the seafloor is possible
+                     availOceanMask(iLayer,iCell) = 1
+                     exit  ! stop looping over levels after we've included the first level below the seafloor
+                  endif
                endif
             enddo
          enddo
-         
+
          ! CAS 8/16/2024 Hijacking Holly's code to test using the 3D SORRM cavity TF field. We set 3d valid ocean mask to original 3d ocean cavity mask.
-         ! We don't need to loop through the layers if we're using a 3d mask already
-         validOceanMask(:,:) = orig3dOceanCavityMask(:,:) 
-
-         !      if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-         !         validOceanMask(iLayer,iCell) = 1
-         !      endif
-         !   enddo
-         !enddo
-
-         call mpas_log_write('==HH==: updating halos for the avail/valid ocean masks')
-         ! Update halos
-         call mpas_timer_start("halo updates")
-         call mpas_dmpar_field_halo_exch(domain, 'availOceanMask')
-         call mpas_dmpar_field_halo_exch(domain, 'validOceanMask')
-         call mpas_timer_stop("halo updates")
+         validOceanMask(:,:) = orig3dOceanCavityMask(:,:)
 
          ! save the initial validOceanMask
          validOceanMaskOrig(:,:) = validOceanMask(:,:)
@@ -217,14 +265,23 @@ contains
          ! initialize the TF field
          TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
          ! initialize the invalid data locations with fill value
-         ! CAS 8/19/2024 Changed availOceanMask in the if check to validOceanMask. We want to make sure all invalid values outside the validOceanMask are set to the invalid_value_TF
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
-               if ( validOceanMask(iLayer,iCell) == 0 ) then
+               if ((connectedMarineMask(iCell) == 0) .and. (bedTopography(iCell) < config_sea_level)) then
+                  ! Don't assign invalid value to lakes/inland seas disconnected from global ocean
+                  ! Let them retain the existing value:
+                  ! This will take on the valid ocean data value where it exists or
+                  ! zero where valid ocean data does not exist
+               elseif (validOceanMask(iLayer,iCell) == 0) then
+                  ! everywhere else where valid ocean data does not exist, insert invalid value outside of validOceanMask
                   TFocean(iLayer,iCell) = invalid_value_TF
                endif
             enddo
          enddo
+
+         ! deallocate scratch fields used for flood fill
+         call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
+         call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
 
          ! flood-fill the valid ocean mask and TF field through
          ! horizontal and vertial extrapolation

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -91,6 +91,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
       integer, dimension(:), pointer :: origOceanMaskHoriz
+      integer, dimension(:,:), pointer :: orig3dOceanCavityMask         ! CAS 8/16/2024
       integer, dimension(:,:), pointer :: validOceanMask, validOceanMaskOrig, availOceanMask !masks to pass to flood-fill routine
       integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz, seedOceanMaskHorizInit
       integer, dimension(:), allocatable :: seedOceanMaskHorizOld
@@ -127,6 +128,7 @@ contains
          call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_3dThermalForcing', ismip6shelfMelt_3dThermalForcing)
          call mpas_pool_get_array(extrapOceanDataPool, 'origOceanMaskHoriz', origOceanMaskHoriz)
+         call mpas_pool_get_array(extrapOceanDataPool, 'orig3dOceanCavityMask', orig3dOceanCavityMask) ! CAS 8/16/2024
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMask', validOceanMask)
          call mpas_pool_get_array(extrapOceanDataPool, 'validOceanMaskOrig', validOceanMaskOrig)
          call mpas_pool_get_array(extrapOceanDataPool, 'availOceanMask', availOceanMask)
@@ -189,11 +191,25 @@ contains
                if ( (seedOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
                   availOceanMask(iLayer,iCell) = 1
                endif
-               if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
-                  validOceanMask(iLayer,iCell) = 1
-               endif
             enddo
          enddo
+         
+         ! CAS 8/16/2024 Hijacking Holly's code to test using the 3D SORRM cavity TF field. We set 3d valid ocean mask to original 3d ocean cavity mask.
+         ! We don't need to loop through the layers if we're using a 3d mask already
+         validOceanMask(:,:) = orig3dOceanCavityMask(:,:) 
+
+         !      if ( (origOceanMaskHoriz(iCell) == 1) .and. (bedTopography(iCell) <  layerTop) ) then
+         !         validOceanMask(iLayer,iCell) = 1
+         !      endif
+         !   enddo
+         !enddo
+
+         call mpas_log_write('==HH==: updating halos for the avail/valid ocean masks')
+         ! Update halos
+         call mpas_timer_start("halo updates")
+         call mpas_dmpar_field_halo_exch(domain, 'availOceanMask')
+         call mpas_dmpar_field_halo_exch(domain, 'validOceanMask')
+         call mpas_timer_stop("halo updates")
 
          ! save the initial validOceanMask
          validOceanMaskOrig(:,:) = validOceanMask(:,:)
@@ -201,9 +217,10 @@ contains
          ! initialize the TF field
          TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
          ! initialize the invalid data locations with fill value
+         ! CAS 8/19/2024 Changed availOceanMask in the if check to validOceanMask. We want to make sure all invalid values outside the validOceanMask are set to the invalid_value_TF
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
-               if ( availOceanMask(iLayer,iCell) == 0 ) then
+               if ( validOceanMask(iLayer,iCell) == 0 ) then
                   TFocean(iLayer,iCell) = invalid_value_TF
                endif
             enddo

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -384,6 +384,7 @@ contains
       integer :: iCell, jCell, iLayer, iNeighbor, iter
       integer :: localLoopCount
       integer :: nValidNeighb, newValidCount, newMaskCountLocalAccum, newMaskCountGlobal
+      integer :: newMaskCountTotal
 
       err = 0
 
@@ -413,6 +414,7 @@ contains
 
       ! initialize the local loop and count for validOceanMask
       localLoopCount = 0
+      newMaskCountTotal = 0
       newMaskCountGlobal = 1
       call mpas_log_write('Weight given to the cell with valid data from extrapolation: $r', realArgs=(/weightCell/))
       do while ( newMaskCountGlobal > 0 )
@@ -474,15 +476,16 @@ contains
 
          ! update count of cells added to mask globally
          call mpas_dmpar_sum_int(domain % dminfo, newMaskCountLocalAccum, newMaskCountGlobal)
-         call mpas_log_write('Horizontal extrap: Added total $i new cells to validOceanMask', intArgs=(/newMaskCountGlobal/))
+         newMaskCountTotal = newMaskCountTotal + newMaskCountGlobal
+         !call mpas_log_write('Horizontal extrap: Added total $i new cells to validOceanMask', intArgs=(/newMaskCountGlobal/))
       enddo
-      call mpas_log_write('Horizontal extrapolation done after $i loops', intArgs=(/localLoopCount/))
+      call mpas_log_write('Horizontal extrapolation done after $i iterations.  Added total of $i cells across all processors', &
+              intArgs=(/localLoopCount, newMaskCountTotal/))
       deallocate(validOceanMaskOld)
-
-
 
    end subroutine horizontal_extrapolation
 !-----------------------------------------------------------------------
+
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -11,11 +11,11 @@
 !  li_ocean_extrap
 !
 !> \MPAS land-ice ocean-data extrapolation driver
-!> \author Holly Han
-!> \date   January 2022
+!> \author Holly Han, modified by Alex Hager
+!> \date   January 2022 (modified September 2024)
 !> \details
 !>  This module contains the routines for extrapolating
-!>  ocean data (e.g., temperature, salinity, thermal forcing)
+!>  ocean data (e.g., temperature and salinity, or thermal forcing)
 !>  into ice draft
 !
 !-----------------------------------------------------------------------
@@ -45,6 +45,8 @@ module li_ocean_extrap
    !--------------------------------------------------------------------
    ! Private module variables
    !--------------------------------------------------------------------
+   
+   real (kind=RKIND), parameter :: invalid_value = 1.0e36_RKIND
 
 !***********************************************************************
 
@@ -84,11 +86,10 @@ contains
       ! local variables
       !-----------------------------------------------------------------
       logical, pointer :: config_ocean_data_extrapolation
-      real(kind=RKIND), pointer :: config_sea_level, invalid_value_TF
+      real(kind=RKIND), pointer :: config_sea_level
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: scratchPool, geometryPool, meshPool, extrapOceanDataPool
       real (kind=RKIND) :: layerTop
-      real (kind=RKIND), dimension(:,:), pointer :: TFocean, TFoceanOld
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing, ismip6shelfMelt_zBndsOcean
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography
@@ -105,6 +106,7 @@ contains
       type (field1dInteger), pointer :: seedMaskField
       type (field1dInteger), pointer :: growMaskField
       integer, dimension(:), pointer :: connectedMarineMask, growMask !masks to pass to flood-fill routine
+      real (kind=RKIND), dimension(:,:,:), allocatable :: oceanField
 
       ! No init is needed.
       err = 0
@@ -120,6 +122,7 @@ contains
         ! initialize the ocean data and mask fields
          call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
          call mpas_pool_get_config(liConfigs, 'config_ocean_data_extrap_ncells_extra', nCellsExtra)
+         call mpas_pool_get_config(liConfigs, 'config_recalculate_thermal_forcing', config_recalcuate_thermal_forcing)
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'extrapOceanData', extrapOceanDataPool)
@@ -140,9 +143,8 @@ contains
          call mpas_pool_get_array(extrapOceanDataPool, 'seedOceanMaskHoriz', seedOceanMaskHoriz)
          call mpas_pool_get_array(extrapOceanDataPool, 'growOceanMaskHoriz', growOceanMaskHoriz)
          call mpas_pool_get_array(extrapOceanDataPool, 'seedOceanMaskHorizInit', seedOceanMaskHorizInit)
-         call mpas_pool_get_array(extrapOceanDataPool, 'TFoceanOld', TFoceanOld)
-         call mpas_pool_get_array(extrapOceanDataPool, 'TFocean', TFocean)
-         call mpas_pool_get_config(liConfigs, 'config_invalid_value_TF', invalid_value_TF)
+         
+         allocate(oceanField(nISMIP6OceanLayers,nCells+1,2))
 
          ! create a 2D mask based on the open ocean + floating ice + grounded ice mask to be used for defining the location of the n-extra cells into the grounded ice
          allocate(seedOceanMaskHorizOld(nCells+1))
@@ -165,7 +167,7 @@ contains
          do iter = 1, nCellsExtra
             do iCell = 1, nCellsSolve
                if ( growOceanMaskHoriz(iCell) == 1 .and. seedOceanMaskHorizOld(iCell) == 0 ) then
-                  do iNeighbor = 1, nEdgesOnCell(iCell)
+                  do iNeighbor /TFoce= 1, nEdgesOnCell(iCell)
                      jCell = cellsOnCell(iNeighbor, iCell)
                      if ( seedOceanMaskHorizOld(jCell) == 1 ) then
                         seedOceanMaskHoriz(iCell) = 1
@@ -262,8 +264,22 @@ contains
          ! save the initial validOceanMask
          validOceanMaskOrig(:,:) = validOceanMask(:,:)
 
-         ! initialize the TF field
-         TFocean(:,:) = ismip6shelfMelt_3dThermalForcing(:,:) * validOceanMask(:,:)
+         ! initialize the extrapolated fields
+         if (config_recalculate_thermal_forcing) then
+            
+            real (kind=RKIND), dimension(:,:), pointer :: MPAS_3dOceanTemperature, MPAS_3dOceanSalinity
+            call mpas_pool_get_array(extrapOceanDataPool, 'MPAS_3dOceanTemperature', oceanTemp)
+            call mpas_pool_get_array(extrapOceanDataPool, 'MPAS_3dOceanSalinity', oceanSalt)
+
+            !combine fields into one variable to expedite extrapolation
+            oceanField(:,:,1) = MPAS_3dOceanTemperature(:,:) * validOceanMask(:,:)
+            oceanField(:,:,2) = MPAS_3dOceanSalinity(:,:) * validOceanMask(:,:)
+         else
+
+            oceanField(:,:,1) = ismip6shelfMelt_3dThermalForcing * validOceanMask(:,:)i
+            oceanField(:,:,2) = invalid_value
+         endif
+         
          ! initialize the invalid data locations with fill value
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
@@ -274,7 +290,7 @@ contains
                   ! zero where valid ocean data does not exist
                elseif (validOceanMask(iLayer,iCell) == 0) then
                   ! everywhere else where valid ocean data does not exist, insert invalid value outside of validOceanMask
-                  TFocean(iLayer,iCell) = invalid_value_TF
+                  oceanField(iLayer,iCell,:) = invalid_value
                endif
             enddo
          enddo
@@ -300,23 +316,31 @@ contains
             endif
             ! call the horizontal extrapolation routine
             call mpas_timer_start("horizontal scheme")
-            call horizontal_extrapolation(domain, availOceanMask, validOceanMask, validOceanMaskOrig, TFocean, err_tmp)
+            call horizontal_extrapolation(domain, availOceanMask, validOceanMask, validOceanMaskOrig, oceanField, err_tmp)
             err = ior(err, err_tmp)
             call mpas_timer_stop("horizontal scheme")
             ! call the vertical extrapolation routine
             call mpas_timer_start("vertical scheme")
-            call vertical_extrapolation(domain, availOceanMask, validOceanMask, newMaskCountGlobal, TFocean, err_tmp)
+            call vertical_extrapolation(domain, availOceanMask, validOceanMask, newMaskCountGlobal, oceanField, err_tmp)
             err = ior(err, err_tmp)
             call mpas_timer_stop("vertical scheme")
 
             if (err > 0) then
-               call mpas_log_write("Ocean extraolation main iteration loop has encountered an error", MPAS_LOG_ERR)
+               call mpas_log_write("Ocean extrapolation main iteration loop has encountered an error", MPAS_LOG_ERR)
                return
             endif
          enddo
 
          ! Reassign extrapolated TF back to primary TF field
-         ismip6shelfMelt_3dThermalForcing(:,:) = TFocean(:,:)
+         if (config_recalculate_thermal_forcing) then
+            MPAS_3dOceanTemperature(:,:) = oceanField(:,:,1)
+            MPAS_3dOceanSalinity(:,:) = oceanField(:,:,2)
+         else 
+            ismip6shelfMelt_3dThermalForcing(:,:) = oceanField(:,:,1)
+         endif
+
+         deallocate(oceanField)
+
       endif
    !--------------------------------------------------------------------
 
@@ -337,8 +361,8 @@ contains
 !  !  routine horizontal_extrapolation
 !
 !> \brief Extrapolate validOceanMask horizontally
-!> \author Holly Kyeore Han
-!> \date   November 2023
+!> \author Holly Kyeore Han, modified by Alex Hager
+!> \date   November 2023 (modified September 2024)
 !> \details
 !> This routine extrapolates takes the initialized availOceanMask
 !> and validOceanMask and extrapolates validOceanMask in horizontal
@@ -348,7 +372,7 @@ contains
 
 !-----------------------------------------------------------------------
 
-   subroutine horizontal_extrapolation(domain, availOceanMask, validOceanMask, validOceanMaskOrig, TFocean, err)
+   subroutine horizontal_extrapolation(domain, availOceanMask, validOceanMask, validOceanMaskOrig, oceanField, err)
 
       !-----------------------------------------------------------------
       ! input variables
@@ -361,7 +385,7 @@ contains
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
       integer, dimension(:,:), pointer, intent(inout) :: validOceanMask
       integer, intent(inout) :: err !< Output: error flag
-      real (kind=RKIND), dimension(:,:), pointer, intent(inout) :: TFocean
+      real (kind=RKIND), dimension(:,:), pointer, intent(inout) :: oceanField
 
       !-----------------------------------------------------------------
       ! output variables
@@ -372,19 +396,21 @@ contains
       !-----------------------------------------------------------------
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: scratchPool, geometryPool, meshPool, extrapOceanDataPool
-      real (kind=RKIND) :: layerTop, TFsum, areaSum, weightCellLocal
+      real (kind=RKIND) :: layerTop, fieldSum, areaSum, weightCellLocal
       real (kind=RKIND), pointer :: weightCell
       integer, dimension(:,:), allocatable :: validOceanMaskOld
       real (kind=RKIND), dimension(:,:), pointer :: ismip6shelfMelt_3dThermalForcing
-      real (kind=RKIND), dimension(:,:), pointer :: TFoceanOld
+      real (kind=RKIND), dimension(:,:,:), pointer :: oceanFieldOld
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, areaCell
       integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers, nCellsExtra
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnCell
-      integer :: iCell, jCell, iLayer, iNeighbor, iter
+      integer :: iCell, jCell, iLayer, iNeighbor, iter, iField
       integer :: localLoopCount
       integer :: nValidNeighb, newValidCount, newMaskCountLocalAccum, newMaskCountGlobal
       integer :: newMaskCountTotal
+      logical, pointer :: config_recalculate_thermal_forcing
+      real (kind=RKIND), dimension(:,:,:), allocatable :: oceanFieldOld
 
       err = 0
 
@@ -392,6 +418,7 @@ contains
       block => domain % blocklist
       call mpas_pool_get_config(liConfigs, 'config_ocean_data_extrap_ncells_extra', nCellsExtra)
       call mpas_pool_get_config(liConfigs,'config_weight_value_cell', weightCell)
+      call mpas_pool_get_config(liConfigs, 'config_recalculate_thermal_forcing', config_recalculate_thermal_forcing)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'extrapOceanData', extrapOceanDataPool)
@@ -404,13 +431,13 @@ contains
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      call mpas_pool_get_array(extrapOceanDataPool, 'TFoceanOld', TFoceanOld)
 
       !TFoceanOld(:,:) = 1.0 ! for debugging, set TF to ones to make it easy to verify the horizonal/vertical averaging
       ! perform horizontal extrapolation until the validOceanMask is unchanged
       allocate(validOceanMaskOld(nISMIP6OceanLayers,nCells+1))
+      allocate(oceanFieldOld(nISMIP6OceanLayers,nCells+1,2))
       validOceanMaskOld(:,:) = validOceanMask(:,:)
-      TFoceanOld(:,:) = TFocean(:,:)
+      oceanFieldOld(:,:,:) = oceanField(:,:,:)
 
       ! initialize the local loop and count for validOceanMask
       localLoopCount = 0
@@ -422,46 +449,52 @@ contains
          newMaskCountLocalAccum = 0
          do iCell = 1, nCellsSolve
             do iLayer = 1, nISMIP6OceanLayers
-               if ( (availOceanMask(iLayer,iCell) == 1) .and. (validOceanMaskOrig(iLayer,iCell) == 0) ) then
-                  TFsum = 0.0
-                  areaSum = 0.0
-                  newValidCount = 0
-                  nValidNeighb = 0
-                  do iNeighbor = 1, nEdgesOnCell(iCell)
-                     jCell = cellsOnCell(iNeighbor, iCell)
-                     if ( validOceanMaskOld(iLayer,jCell) == 1 ) then
-                        if ( TFoceanOld(iLayer,jCell) > 1.0e6_RKIND) then
-                           ! raise error if an invalid ocean data value is used
-                           call mpas_log_write("ocean data value used for extrapolation is invalid", &
-                                MPAS_LOG_ERR)
-                           err = ior(err,1)
-                        else
-                           TFsum = TFsum + (TFoceanOld(iLayer,jCell) * areaCell(jCell))
+               do iField = 1, 2  
+                  if ( (availOceanMask(iLayer,iCell) == 1) .and. (validOceanMaskOrig(iLayer,iCell) == 0) ) then
+                     fieldSum = 0.0
+                     areaSum = 0.0
+                     newValidCount = 0
+                     nValidNeighb = 0
+                     do iNeighbor = 1, nEdgesOnCell(iCell)
+                        jCell = cellsOnCell(iNeighbor, iCell)
+                        if ( validOceanMaskOld(iLayer,jCell) == 1 ) then
+                           if ( oceanFieldOld(iLayer,jCell,iField) > 1.0e6_RKIND) then
+                              ! raise error if an invalid ocean data value is used
+                              call mpas_log_write("ocean data value used for extrapolation is invalid", &
+                                   MPAS_LOG_ERR)
+                              err = ior(err,1)
+                            else
+                              fieldSum = fieldSum + (oceanFieldOld(iLayer,jCell,iField) * areaCell(jCell))
+                            endif
+                            areaSum = areaSum + areaCell(jCell)
+                            nValidNeighb = nValidNeighb + 1
                         endif
-                        areaSum = areaSum + areaCell(jCell)
-                        nValidNeighb = nValidNeighb + 1
+                     enddo
+                     if ( validOceanMaskOld(iLayer,iCell) == 0 .and. nValidNeighb > 0 ) then
+                        ! if current cell is not valid, set its weight to zero
+                        weightCellLocal = 0.0_RKIND
+                        validOceanMask(iLayer,iCell) = 1
+                        newValidCount = 1
+                     else
+                        weightCellLocal = weightCell
                      endif
-                  enddo
-                  if ( validOceanMaskOld(iLayer,iCell) == 0 .and. nValidNeighb > 0 ) then
-                     ! if current cell is not valid, set its weight to zero
-                     weightCellLocal = 0.0_RKIND
-                     validOceanMask(iLayer,iCell) = 1
-                     newValidCount = 1
-                  else
-                     weightCellLocal = weightCell
+                     ! perform area-weighted averaging of ocean fields
+                     if ( nValidNeighb == 0 ) then
+                        oceanField(iLayer,iCell,iField) = oceanFieldOld(iLayer,iCell,iField)
+                     else
+                        oceanField(iLayer,iCell,iField) = ( weightCellLocal * oceanFieldOld(iLayer,iCell,iField) * areaCell(iCell) + &
+                                                 & ((1.0_RKIND - weightCellLocal) * (fieldSum / nValidNeighb)) ) / &
+                                                 & ( weightCellLocal * areaCell(iCell) + &
+                                                 & (1.0_RKIND - weightCellLocal) * (areaSum / nValidNeighb) )
+                     endif
+                     ! Accumulate cells added locally until we do the next global reduce
+                     newMaskCountLocalAccum = newMaskCountLocalAccum + newValidCount
                   endif
-                  ! perform area-weighted averaging of the thermal forcing field
-                  if ( nValidNeighb == 0 ) then
-                     TFocean(iLayer,iCell) = TFoceanOld(iLayer,iCell)
-                  else
-                     TFocean(iLayer,iCell) = ( weightCellLocal * TFoceanOld(iLayer,iCell) * areaCell(iCell) + &
-                                              & ((1.0_RKIND - weightCellLocal) * (TFsum / nValidNeighb)) ) / &
-                                              & ( weightCellLocal * areaCell(iCell) + &
-                                              & (1.0_RKIND - weightCellLocal) * (areaSum / nValidNeighb) )
+                  if (.not. config_recalculate_thermal_forcing) then
+                     ! Don't repeat loop if only extrapolating thermal forcing
+                     exit 
                   endif
-                  ! Accumulate cells added locally until we do the next global reduce
-                  newMaskCountLocalAccum = newMaskCountLocalAccum + newValidCount
-               endif
+               enddo
             enddo
          enddo
 
@@ -482,6 +515,7 @@ contains
       call mpas_log_write('Horizontal extrapolation done after $i iterations.  Added total of $i cells across all processors', &
               intArgs=(/localLoopCount, newMaskCountTotal/))
       deallocate(validOceanMaskOld)
+      deallocate(oceanFieldOld)
 
    end subroutine horizontal_extrapolation
 !-----------------------------------------------------------------------
@@ -492,18 +526,19 @@ contains
 !  !  routine vertical_extrapolation
 !
 !> \brief Extrapolate validOceanMask vertically
-!> \author Holly Kyeore Han
-!> \date   November 2023
+!> \author Holly Kyeore Han, modified by Alex Hager
+!> \date   November 2023 (modified September 2024)
 !> \details
 !> This routine extrapolates the horizontally extrapolated
 !> validOceanMask through the vertical layers of the ocean.
 !> The vertical extrapolation is completed once local new mask count
 !> stops updating. The output of the routine is an updated
-!> validOceanMask, thermal forcing fields and newMaskCountLocal.
+!> validOceanMask, ocean forcing fields (temperature and salinity, or 
+!> thermal forcing) and newMaskCountLocal.
 
 !-----------------------------------------------------------------------
 
-   subroutine vertical_extrapolation(domain, availOceanMask, validOceanMask, newMaskCountGlobal, TFocean, err)
+   subroutine vertical_extrapolation(domain, availOceanMask, validOceanMask, newMaskCountGlobal, oceanField, err)
 
       use li_constants, only: oceanFreezingTempDepthDependence
 
@@ -518,7 +553,7 @@ contains
       type (domain_type), intent(inout) :: domain  !< Input/Output: domain object
       integer, dimension(:,:), pointer, intent(inout) :: validOceanMask
       integer, intent(inout) :: err !< Output: error flag
-      real (kind=RKIND), dimension(:,:), pointer, intent(inout) :: TFocean
+      real (kind=RKIND), dimension(:,:), pointer, intent(inout) :: oceanField
 
       !-----------------------------------------------------------------
       ! output variables
@@ -530,19 +565,21 @@ contains
       !-----------------------------------------------------------------
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: scratchPool, geometryPool, meshPool, extrapOceanDataPool
-      real (kind=RKIND) :: layerTop, TFsum, areaSum
+      real (kind=RKIND) :: layerTop, fieldSum, areaSum
       real (kind=RKIND), dimension(:), pointer :: ismip6shelfMelt_zOcean
       real (kind=RKIND), dimension(:), pointer :: thickness, bedTopography, areaCell
       integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
       integer, dimension(:,:), pointer :: cellsOnCell
-      integer :: iCell, jCell, iLayer, iNeighbor, iter
+      integer :: iCell, jCell, iLayer, iNeighbor, iter, iField
       integer :: localLoopCount, newMaskCountLocalAccum
+      logical, pointer :: config_recalculate_thermal_forcing
 
       err = 0
 
       ! initialize the ocean data and mask fields
       block => domain % blocklist
+      call mpas_pool_get_config(liConfigs, 'config_recalculate_thermal_forcing', config_recalculate_thermal_forcing)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'extrapOceanData', extrapOceanDataPool)
@@ -562,22 +599,34 @@ contains
       newMaskCountLocalAccum = 0
       do iCell = 1, nCellsSolve
          do iLayer = 2, nISMIP6OceanLayers
-            if ( (availOceanMask(iLayer,iCell) == 1) .and. (validOceanMask(iLayer,iCell) == 0) ) then
-              if ( validOceanMask(iLayer-1,iCell) == 1 ) then
-                 if (TFocean(iLayer-1,iCell) > 1.0e6_RKIND) then
-                    ! raise error if an invalid ocean data value is used
-                    call mpas_log_write("ocean data value used for extrapolation is invalid", &
-                         MPAS_LOG_ERR)
-                    err = ior(err,1)
-                 else
-                    TFocean(iLayer,iCell) = TFocean(iLayer-1,iCell) - &
-                       (ismip6shelfMelt_zOcean(iLayer-1) - ismip6shelfMelt_zOcean(iLayer)) * &
-                       oceanFreezingTempDepthDependence
-                 endif
-                 validOceanMask(iLayer,iCell) = 1
-                 newMaskCountLocalAccum = newMaskCountLocalAccum + 1
-              endif
-            endif
+            do iField = 1, 2
+               if ( (availOceanMask(iLayer,iCell) == 1) .and. (validOceanMask(iLayer,iCell) == 0) ) then
+                  if ( validOceanMask(iLayer-1,iCell) == 1 ) then
+                     if (oceanField(iLayer-1,iCell,iField) > 1.0e6_RKIND) then
+                        ! raise error if an invalid ocean data value is used
+                        call mpas_log_write("ocean data value used for extrapolation is invalid", &
+                               MPAS_LOG_ERR)
+                        err = ior(err,1)
+                     else
+                        ! << TO DO >>: This will have to be done differently for temp/salt
+                        if (config_recalculate_thermal_forcing) then
+                           !if extrapolating temp/salt, assign value equal to overlying cell
+                           oceanField(iLayer,iCell,iField) = oceanField(iLayer-1,iCell,iField)
+                        else
+                           !if extrapolating thermal forcing, need to account for depth-dependent difference in freezing temp
+                           oceanField(iLayer,iCell,iField) = oceanField(iLayer-1,iCell,iField) - &
+                              (ismip6shelfMelt_zOcean(iLayer-1) - ismip6shelfMelt_zOcean(iLayer)) * &
+                               oceanFreezingTempDepthDependence
+                     endif
+                     validOceanMask(iLayer,iCell) = 1
+                     newMaskCountLocalAccum = newMaskCountLocalAccum + 1
+                  endif
+               endif
+               
+               if (.not. config_recalculate_thermal_forcing) then
+                  exit
+               endif
+            enddo
          enddo
       enddo
 


### PR DESCRIPTION
Makes edits to the existing ocean thermal forcing extrapolation framework so that either user can choose to either extrapolate ocean thermal forcing, or ocean temperature and salinity. If the case of the latter, ocean thermal forcing is then recalculated following extrapolation according to the method declared in the namelist files (<< add those options here once code is written >>). Temperature and salinity will be extrapolated instead of thermal forcing is `config_recalculate_thermal_forcing` is set to `.true.`.