### PR TITLE
Set SGH coupling interval

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -184,7 +184,7 @@
                 <!-- convenience variables -->
                 <var name="effectivePressureSGH" type="real" dimensions="nCells Time" units="Pa"
                         description="effective ice pressure in subglacial hydrology system" />
-                <var name="effectivePressure" type="real" dimensions="nCells Time" units="Pa" packages="higherOrderVelocity"
+                <var name="effectivePressure" type="real" dimensions="nCells Time" units="Pa" packages="higherOrderVelocity" default_value="-1e36"
                         description="Effective pressure used in basal friction calculation.  If subglacial hydrology model is active, this will be effectivePressureSGH averaged over the interval defined by config_SGH_coupling_interval. If subglacial hydrology model is inactive, this will come from a file or a parameterization."/>
                 <var name="effectivePressureTimeCycleAvg" type="real" dimensions="nCells Time" units="Pa"
                         description="effectivePressureSGH averaged over the subglacial hydrology model timestepping subcycle." /> 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -111,6 +111,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), dimension(:), pointer :: hydropotential
+      real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
+      real (kind=RKIND),dimension(:), pointer :: effectivePressure
       integer, dimension(:), pointer :: cellMask
       real (kind=RKIND), pointer :: tillMax
       real (kind=RKIND), pointer :: rhoi, rhoo
@@ -265,7 +267,22 @@ module li_subglacial_hydro
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'waterPressureSmooth')
       call mpas_timer_stop("halo updates")
-     
+    
+      ! initialize effectivePressure
+      block => domain % blocklist
+      do while (associated(block))
+        
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
+         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
+         call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
+         
+         if (all(effectivePressure == -1e36_RKIND)) then
+            effectivePressure = effectivePressureSGH
+         endif
+         
+         block => block % next
+      end do
+
       ! === error check
       if (err > 0) then
           call mpas_log_write("An error has occurred in li_SGH_init.", MPAS_LOG_ERR)
@@ -342,8 +359,8 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterVelocity
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellX
       real (kind=RKIND), dimension(:), pointer :: waterVelocityCellY
+      real (kind=RKIND), dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressureSGH
-      real (kind=RKIND),dimension(:), pointer :: effectivePressure
       real (kind=RKIND), dimension(:), pointer :: effectivePressureTimeCycleAvg
       real (kind=RKIND), dimension(:), allocatable :: cellJunk
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -414,22 +431,20 @@ module li_subglacial_hydro
       timeLeft = masterDeltat  ! in seconds
       numSubCycles = 0
 
+      ! initialize accumulated time averages/sums throughout timecycle
       block => domain % blocklist
       do while (associated(block))
         
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
-         call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
          call mpas_pool_get_array(hydroPool, 'effectivePressureTimeCycleAvg', effectivePressureTimeCycleAvg)
          call mpas_pool_get_array(hydroPool, 'deltatSGHaccumulated', deltatSGHaccumulated)
-
-         effectivePressure = 0.0_RKIND
+         
          effectivePressureTimeCycleAvg = 0.0_RKIND
          deltatSGHaccumulated = 0.0_RKIND
-
+         
          block => block % next
-      end do
-
-
+      enddo
+      
       ! =============
       ! =============
       ! =============
@@ -761,9 +776,9 @@ module li_subglacial_hydro
          do while (associated(block))
 
             call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
-            call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
+            call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
             call mpas_pool_get_array(hydroPool, 'effectivePressureTimeCycleAvg', effectivePressureTimeCycleAvg)
-         
+            
             effectivePressure = effectivePressureTimeCycleAvg
             block => block % next
          end do


### PR DESCRIPTION
Establishes `config_SGH_coupling_interval`, the interval at which the SGH model is coupled to the dynamics model. SGH output is then averaged over the coupling interval so that the dynamics model only sees a time-averaged hydrologic state, and not an arbitrary sampling of hydrologic conditions. `config_SGH_coupling_interval` must be able to divide evenly into `config_dt` or `config_adaptive_timestep_force_interval`, whichever one is used.