### PR TITLE
Add new GLC grid: mpas.gis4to40km

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5918,7 +5918,7 @@
     <!-- GLC: mpas.gis4to40km    -->
     <!-- ====================    -->
 
-    <gridmap glc_grid="mpas.gis4to40kmR2" lnd_grid="r05">
+    <gridmap glc_grid="mpas.gis4to40km" lnd_grid="r05">
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r05/map_r05_to_gis4to40_traave.20250218.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/map_r05_to_gis4to40_trbilin.20250218.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_r05_traave.20250218.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1999,6 +1999,16 @@
       <mask>IcoswISC30E3r5</mask>
     </model_grid>
 
+    <model_grid alias="TL319_oQU240wLI_gis4to40" compset="_MALI">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">oQU240wLI</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">mpas.gis4to40km</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240wLI</mask>
+    </model_grid>
+
     <model_grid alias="TL319_IcoswISC30E3r5_gis4to40" compset="_MALI">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -5944,6 +5954,18 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_gis4to40_trbilin.20250218.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_TL319_traave.20250218.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_TL319_traave.20250218.nc</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis4to40km" ocn_grid="oQU240wLI">
+      <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_gis4to40_esmfaave.20250303.nc</map>
+      <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_gis4to40_esmfbilin.20250303.nc</map>
+      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/oQU240wLI/XXX</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_nn.20250303.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_nn.20250303.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis4to40km" ocn_grid="IcoswISC30E3r5">

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5959,7 +5959,7 @@
     <gridmap glc_grid="mpas.gis4to40km" ocn_grid="oQU240wLI">
       <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_gis4to40_esmfaave.20250303.nc</map>
       <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_gis4to40_esmfbilin.20250303.nc</map>
-      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/oQU240wLI/XXX</map>
+      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_to_gis4to40_esmfaave.20250303.nc</map>
       <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
       <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
       <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_oQU240wLI_esmfaave.20250303.nc</map>
@@ -5971,7 +5971,7 @@
     <gridmap glc_grid="mpas.gis4to40km" ocn_grid="IcoswISC30E3r5">
       <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_gis4to40_esmfaave.20250218.nc</map>
       <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_gis4to40_esmfbilin.20250218.nc</map>
-      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
+      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_gis4to40_esmfaave.20250218.nc</map>
       <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
       <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
       <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -5919,45 +5919,44 @@
     <!-- ====================    -->
 
     <gridmap glc_grid="mpas.gis4to40kmR2" lnd_grid="r05">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r05/XXX</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/XXX</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r05/map_r05_to_gis4to40_traave.20250218.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/map_r05_to_gis4to40_trbilin.20250218.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_r05_traave.20250218.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_r05_traave.20250218.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis4to40km" lnd_grid="r025">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r025/XXX</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r025/XXX</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r025/map_r025_to_gis4to40_traave.20250218.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r025/map_r025_to_gis4to40_trbilin.20250218.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_r025_traave.20250218.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_r025_traave.20250218.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis4to40km" lnd_grid="ne30np4.pg2">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/XXX</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/XXX</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis4to40_traave.20250218.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/map_ne30pg2_to_gis4to40_trbilin.20250218.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_ne30pg2_traave.20250218.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_ne30pg2_traave.20250218.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis4to40km" lnd_grid="TL319">
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/TL319/XXX</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/XXX</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/TL319/map_TL319_to_gis4to40_traave.20250218.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/map_TL319_to_gis4to40_trbilin.20250218.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_TL319_traave.20250218.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_TL319_traave.20250218.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.gis4to40km" ocn_grid="IcoswISC30E3r5">
-      <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
-      <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
+      <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_gis4to40_esmfaave.20250218.nc</map>
+      <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/map_IcoswISC30E3r5_to_gis4to40_esmfbilin.20250218.nc</map>
       <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
-      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
-      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_esmfaave.20250218.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_nn.20250218.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/map_gis4to40_to_IcoswISC30E3r5_nn.20250218.nc</map>
     </gridmap>
-
 
     <!-- ====================  -->
     <!-- GLC: mpas.gis1to10km  -->

--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1989,6 +1989,46 @@
       <mask>IcoswISC30E3r5</mask>
     </model_grid>
 
+    <model_grid alias="ne30pg2_r05_IcoswISC30E3r5_gis4to40" compset="_MALI">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis4to40km</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
+    <model_grid alias="TL319_IcoswISC30E3r5_gis4to40" compset="_MALI">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">JRA025</grid>
+      <grid name="glc">mpas.gis4to40km</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
+    <model_grid alias="ERA5r025_r05_IcoswISC30E3r5_gis4to40" compset="_MALI">
+      <grid name="atm">ERA5r025</grid>
+      <grid name="lnd">r05</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis4to40km</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
+    <model_grid alias="ERA5r025_r025_IcoswISC30E3r5_gis4to40" compset="_MALI">
+      <grid name="atm">ERA5r025</grid>
+      <grid name="lnd">r025</grid>
+      <grid name="ocnice">IcoswISC30E3r5</grid>
+      <grid name="rof">r025</grid>
+      <grid name="glc">mpas.gis4to40km</grid>
+      <grid name="wav">null</grid>
+      <mask>IcoswISC30E3r5</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_r05_oECv3_gis1to10" compset="_MALI">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -3469,6 +3509,12 @@
       <nx>7425</nx>
       <ny>1</ny>
       <desc>mpas.gis20km is a uniform-resolution 20km MALI grid of the Greenland Ice Sheet.  It is primarily intended for testing.</desc>
+    </domain>
+
+    <domain name="mpas.gis4to40km">
+      <nx>7425</nx>
+      <ny>1</ny>
+      <desc>mpas.gis4to40km is a variable-resolution, from 4 to 40 km MALI grid of the Greenland Ice Sheet.  It extends into the ocean to the continental shelf break to ensure ample overlap with ocean meshes</desc>
     </domain>
 
     <domain name="mpas.gis1to10km">
@@ -5867,6 +5913,51 @@
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis20km/map_gis20km_to_IcoswISC30E3r5_esmfaave.20240403.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis20km/map_gis20km_to_IcoswISC30E3r5_esmfaave.20240403.nc</map>
     </gridmap>
+
+    <!-- ====================    -->
+    <!-- GLC: mpas.gis4to40km    -->
+    <!-- ====================    -->
+
+    <gridmap glc_grid="mpas.gis4to40kmR2" lnd_grid="r05">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r05/XXX</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r05/XXX</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis4to40km" lnd_grid="r025">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/r025/XXX</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/r025/XXX</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis4to40km" lnd_grid="ne30np4.pg2">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg2/XXX</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg2/XXX</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis4to40km" lnd_grid="TL319">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/TL319/XXX</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/TL319/XXX</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+    </gridmap>
+
+    <gridmap glc_grid="mpas.gis4to40km" ocn_grid="IcoswISC30E3r5">
+      <map name="OCN2GLC_SHELF_FMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
+      <map name="OCN2GLC_SHELF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
+      <map name="OCN2GLC_TF_SMAPNAME">cpl/gridmaps/IcoswISC30E3r5/XXX</map>
+      <map name="GLC2ICE_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2ICE_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis4to40km/XXX</map>
+    </gridmap>
+
 
     <!-- ====================  -->
     <!-- GLC: mpas.gis1to10km  -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -221,9 +221,10 @@ Normally this is ONLY used when running CESM with the active glacier model.
 </entry>
 
 <entry id="glc_grid" type="char*10" category="elm_physics"
-        group="elm_inparm" valid_values="mpas.gis20km,mpas.gis1to10km,mpas.gis1to10kmR2" >
+        group="elm_inparm" valid_values="mpas.gis20km,mpas.gis4to40km,mpas.gis1to10km,mpas.gis1to10kmR2" >
 Glacier model grid
     mpas.gis20km  = Greenland at 20km resolution
+    mpas.gis4to40km = Greenland at 4-to-40km variable resolution
     mpas.gis1to10km = Greenland at 1-to-10km variable resolution (v1, kept for backwards compatibility)
     mpas.gis1to10kmR2 = Greenland at 1-to-10km variable resolution (v2, improved init. cond., fewer total grid cells)
 </entry>

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.gis_4to40km.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.gis_4to40km.yaml
@@ -1,0 +1,247 @@
+%YAML 1.1
+---
+ANONYMOUS:
+
+  Problem:
+    Depth Integrated Model: true
+    Basal Cubature Degree: 4
+    LandIce Field Norm:
+      sliding_velocity_basalside:
+        Regularization Type: Given Value
+        Regularization Value: 1.0e-4
+    LandIce BCs:
+      BC 0:
+        Basal Friction Coefficient:
+          Type: Power Law
+          Power Exponent: 1.0
+          Mu Type: Field
+          Effective Pressure Type: Hydrostatic Computed At Nodes
+          Zero Effective Pressure On Floating Ice At Nodes: true
+          Zero Beta On Floating Ice: false
+          Use Pressurized Bed Above Sea Level: false
+# Discretization Description
+  Discretization:
+    #Exodus Output File Name: albany_output.exo
+
+  Piro:
+#   Nonlinear Solver Information
+    NOX:
+      Nonlinear Solver: Line Search Based
+      Line Search:
+        Full Step:
+          Full Step: 1.0e+00
+        Method: Backtrack
+      Solver Options:
+        Status Test Check Type: Minimal
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: AND
+          Number of Tests: 2
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Unscaled
+            Tolerance: 1.0e-03
+          Test 1:
+            Test Type: RelativeNormF
+            Norm Type: Two Norm
+            Tolerance: 0.9999
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 100
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Type 2
+          Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-8
+
+          Stratimikos Linear Solver:
+            Stratimikos:
+
+#             Linear Solver Information
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Output File: none
+                    Verbosity Level: low
+
+#             Preconditioner Information
+              Preconditioner Type: MueLu
+              Preconditioner Types:
+
+                Ifpack2:
+                  Overlap: 1
+                  Prec Type: ILUT
+
+                MueLu:
+                  Matrix:
+                    PDE equations: 2
+                  Factories:
+                    myLineDetectionFact:
+                      factory: LineDetectionFactory
+                      'linedetection: orientation': coordinates
+                    mySemiCoarsenPFact1:
+                      factory: SemiCoarsenPFactory
+                      'semicoarsen: coarsen rate': 14
+                    UncoupledAggregationFact2:
+                      factory: UncoupledAggregationFactory
+                      'aggregation: ordering': graph
+                      'aggregation: max selected neighbors': 0
+                      'aggregation: min agg size': 3
+                      'aggregation: phase3 avoid singletons': true
+                    MyCoarseMap2:
+                      factory: CoarseMapFactory
+                      Aggregates: UncoupledAggregationFact2
+                    myTentativePFact2:
+                      'tentative: calculate qr': true
+                      factory: TentativePFactory
+                      Aggregates: UncoupledAggregationFact2
+                      CoarseMap: MyCoarseMap2
+                    mySaPFact2:
+                      'sa: eigenvalue estimate num iterations': 10
+                      'sa: damping factor': 1.33333e+00
+                      factory: SaPFactory
+                      P: myTentativePFact2
+                    myTransferCoordinatesFact:
+                      factory: CoordinatesTransferFactory
+                      CoarseMap: MyCoarseMap2
+                      Aggregates: UncoupledAggregationFact2
+                    myTogglePFact:
+                      factory: TogglePFactory
+                      'semicoarsen: number of levels': 2
+                      TransferFactories:
+                        P1: mySemiCoarsenPFact1
+                        P2: mySaPFact2
+                        Ptent1: mySemiCoarsenPFact1
+                        Ptent2: myTentativePFact2
+                        Nullspace1: mySemiCoarsenPFact1
+                        Nullspace2: myTentativePFact2
+                    myRestrictorFact:
+                      factory: TransPFactory
+                      P: myTogglePFact
+                    myToggleTransferCoordinatesFact:
+                      factory: ToggleCoordinatesTransferFactory
+                      Chosen P: myTogglePFact
+                      TransferFactories:
+                        Coordinates1: mySemiCoarsenPFact1
+                        Coordinates2: myTransferCoordinatesFact
+                    myRAPFact:
+                      factory: RAPFactory
+                      P: myTogglePFact
+                      R: myRestrictorFact
+                      TransferFactories:
+                        For Coordinates: myToggleTransferCoordinatesFact
+                    myRepartitionHeuristicFact:
+                      factory: RepartitionHeuristicFactory
+                      A: myRAPFact
+                      'repartition: min rows per proc': 3000
+                      'repartition: max imbalance': 1.327e+00
+                      'repartition: start level': 1
+                    myZoltanInterface:
+                      factory: ZoltanInterface
+                      A: myRAPFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      number of partitions: myRepartitionHeuristicFact
+                    myRepartitionFact:
+                      factory: RepartitionFactory
+                      A: myRAPFact
+                      Partition: myZoltanInterface
+                      'repartition: remap parts': true
+                      number of partitions: myRepartitionHeuristicFact
+                    myRebalanceProlongatorFact:
+                      factory: RebalanceTransferFactory
+                      type: Interpolation
+                      P: myTogglePFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      Nullspace: myTogglePFact
+                    myRebalanceRestrictionFact:
+                      factory: RebalanceTransferFactory
+                      type: Restriction
+                      R: myRestrictorFact
+                    myRebalanceAFact:
+                      factory: RebalanceAcFactory
+                      A: myRAPFact
+                      TransferFactories: { }
+                    mySmoother1:
+                      factory: TrilinosSmoother
+                      type: LINESMOOTHING_BANDEDRELAXATION
+                      'smoother: pre or post': both
+                      ParameterList:
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0
+                    mySmoother3:
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': both
+                      ParameterList:
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0
+                    mySmoother4:
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': pre
+                      ParameterList:
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 4
+                        'relaxation: damping factor': 1.0
+                  Hierarchy:
+                    max levels: 7
+                    'coarse: max size': 2000
+                    verbosity: None
+                    Finest:
+                      Smoother: mySmoother1
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact
+                    All:
+                      startLevel: 1
+                      Smoother: mySmoother4
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact

--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -82,6 +82,11 @@ def buildnml(case, caseroot, compname):
         grid_prefix += 'gis_20km_r01'
         decomp_date += '150922'
         decomp_prefix += 'mpasli.graph.info.'
+    elif glc_grid == 'mpas.gis4to40km':
+        grid_date += 'XXXXX'
+        grid_prefix += 'gis_4to40km_r01'
+        decomp_date += 'XXXXX'
+        decomp_prefix += 'mpasli.graph.info.'
     elif glc_grid == 'mpas.gis1to10km':
         grid_date += '20210824'
         grid_prefix += 'gis_1to10km_r01'

--- a/components/mpas-albany-landice/cime_config/buildnml
+++ b/components/mpas-albany-landice/cime_config/buildnml
@@ -83,9 +83,9 @@ def buildnml(case, caseroot, compname):
         decomp_date += '150922'
         decomp_prefix += 'mpasli.graph.info.'
     elif glc_grid == 'mpas.gis4to40km':
-        grid_date += 'XXXXX'
-        grid_prefix += 'gis_4to40km_r01'
-        decomp_date += 'XXXXX'
+        grid_date += '20250214'
+        grid_prefix += 'gis_4to40km'
+        decomp_date += '20250214'
         decomp_prefix += 'mpasli.graph.info.'
     elif glc_grid == 'mpas.gis1to10km':
         grid_date += '20210824'

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -1085,7 +1085,7 @@
 
   <entry id="GLC_GRID">
     <type>char</type>
-    <valid_values>mpas.aisgis20km,mpas.ais20km,mpas.ais8to30km,mpas.ais4to20km,mpas.gis20km,mpas.gis1to10km,mpas.gis1to10kmR2,null</valid_values>
+    <valid_values>mpas.aisgis20km,mpas.ais20km,mpas.ais8to30km,mpas.ais4to20km,mpas.gis20km,mpas.gis4to40km,mpas.gis1to10km,mpas.gis1to10kmR2,null</valid_values>
     <default_value>mpas.gis20km</default_value>
     <group>build_grid</group>
     <file>env_build.xml</file>

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -1085,7 +1085,7 @@
 
   <entry id="GLC_GRID">
     <type>char</type>
-    <valid_values>mpas.aisgis20km,mpas.ais20km,mpas.ais8to30km,mpas.ais4to20km,mpas.gis20km,mpas.gis1to10km,mpas.gis1to10kmR2,null</valid_values>
+    <valid_values>mpas.aisgis20km,mpas.ais20km,mpas.ais8to30km,mpas.ais4to20km,mpas.gis20km,mpas.gis4to40km,mpas.gis1to10km,mpas.gis1to10kmR2,null</valid_values>
     <default_value>mpas.gis20km</default_value>
     <group>build_grid</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
This is a medium resolution Greenland grid for MALI.  It will replace the gis20km grid for testing.  It is the first MALI Greenland grid to extend far enough into the ocean to ensure overlap with MPAS-Ocean meshes, which is needed for OCN-GLC thermal forcing coupling used for Greenland fjords.  E3SM grids are added that include this mesh paired with the other component grids for the suite of v3 BG, IG, and GG cases currently being used, as well as a GG case at ultra-low-res for rapid testing.
