### PR TITLE
Fix mass leak during advection with RK time integration

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1871,7 +1871,7 @@ module li_advection
       !-----------------------------------------------------------------
 
       integer, pointer :: &
-           nEdges,     & ! dnumber of locally owned edges
+           nEdges,     & ! number of edges
            nVertLevels        ! number of vertical layers
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -1907,7 +1907,7 @@ module li_advection
       ! initialize output variables
       minOfMaxAllowableDt = bigNumber
 
-      ! loop over local edges
+      ! loop over edges
       do iEdge = 1, nEdges
 
          if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1871,7 +1871,7 @@ module li_advection
       !-----------------------------------------------------------------
 
       integer, pointer :: &
-           nEdgesSolve,     & ! dnumber of locally owned edges
+           nEdges,     & ! dnumber of locally owned edges
            nVertLevels        ! number of vertical layers
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -1894,7 +1894,7 @@ module li_advection
       err = 0
 
       ! get dimensions
-      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
 
       ! get mesh arrays
@@ -1908,7 +1908,7 @@ module li_advection
       minOfMaxAllowableDt = bigNumber
 
       ! loop over local edges
-      do iEdge = 1, nEdgesSolve
+      do iEdge = 1, nEdges
 
          if (li_mask_is_dynamic_ice(edgeMask(iEdge))) then
 


### PR DESCRIPTION
Loop over nEdges instead of nEdgesSolve in li_layer_normal_velocity, which fixes a mass leak during RK advection that was introduced in commit 8fa61a6.