### PR TITLE
Add flux gate analysis member

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1841,7 +1841,9 @@ is the value of that variable from the *previous* time level!
           <var name="fluxGateEdgeMasksSigns" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
                description="sign of edge for flux gate calculations"
                />
-        </var_struct>
+	  <var name="fluxGateNames" type="text" dimensions="nFluxGates" units="unitless"
+	       description="name of region masks"
+	       />
 
 <!-- ======================================================================= -->
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -54,6 +54,9 @@
 		<dim name="maxRegionsInGroup" definition="1" units="unitless"
 		     description="The maximum number of regions in a region group used for AM_regionalStats"
 		/>
+                <dim name="nFluxGates" definition="1" units="unitless"
+                     description="The number of flux gates used for AM_fluxGates"
+                />
 	</dims>
 
 
@@ -968,6 +971,14 @@
                         <var name="regionGroupNames"/-->
 		</stream>
 
+                <stream name="fluxGatesInput" type="input"
+                                mode="forward;analysis"
+                                filename_template="fluxGateMasks.nc"
+                                input_interval="initial_only"
+                                runtime_format="single_file">
+                        <var name="fluxGateEdgeMasks"/>
+                </stream>
+
 		<!-- Input stream for use with config_calving = ismip6_retreat, which requires multiple
 		     time levels from forcing file, which could inadvertently clobber some fields if
                      not set up carefully. So we use an immutable stream to avoid mishap. -->
@@ -1821,6 +1832,12 @@ is the value of that variable from the *previous* time level!
 	       description="name of region groups"
 	       /-->
 	</var_struct>
+
+        <var_struct name="fluxGates" time_levs="1">
+          <var name="fluxGateEdgeMasks" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
+               description="masks set to 1 in edges that belong to a given flux gate and 0 otherwise"
+               />
+        </var_struct>
 
 <!-- ======================================================================= -->
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -977,6 +977,7 @@
                                 input_interval="initial_only"
                                 runtime_format="single_file">
                         <var name="fluxGateEdgeMasks"/>
+                        <var name="fluxGateEdgeMasksSigns"/>
                 </stream>
 
 		<!-- Input stream for use with config_calving = ismip6_retreat, which requires multiple
@@ -1836,6 +1837,9 @@ is the value of that variable from the *previous* time level!
         <var_struct name="fluxGates" time_levs="1">
           <var name="fluxGateEdgeMasks" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
                description="masks set to 1 in edges that belong to a given flux gate and 0 otherwise"
+               />
+          <var name="fluxGateEdgeMasksSigns" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
+               description="sign of edge for flux gate calculations"
                />
         </var_struct>
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1836,10 +1836,10 @@ is the value of that variable from the *previous* time level!
 
         <var_struct name="fluxGates" time_levs="1">
           <var name="fluxGateEdgeMasks" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
-               description="masks set to 1 in edges that belong to a given flux gate and 0 otherwise"
+               description="Masks set to 1 in edges that belong to a given flux gate and 0 otherwise."
                />
           <var name="fluxGateEdgeMasksSigns" type="integer" dimensions="nFluxGates nEdges" units="unitless" default_value="1"
-               description="sign of edge for flux gate calculations"
+               description="Sign of edge for flux gate calculations, calculated using compute_mpas_transect_masks with --add_edge_sign in MPAS-Tools."
                />
 	  <var name="fluxGateNames" type="text" dimensions="nFluxGates" units="unitless"
 	       description="name of region masks"

--- a/components/mpas-albany-landice/src/analysis_members/Makefile
+++ b/components/mpas-albany-landice/src/analysis_members/Makefile
@@ -3,7 +3,8 @@
 OBJS = mpas_li_analysis_driver.o
 
 MEMBERS = mpas_li_global_stats.o \
-          mpas_li_regional_stats.o 
+          mpas_li_regional_stats.o \
+          mpas_li_flux_gates.o
 
 all: $(OBJS)
 

--- a/components/mpas-albany-landice/src/analysis_members/Registry_analysis_members.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_analysis_members.xml
@@ -1,2 +1,3 @@
 #include "Registry_global_stats.xml"
 #include "Registry_regional_stats.xml"
+#include "Registry_flux_gates.xml"

--- a/components/mpas-albany-landice/src/analysis_members/Registry_flux_gates.xml
+++ b/components/mpas-albany-landice/src/analysis_members/Registry_flux_gates.xml
@@ -1,0 +1,48 @@
+        <nml_record name="AM_fluxGates" mode="forward;analysis">
+                <nml_option name="config_AM_fluxGates_enable" type="logical" default_value=".false." units="unitless"
+                        description="If true, landice analysis member fluxGates is called."
+                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_AM_fluxGates_compute_interval" type="character" default_value="output_interval" units="unitless"
+                        description="Timestamp determining how often analysis member computations should be performed."
+                        possible_values="Any valid time stamp, 'dt', or 'output_interval'"
+                />
+                <nml_option name="config_AM_fluxGates_stream_name" type="character" default_value="fluxGatesOutput" units="unitless"
+                        description="Name of the stream that the fluxGates analysis member should be tied to."
+                        possible_values="Any existing stream name or 'none'"
+                />
+                <nml_option name="config_AM_fluxGates_compute_on_startup" type="logical" default_value=".true." units="unitless"
+                        description="Logical flag determining if analysis member computations occur on start-up."
+                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_AM_fluxGates_write_on_startup" type="logical" default_value=".true." units="unitless"
+                        description="Logical flag determining if an analysis member write occurs on start-up."
+                        possible_values=".true. or .false."
+                />
+        </nml_record>
+        <packages>
+                <package name="fluxGatesAMPKG" description="This package includes variables required for the fluxGates analysis member."/>
+        </packages>
+        <var_struct name="fluxGatesAM" time_levs="1" packages="fluxGatesAMPKG">
+
+                <var name="iceFluxThroughGates" type="real" dimensions="nFluxGates Time" units="kg yr^{-1}"
+                        description="ice flux through flux gates"
+                />
+        </var_struct>
+        <streams>
+                <stream name="fluxGatesOutput" type="output"
+                                mode="forward;analysis"
+                                filename_template="fluxGates.nc"
+                                filename_interval="01-00-00_00:00:00"
+                                output_interval="00-00-01_00:00:00"
+                                reference_time="0000-01-01_00:00:00"
+                                packages="fluxGatesAMPKG"
+                                clobber_mode="truncate"
+                                runtime_format="single_file">
+                        <var name="xtime"/>
+                        <var name="deltat"/>
+                        <var name="daysSinceStart"/>
+                        <var name="simulationStartTime"/>
+                        <var_struct name="fluxGatesAM"/>
+                </stream>
+        </streams>

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_analysis_driver.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_analysis_driver.F
@@ -29,6 +29,7 @@ module li_analysis_driver
    use li_constants
    use li_global_stats
    use li_regional_stats
+   use li_flux_gates
 
    implicit none
    private
@@ -131,6 +132,7 @@ contains
       call mpas_pool_create_pool(analysisMemberList)
       call mpas_pool_add_config(analysisMemberList, 'globalStats', 1)
       call mpas_pool_add_config(analysisMemberList, 'regionalStats', 1)
+      call mpas_pool_add_config(analysisMemberList, 'fluxGates', 1)
 
       ! DON'T EDIT BELOW HERE
 
@@ -736,6 +738,7 @@ contains
       integer, intent(in) :: timeLevel !< Input: Time level to compute with in analysis member
       character (len=*), intent(in) :: analysisMemberName !< Input: Name of analysis member
       integer, intent(out) :: iErr !< Output: Error code
+      integer, pointer :: nFluxGates
 
       integer :: nameLength, err_tmp
 
@@ -749,6 +752,10 @@ contains
       if ( analysisMemberName(1:nameLength) == 'regionalStats' ) then
         call li_compute_regional_stats(domain, analysisMemberName, timeLevel, err_tmp)
       end if
+      if ( analysisMemberName(1:nameLength) == 'fluxGates' ) then
+        call mpas_pool_get_dimension(domain % blocklist % dimensions, 'nFluxGates', nFluxGates)
+        call li_compute_flux_across_gates(domain, analysisMemberName, timeLevel, nFluxGates, err_tmp)
+      endif
 
       iErr = ior(iErr, err_tmp)
 

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
@@ -1,0 +1,156 @@
+! Copyright (c) 2013-2018,  Los Alamos National Security, LLC (LANS)
+! and the University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at http://mpas-dev.github.io/license.html
+!
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  mpas_li_flux_gates
+!
+!> \brief MPAS land ice analysis mode member: mpas_li_flux_fates
+!> \author Trevor Hillebrand
+!> \date   03-28-2025
+!> \details Calculates ice flux through gates defined in input file.
+!>
+!>
+!-----------------------------------------------------------------------
+module li_flux_gates
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_timekeeping
+   use mpas_stream_manager
+
+   use li_mask
+   use li_constants
+
+   implicit none
+   private
+   save
+
+   !--------------------------------------------------------------------
+   !
+   ! Public parameters
+   !
+   !--------------------------------------------------------------------
+
+   !--------------------------------------------------------------------
+   !
+   ! Public member functions
+   !
+   !--------------------------------------------------------------------
+
+   public :: li_compute_flux_across_gates
+
+   !--------------------------------------------------------------------
+   !
+   ! Private module variables
+   !
+   !--------------------------------------------------------------------
+
+!***********************************************************************
+
+contains
+
+!***********************************************************************
+
+!***********************************************************************
+!
+!  routine li_compute_flux_across_gates
+!
+!> \brief   Compute MPAS-Land Ice analysis member
+!> \author  Trevor Hillebrand
+!> \date    03/28/2025
+!> \details
+!>  This routine conducts all computation required for flux through specified gates
+!
+!-----------------------------------------------------------------------
+
+   subroutine li_compute_flux_across_gates(domain, memberName, timeLevel, nFluxGates, err)
+
+      !-----------------------------------------------------------------
+      !
+      ! input variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(in) :: timeLevel
+      integer, intent(in) :: nFluxGates  ! need as an input instead of pointer for global reduce
+      character (len=*), intent(in) :: memberName
+
+      !-----------------------------------------------------------------
+      !
+      ! input/output variables
+      !
+      !-----------------------------------------------------------------
+
+      type (domain_type), intent(inout) :: domain
+
+      !-----------------------------------------------------------------
+      !
+      ! output variables
+      !
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< Output: error flag
+
+      !-----------------------------------------------------------------
+      !
+      ! local variables
+      !
+      !-----------------------------------------------------------------
+
+      type (mpas_pool_type), pointer :: fluxGatesAMPool
+      type (dm_info) :: dminfo
+      type (mpas_pool_type), pointer :: fluxGatesPool
+      type (mpas_pool_type), pointer :: meshPool
+      type (mpas_pool_type), pointer :: scratchPool
+      type (mpas_pool_type), pointer :: diagnosticsPool
+      type (mpas_pool_type), pointer :: fluxGatesAM
+      type (mpas_pool_type), pointer :: geometryPool
+      type (mpas_pool_type), pointer :: velocityPool
+      type (mpas_pool_type), pointer :: hydroPool
+
+      real (kind=RKIND), dimension(:), pointer ::  dvEdge
+      integer, dimension(:), pointer :: edgeMask
+      real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, &
+                                                    layerNormalVelocity
+      integer, dimension(:,:), pointer :: fluxGateEdgeMasks
+      real (kind=RKIND), dimension(:), pointer :: iceFluxThroughGates
+      integer, pointer :: nEdges, nVertLevels
+      real (kind=RKIND), pointer ::  rhoi
+      real (kind=RKIND), dimension(nFluxGates) :: localIceFluxThroughGates
+      integer :: iGate
+
+      dminfo = domain % dminfo
+      call mpas_pool_get_config(liConfigs, 'config_ice_density', rhoi)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'fluxGatesAM', fluxGatesAMPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'fluxGates', fluxGatesPool)
+
+      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+
+      call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+      call mpas_pool_get_array(geometryPool, 'layerThicknessEdge', layerThicknessEdge)
+      call mpas_pool_get_array(fluxGatesAMPool, 'iceFluxThroughGates', iceFluxThroughGates)
+      call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
+      call mpas_pool_get_array(fluxGatesPool, 'fluxGateEdgeMasks', fluxGateEdgeMasks)
+
+      localIceFluxThroughGates(:) = 0.0_RKIND
+      iceFluxThroughGates(:) = 0.0_RKIND
+      do iGate = 1, nFluxGates
+         localIceFluxThroughGates(iGate) = sum( sum(layerNormalVelocity(:,:) * layerThicknessEdge(:,:), 1) * &
+                                                dvEdge(:) * rhoi * scyr * fluxGateEdgeMasks(iGate, :))
+      enddo
+
+      call mpas_dmpar_sum_real_array(dminfo, nFluxGates, localIceFluxThroughGates, iceFluxThroughGates)
+
+   end subroutine li_compute_flux_across_gates
+
+end module li_flux_gates

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
@@ -149,7 +149,7 @@ contains
       do iGate = 1, nFluxGates
          localIceFluxThroughGates(iGate) = sum( sum(layerNormalVelocity(:,:) * layerThicknessEdge(:,:), 1) * &
                                                 dvEdge(:) * rhoi * scyr * fluxGateEdgeMasks(iGate, :) * &
-                                                merge(1.0_RKIND, 0.0_RKIND, fluxGateEdgeMasksSigns(iGate, :) > 0))
+                                                fluxGateEdgeMasksSigns(iGate, :) )
       enddo
 
       call mpas_dmpar_sum_real_array(dminfo, nFluxGates, localIceFluxThroughGates, iceFluxThroughGates)

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
@@ -107,20 +107,16 @@ contains
       type (dm_info) :: dminfo
       type (mpas_pool_type), pointer :: fluxGatesPool
       type (mpas_pool_type), pointer :: meshPool
-      type (mpas_pool_type), pointer :: scratchPool
-      type (mpas_pool_type), pointer :: diagnosticsPool
       type (mpas_pool_type), pointer :: fluxGatesAM
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: velocityPool
-      type (mpas_pool_type), pointer :: hydroPool
 
       real (kind=RKIND), dimension(:), pointer ::  dvEdge
-      integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, &
                                                     layerNormalVelocity
       integer, dimension(:,:), pointer :: fluxGateEdgeMasks, fluxGateEdgeMasksSigns
       real (kind=RKIND), dimension(:), pointer :: iceFluxThroughGates
-      integer, pointer :: nEdges, nVertLevels
+      integer, pointer :: nEdgesSolve
       real (kind=RKIND), pointer ::  rhoi
       real (kind=RKIND), dimension(nFluxGates) :: localIceFluxThroughGates
       integer :: iGate
@@ -133,10 +129,9 @@ contains
       call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
       call mpas_pool_get_subpool(domain % blocklist % structs, 'fluxGates', fluxGatesPool)
 
-      call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nEdgesSolve', nEdgesSolve)
 
       call mpas_pool_get_array(meshPool, 'dvEdge', dvEdge)
-      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
       call mpas_pool_get_array(geometryPool, 'layerThicknessEdge', layerThicknessEdge)
       call mpas_pool_get_array(fluxGatesAMPool, 'iceFluxThroughGates', iceFluxThroughGates)
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
@@ -147,9 +142,9 @@ contains
       iceFluxThroughGates(:) = 0.0_RKIND
 
       do iGate = 1, nFluxGates
-         localIceFluxThroughGates(iGate) = sum( sum(layerNormalVelocity(:,:) * layerThicknessEdge(:,:), 1) * &
-                                                dvEdge(:) * rhoi * scyr * fluxGateEdgeMasks(iGate, :) * &
-                                                fluxGateEdgeMasksSigns(iGate, :) )
+         localIceFluxThroughGates(iGate) = sum( sum(layerNormalVelocity(:,1:nEdgesSolve) * layerThicknessEdge(:,1:nEdgesSolve), 1) * &
+                                                dvEdge(1:nEdgesSolve) * rhoi * scyr * fluxGateEdgeMasks(iGate, 1:nEdgesSolve) * &
+                                                fluxGateEdgeMasksSigns(iGate, 1:nEdgesSolve) )
       enddo
 
       call mpas_dmpar_sum_real_array(dminfo, nFluxGates, localIceFluxThroughGates, iceFluxThroughGates)

--- a/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
+++ b/components/mpas-albany-landice/src/analysis_members/mpas_li_flux_gates.F
@@ -118,7 +118,7 @@ contains
       integer, dimension(:), pointer :: edgeMask
       real (kind=RKIND), dimension(:,:), pointer :: layerThicknessEdge, &
                                                     layerNormalVelocity
-      integer, dimension(:,:), pointer :: fluxGateEdgeMasks
+      integer, dimension(:,:), pointer :: fluxGateEdgeMasks, fluxGateEdgeMasksSigns
       real (kind=RKIND), dimension(:), pointer :: iceFluxThroughGates
       integer, pointer :: nEdges, nVertLevels
       real (kind=RKIND), pointer ::  rhoi
@@ -141,12 +141,15 @@ contains
       call mpas_pool_get_array(fluxGatesAMPool, 'iceFluxThroughGates', iceFluxThroughGates)
       call mpas_pool_get_array(velocityPool, 'layerNormalVelocity', layerNormalVelocity)
       call mpas_pool_get_array(fluxGatesPool, 'fluxGateEdgeMasks', fluxGateEdgeMasks)
+      call mpas_pool_get_array(fluxGatesPool, 'fluxGateEdgeMasksSigns', fluxGateEdgeMasksSigns)
 
       localIceFluxThroughGates(:) = 0.0_RKIND
       iceFluxThroughGates(:) = 0.0_RKIND
+
       do iGate = 1, nFluxGates
          localIceFluxThroughGates(iGate) = sum( sum(layerNormalVelocity(:,:) * layerThicknessEdge(:,:), 1) * &
-                                                dvEdge(:) * rhoi * scyr * fluxGateEdgeMasks(iGate, :))
+                                                dvEdge(:) * rhoi * scyr * fluxGateEdgeMasks(iGate, :) * &
+                                                merge(1.0_RKIND, 0.0_RKIND, fluxGateEdgeMasksSigns(iGate, :) > 0))
       enddo
 
       call mpas_dmpar_sum_real_array(dminfo, nFluxGates, localIceFluxThroughGates, iceFluxThroughGates)

--- a/components/mpas-albany-landice/src/landice.cmake
+++ b/components/mpas-albany-landice/src/landice.cmake
@@ -52,6 +52,7 @@ list(APPEND RAW_SOURCES
 # analysis members
 list(APPEND RAW_SOURCES
   core_landice/analysis_members/mpas_li_analysis_driver.F
+  core_landice/analysis_members/mpas_li_flux_gates.F
   core_landice/analysis_members/mpas_li_global_stats.F
   core_landice/analysis_members/mpas_li_regional_stats.F
 )


### PR DESCRIPTION
This merge adds a MALI analysis member with online calculations of ice flux through user-defined flux gates, for comparison with observational data sets.

This may require a new workflow in COMPASS or MPAS-Tools for creating the flux gate edge masks from flux gate datasets. Note that if gate geojson files exist, the required fields can be calculated using compute_mpas_transect_masks with --add_edge_sign in MPAS-Tools.