### PR TITLE
Fix bugs in effective strain rate and meanFlowParamA calculations

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -905,6 +905,7 @@ contains
       real(kind=RKIND), pointer :: config_flowLawExponent
 
       real (kind=RKIND), dimension(:), pointer :: thickness
+      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
       real (kind=RKIND), dimension(:,:), pointer :: temperature
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       real (kind=RKIND), dimension(:), pointer :: effectiveViscosity
@@ -950,6 +951,7 @@ contains
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
 
       call mpas_pool_get_field(scratchPool, 'meanFlowParamA', meanFlowParamAVar)
@@ -976,11 +978,11 @@ contains
       err = ior(err, err_tmp)
 
       ! calculate the depth-averaged flow parameter A
-      meanFlowParamA(:) = sum(flowParamA(:,:), dim=1)/REAL(nVertLevels, kind=RKIND)
+      meanFlowParamA(:) = sum(layerThickness(:,:) * flowParamA(:,:), dim=1) / thickness(:)
 
       ! calculate effective viscosity from strain rate and flow param.
       do iCell = 1, nCells
-         eEff = sqrt(exx(iCell)**2 + eyy(iCell)**2 + exx(iCell)*eyy(iCell) + exy(iCell)**2) ! effective strain rate
+         eEff = sqrt(0.5_RKIND * (eMax(iCell)**2.0_RKIND + eMin(iCell)**2.0_RKIND ))
          if ( (eEff == 0.0_RKIND) .or. (meanFlowParamA(iCell) == 0.0_RKIND) ) then
             effectiveViscosity(iCell) = 0.0_RKIND
          else

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -978,7 +978,13 @@ contains
       err = ior(err, err_tmp)
 
       ! calculate the depth-averaged flow parameter A
-      meanFlowParamA(:) = sum(layerThickness(:,:) * flowParamA(:,:), dim=1) / thickness(:)
+      do iCell = 1, nCells
+         if (thickness(iCell) > 0.0_RKIND) then
+            meanFlowParamA(iCell) = sum(layerThickness(:,iCell) * flowParamA(:,iCell)) / thickness(iCell)
+         else
+            meanFlowParamA(iCell) = 0.0_RKIND
+         endif
+      enddo
 
       ! calculate effective viscosity from strain rate and flow param.
       do iCell = 1, nCells

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -905,7 +905,7 @@ contains
       real(kind=RKIND), pointer :: config_flowLawExponent
 
       real (kind=RKIND), dimension(:), pointer :: thickness
-      real (kind=RKIND), dimension(:,:), pointer :: layerThickness
+      real (kind=RKIND), dimension(:), pointer :: layerThicknessFractions
       real (kind=RKIND), dimension(:,:), pointer :: temperature
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
       real (kind=RKIND), dimension(:), pointer :: effectiveViscosity
@@ -931,6 +931,8 @@ contains
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
+      call mpas_pool_get_array(meshPool, 'layerThicknessFractions', layerThicknessFractions)
+
       call mpas_pool_get_array(velocityPool, 'exx', exx)
       call mpas_pool_get_array(velocityPool, 'eyy', eyy)
       call mpas_pool_get_array(velocityPool, 'dudy', dudy)
@@ -951,7 +953,6 @@ contains
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
 
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-      call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'effectiveViscosity', effectiveViscosity)
 
       call mpas_pool_get_field(scratchPool, 'meanFlowParamA', meanFlowParamAVar)
@@ -979,11 +980,7 @@ contains
 
       ! calculate the depth-averaged flow parameter A
       do iCell = 1, nCells
-         if (thickness(iCell) > 0.0_RKIND) then
-            meanFlowParamA(iCell) = sum(layerThickness(:,iCell) * flowParamA(:,iCell)) / thickness(iCell)
-         else
-            meanFlowParamA(iCell) = 0.0_RKIND
-         endif
+         meanFlowParamA(iCell) = sum(flowParamA(:,iCell) * layerThicknessFractions(:))
       enddo
 
       ! calculate effective viscosity from strain rate and flow param.


### PR DESCRIPTION
Fix bugs in effective strain rate and viscosity calculations. Depth-averaged flow parameter A calculation assumed uniform vertical layer spacing, and effective strain rate calculation included an extra cross term.