### PR TITLE
Improve robustness of thermal forcing application

### DIFF
--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -808,6 +808,7 @@ contains
 
       ! Set MPAS Log module instance
       mpas_log_info => domain % logInfo
+      call mpas_log_write("")
       call mpas_log_write("=== Beginning glc_run_mct ===")
 
       err = 0

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -496,8 +496,8 @@
 				  description="Depth above which to iceberg meltwater is important. If config_TF_iceberg_melt is set to 'true' or 'mask', water above this depth will be altered to follow the submarine meltwater mixing line. Default value is taken from Hager et al. (2024)."
 				  possible_values="Any negative real value"
 		/>
-		<nml_option name="config_ocean_data_extrap_ncells_extra" type="integer" default_value="2" units="unitless"
-			    description="number of extra cells for over-extrapolation into grounded ice" possible_values="any non-negative value"
+		<nml_option name="config_ocean_data_extrap_ncells_extra" type="integer" default_value="3" units="unitless"
+                        description="number of extra cells for over-extrapolation into grounded ice. Note: value must >=3 when used with facemelting." possible_values="any non-negative value"
       />
       <nml_option name="config_invalid_value_TF" type="real" default_value="1.0e36" units="unitless"
              description="value assigned to indicate invalid thermal forcing value when config_ocean_data_extrapolation is set to true"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1310,6 +1310,9 @@ is the value of that variable from the *previous* time level!
                 <var name="floatingBasalMassBalApplied" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
                      description="Applied basal mass balance on floating regions"
                 />
+                <var name="connectedOceanMask" type="integer" dimensions="nCells Time" units=""
+                        description="grid cells below sea level and without grounded ice connected to open ocean (i.e., open ocean plus ice shelves ignoring floating ice over subglacial lakes).  0=no, 1=yes"
+                />
                 <var name="calvingMask" type="integer" dimensions="nCells Time" units="" time_levs="1"
                         description="mask of grid cells that should be calved.  0=no calving, 1=should be calved"
                 />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4708,7 +4708,7 @@ module li_calving
 
          ! update count of cells added to mask globally
          call mpas_dmpar_sum_int(domain % dminfo, newMaskCountLocalAccum, newMaskCountGlobal)
-         call mpas_log_write("  Added $i new cells to global mask", intArgs=(/newMaskCountGlobal/))
+         !call mpas_log_write("  Added $i new cells to global mask", intArgs=(/newMaskCountGlobal/))
 
          if (globalLoopCount>200) then
             call mpas_log_write("Too many global loops!", MPAS_LOG_ERR)
@@ -4716,7 +4716,7 @@ module li_calving
       end do ! global loop
       deallocate(seedMaskOld)
 
-      call mpas_log_write("Flood fill complete.")
+      call mpas_log_write("Flood fill complete in $i iterations", intArgs=(/newMaskCountGlobal/))
 
    end subroutine li_flood_fill
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -277,6 +277,8 @@ module li_iceshelf_melt
            lowerSurface,             & ! lower surface elevation (m)
            bedTopography               ! bed topography (m; negative below sea level)
 
+      integer, dimension(:), pointer :: connectedOceanMask
+
       real(kind=RKIND), pointer :: daysSinceStart
 
       integer :: iCell, jCell, iEdge, iNeighbor, err_tmp
@@ -356,6 +358,38 @@ module li_iceshelf_melt
             call mpas_log_write('GLdepth=$r, CFdepth=$r', realArgs=(/GLdepth, CFdepth/))
          endif
       endif
+
+      ! Allocate scratch fields for flood-fill
+      ! Note: This only supports one block per processor
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
+      call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
+      call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
+      seedMask => seedMaskField % array
+      seedMask(:) = 0
+      call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
+      call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
+      growMask => growMaskField % array
+      growMask(:) = 0
+
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
+      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
+      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
+      call mpas_pool_get_array(geometryPool, 'connectedOceanMask', connectedOceanMask)
+      do iCell = 1, nCells
+         if ( (.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) then
+              seedMask(iCell) = 1
+         else if ( li_mask_is_floating_ice(cellMask(iCell)) ) then
+              growMask(iCell) = 1
+         end if
+      end do
+      call li_flood_fill(seedMask, growMask, domain)
+      connectedOceanMask = seedMask
+      ! deallocate scratch fields used for flood fill
+      call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
+      call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
 
       if (trim(config_basal_mass_bal_float) == 'ismip6') then
          call iceshelf_melt_ismip6(domain, err_tmp)
@@ -506,39 +540,8 @@ module li_iceshelf_melt
 
       endif
 
-      ! Allocate scratch fields for flood-fill
-      ! Note: This only supports one block per processor
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'scratch', scratchPool)
-      call mpas_pool_get_field(scratchPool, 'seedMask', seedMaskField)
-      call mpas_allocate_scratch_field(seedMaskField, single_block_in = .true.)
-      seedMask => seedMaskField % array
-      seedMask(:) = 0
-      call mpas_pool_get_field(scratchPool, 'growMask', growMaskField)
-      call mpas_allocate_scratch_field(growMaskField, single_block_in = .true.)
-      growMask => growMaskField % array
-      growMask(:) = 0
-
       ! Prevent sub-shelf melt in subglacial lakes
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'geometry', geometryPool)
-      call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)
-      call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
-      call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
-      call mpas_pool_get_array(geometryPool, 'floatingBasalMassBal', floatingBasalMassBal)
-      call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      do iCell = 1, nCells
-         if ( (.not. li_mask_is_ice(cellMask(iCell))) .and. (bedTopography(iCell) < config_sea_level) ) then
-              seedMask(iCell) = 1
-         else if ( li_mask_is_floating_ice(cellMask(iCell)) ) then
-              growMask(iCell) = 1
-         end if
-      end do
-      call li_flood_fill(seedMask, growMask, domain)
-
-      floatingBasalMassBal(:) = floatingBasalMassBal(:) * seedMask(:)
-
-      ! deallocate scratch fields used for flood fill
-      call mpas_deallocate_scratch_field(seedMaskField, single_block_in=.true.)
-      call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
+      floatingBasalMassBal(:) = floatingBasalMassBal(:) * connectedOceanMask(:)
 
       if (trim(config_front_mass_bal_grounded) .ne. 'none') then
          block => domain % blocklist
@@ -1204,6 +1207,7 @@ module li_iceshelf_melt
       real (kind=RKIND), pointer :: gamma0
       real (kind=RKIND), dimension(:), pointer :: floatingBasalMassBal
       real (kind=RKIND), dimension(:), pointer :: bedTopography
+      integer, dimension(:), pointer :: connectedOceanMask
       real (kind=RKIND) :: coef
       integer :: i
 
@@ -1249,6 +1253,7 @@ module li_iceshelf_melt
          call mpas_pool_get_array(geometryPool, 'lowerSurface', lowerSurface)
          call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
          call mpas_pool_get_array(meshPool, 'areaCell', areaCell)
+         call mpas_pool_get_array(geometryPool, 'connectedOceanMask', connectedOceanMask)
 
          ! Get TFdraft field that we will calculate
          call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_TFdraft', TFdraft)
@@ -1270,7 +1275,7 @@ module li_iceshelf_melt
 
          do iCell = 1, nCellsSolve
 
-            if ( li_mask_is_floating_ice(cellMask(iCell)) ) then
+            if ( li_mask_is_floating_ice(cellMask(iCell)) .and. (connectedOceanMask(iCell) == 1)) then
                ! 1 -  Linear interpolation of the thermal forcing on the ice draft depth :
                ksup=0
                do kk=1,nOceanLayers
@@ -1363,7 +1368,7 @@ module li_iceshelf_melt
          floatingBasalMassBal(:) = 0.0_RKIND
          coef = gamma0 * cste / scyr * rhoi
          do iCell = 1, nCellsSolve
-            if ( li_mask_is_floating_ice(cellMask(iCell)) ) then
+            if ( li_mask_is_floating_ice(cellMask(iCell)) .and. (connectedOceanMask(iCell) == 1)) then
                floatingBasalMassBal(iCell) = -1.0_RKIND * coef * (TFdraft(iCell) + deltaT(iCell)) * &
                   abs(mean_TF(basinNumber(iCell)+1) + deltaT(iCell)) + ismip6shelfMelt_offset(iCell)
             endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_iceshelf_melt.F
@@ -1462,6 +1462,8 @@ module li_iceshelf_melt
       real (kind=RKIND), pointer :: invalid_value_TF
       logical :: validTF
       logical, pointer :: config_calculate_thermal_forcing
+      logical, pointer :: config_ocean_data_extrapolation
+      integer, pointer :: config_ocean_data_extrap_ncells_extra
       real (kind=RKIND) :: dzAccumulated, dz
       integer :: err_tmp, kk, iLayer
 
@@ -1515,6 +1517,18 @@ module li_iceshelf_melt
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zOcean', zOcean)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_deltaT', ismip6shelfMelt_deltaT)
             call mpas_pool_get_array(geometryPool, 'ismip6shelfMelt_zBndsOcean', zBndsOcean)
+
+            ! Check for option incompatibility - apply_ablation routine needs valid faceMeltSpeed 3 rows back
+            call mpas_pool_get_config(liConfigs, 'config_ocean_data_extrapolation', config_ocean_data_extrapolation)
+            call mpas_pool_get_config(liConfigs, 'config_ocean_data_extrap_ncells_extra', config_ocean_data_extrap_ncells_extra)
+            if (config_ocean_data_extrapolation .and. (config_ocean_data_extrap_ncells_extra < 3)) then
+               call mpas_log_write("If config_front_mass_bal_grounded='ismip6', config_use_3d_thermal_forcing_for_face_melt=.true., " // &
+                                   "and config_ocean_data_extrapolation=.true., " // &
+                                   "then config_ocean_data_extrap_ncells_extra must be >= 3", MPAS_LOG_ERR)
+               err = ior(err, 1)
+               return
+            endif
+
 
                !Consolidate 3d profile to 2d depending on parameterization type
                if (config_TF_vertical_calc == 'average' ) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -127,7 +127,7 @@ contains
       if ( config_ocean_data_extrapolation ) then
 
          ! call the extrapolation scheme
-         call mpas_log_write('ocean data will be extrapolated into the MALI ice draft')
+         call mpas_log_write('Beginning ocean data extrapolation')
          block => domain % blocklist
 
         ! initialize the ocean data and mask fields
@@ -534,6 +534,7 @@ contains
          deallocate(alteredCells)
          call mpas_deallocate_scratch_field(growMaskField, single_block_in=.true.)
          
+         call mpas_log_write('Ocean data extrapolation complete')
       endif
    !--------------------------------------------------------------------
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -1636,7 +1636,7 @@ module li_time_integration_fe_rk
       currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, err_tmp)
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
       err = ior(err, err_tmp)
-      call mpas_log_write('  Completed timestep.  New time is: ' // trim(timeStamp), flushNow=.true.)
+      call mpas_log_write('Model time updated to: ' // trim(timeStamp), flushNow=.true.)
 
       block => domain % blocklist
       do while (associated(block))


### PR DESCRIPTION
This merge introduces fixed to improve robustness of thermal forcing being used for ice-shelf basal melting and facemelting:
* Remove subglacial lakes (floating ice not connected to the open ocean) from the calculation of mean thermal forcing used by the ismip6 ice-shelf basal melt parameterization
* ensure that ocean extrapolation uses at least 3 extra cells to avoid facemelting potentially accessing cells where faceMeltSpeed is calculated from bad data
* minor incidental log file cleanup