### PR TITLE
Fix missing Makefile dependency

### DIFF
--- a/components/mpas-albany-landice/src/shared/Makefile
+++ b/components/mpas-albany-landice/src/shared/Makefile
@@ -20,7 +20,7 @@ mpas_li_mesh.o:
 
 mpas_li_config.o:
 
-mpas_li_time_average_coupled.o:
+mpas_li_time_average_coupled.o: mpas_li_setup.o
 
 clean:
 	$(RM) *.o *.mod *.f90


### PR DESCRIPTION
Standalone MALI builds fail if invoked in parallel because of this missing dependency.  Serial builds don't expose it.
