### PR TITLE
Introduce output variables oceanTemperatureApplied and oceanSalinityApplied

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1805,6 +1805,12 @@ is the value of that variable from the *previous* time level!
                 <var name="oceanSalinity" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="g/kg"
                      description="ocean salinity to be extrapolated to all grounding lines if config_calcuate_thermal_forcing is true."
                 />
+                <var name="oceanTemperatureApplied" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="C"
+                     description="The actual ocean potential temperature used to calculate thermal forcing after extrapolation."
+                />
+                <var name="oceanSalinityApplied" type="real" dimensions="nISMIP6OceanLayers nCells Time" units="g/kg"
+                     description="The actual ocean salinity used to calculate thermal forcing after extrapolation."
+                />
                 <var name="icebergFjordMask" type="integer" dimensions="nCells Time" default_value="0"
                      description="Binary mask depicting where to parameterize iceberg melt-driven cooling if using config_TF_iceberg_melt = mask. 1 parameterizes iceberg melt-driven cooling at that cell, 0 indicates no iceberg-related alteration."
 		/>

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -107,6 +107,7 @@ contains
       integer, dimension(:,:), pointer :: validOceanMask, validOceanMaskOrig, availOceanMask !masks to pass to flood-fill routine
       integer, dimension(:), pointer :: seedOceanMaskHoriz, growOceanMaskHoriz
       real (kind=RKIND), dimension(:,:), pointer :: oceanSalinity, oceanTemperature
+      real (kind=RKIND), dimension(:,:), pointer :: oceanSalinityApplied, oceanTemperatureApplied
       integer, dimension(:), allocatable :: seedOceanMaskHorizOld
       integer, pointer :: nCells, nCellsSolve, nISMIP6OceanLayers, nCellsExtra
       integer, dimension(:), pointer :: cellMask, nEdgesOnCell
@@ -162,6 +163,8 @@ contains
          if (config_calculate_thermal_forcing) then
             call mpas_pool_get_array(extrapOceanDataPool, 'oceanTemperature', oceanTemperature)
             call mpas_pool_get_array(extrapOceanDataPool, 'oceanSalinity', oceanSalinity)
+            call mpas_pool_get_array(extrapOceanDataPool, 'oceanSalinityApplied', oceanSalinityApplied)
+            call mpas_pool_get_array(extrapOceanDataPool, 'oceanTemperatureApplied', oceanTemperatureApplied)
          endif
 
          ! check parameterization compatibility. TF_vertical_calc = '200-500'
@@ -523,9 +526,16 @@ contains
                   enddo
                endif
             enddo
+            
+            ! Assign 'applied' ocean t/s, otherwise original fields will be
+            ! clobbered by input file each time step
+
+            oceanSalinityApplied = oceanSalinity
+            oceanTemperatureApplied = oceanTemperature
+
             call mpas_timer_start("halo_updates")
-            call mpas_dmpar_field_halo_exch(domain,'oceanSalinity')
-            call mpas_dmpar_field_halo_exch(domain,'oceanTemperature')
+            call mpas_dmpar_field_halo_exch(domain,'oceanSalinityApplied')
+            call mpas_dmpar_field_halo_exch(domain,'oceanTemperatureApplied')
             call mpas_dmpar_field_halo_exch(domain,'ismip6shelfMelt_3dThermalForcing')
             call mpas_dmpar_field_halo_exch(domain,'growMask')
             call mpas_timer_stop("halo_updates")


### PR DESCRIPTION
Introduces two new output variables, oceanTemperatureApplied and oceanSalinityApplied, which are the extrapolated ocean T/S used to calculate thermal forcing. Previously, input variables oceanTemperature and oceanSalinity clobbered extrapolated T/S fields in the output file if input/output names were the same.