### PR TITLE
Add subglacial hydrology transition flow law

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -33,6 +33,14 @@
 'overburden' assumes water pressure is always equal to ice overburden pressure."
 		            possible_values="'cavity', 'overburden'"
                 />
+		<nml_option name="config_SGH_transition_flow" type="logical" default_value=".false." units="unitless"
+		            description="Whether to use the transition flow law for distributed flow from Hill et al. (2024) (https://doi.org/10.1017/jog.2023.103).  If true, config_SGH_beta is ignored and a value of 1.5 is used for the turbulent flow regime and 2 is used for laminar flow regime in the transition law.  Also, if true, a value of 3 is used for config_SGH_alpha in the laminar regime, while the specified value for config_SGH_alpha is used for the turbulent regime.  These choices follow Hill et al. (Sec. 2.2.1)."
+		            possible_values=".true. or .false."
+		/>
+		<nml_option name="config_SGH_flow_transition_param" type="real" default_value="0.0005" units="unitless"
+		            description="laminar-turbulent transition parameter used when config_SGH_transition_flow=.true., defined as one over the Reynolds number controlling the transition between laminar and turbulent flow.  Default value of 0.0005 corresponds to Reynolds number of 2000, which is a standard transition value."
+		            possible_values="positive real number"
+		/>
 		<nml_option name="config_SGH_alpha" type="real" default_value="1.25" units="unitless"
 		            description="power of alpha parameter in subglacial water flux formula"
 		            possible_values="positive real number"
@@ -42,7 +50,7 @@
 		            possible_values="positive real number"
 		/>
 		<nml_option name="config_SGH_conduc_coeff" type="real" default_value="0.001" units="m^(2*beta-alpha) s^(2*beta-3) kg^(1-beta)"
-		            description="conductivity coefficient for subglacial water flux"
+		            description="conductivity coefficient for subglacial water flux.  Units are Pa s^(-1) when using the transition flow law."
 		            possible_values="positive real number"
 		/>
 		<nml_option name="config_SGH_conduc_coeff_drowned" type="real" default_value="0.0" units="m^(2*beta-alpha) s^(2*beta-3) kg^(1-beta)"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -899,10 +899,12 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: alpha, beta
       real (kind=RKIND), pointer :: conduc_coeff
       real (kind=RKIND), pointer :: conduc_coeff_drowned
+      real (kind=RKIND), pointer :: flow_transition_param
       real (kind=RKIND), pointer :: bedRoughMax
       real (kind=RKIND), dimension(:), allocatable :: conduc_coeff_wtd
       character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
       logical, pointer :: config_SGH_allow_terrestrial_outflow
+      logical, pointer :: config_SGH_transition_flow
       real (kind=RKIND), pointer :: config_sea_level
       real (kind=RKIND), pointer :: rhoo
       integer, pointer :: nEdges
@@ -931,12 +933,14 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_beta', beta)
       call mpas_pool_get_config(liConfigs, 'config_SGH_conduc_coeff', conduc_coeff)
       call mpas_pool_get_config(liConfigs, 'config_SGH_conduc_coeff_drowned', conduc_coeff_drowned)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_transition_flow', config_SGH_transition_flow)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_flow_transition_param', flow_transition_param)
       call mpas_pool_get_config(liConfigs, 'config_SGH_bed_roughness_max', bedRoughMax)
       call mpas_pool_get_config(liConfigs, 'config_SGH_tangent_slope_calculation', config_SGH_tangent_slope_calculation)
       call mpas_pool_get_config(liConfigs, 'config_SGH_allow_terrestrial_outflow', config_SGH_allow_terrestrial_outflow)
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_ocean_density', rhoo)
-      
+
       call mpas_pool_get_array(hydroPool, 'waterThickness', waterThickness)
       call mpas_pool_get_array(hydroPool, 'waterPressure', waterPressure)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
@@ -1156,10 +1160,25 @@ module li_subglacial_hydro
       endif
 
       ! Calculate effectiveConducEdge now that we have determined the conductivity coefficient
-      do iEdge = 1, nEdges
-         effectiveConducEdge(iEdge) = conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-            gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
-      end do
+      if (config_sgh_transition_flow) then
+         ! Transition flow law from Hill et al. (2024), https://doi.org/10.1017/jog.2023.103
+         do iEdge = 1, nEdges
+            effectiveConducEdge(iEdge) = kin_visc_water / (2.0_RKIND * flow_transition_param) * &
+               (waterThicknessEdge(iEdge) / bedRoughMax)** &
+               ((-2.0_RKIND + 2.0_RKIND * alpha) / (3.0_RKIND - 2.0_RKIND * alpha)) &
+               * &
+               (-1.0_RKIND + sqrt(1.0_RKIND + 4.0_RKIND * (flow_transition_param / kin_visc_water) * &
+               (waterThicknessEdge(iEdge) / bedRoughMax)**(3.0_RKIND - 2.0_RKIND * alpha) * &
+               conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**3 * gradMagPhiBaseEdge(iEdge))) / &
+               gradMagPhiBaseEdge(iEdge)
+         end do
+      else
+         ! Traditional flow law (laminar or turbulent)
+         do iEdge = 1, nEdges
+            effectiveConducEdge(iEdge) = conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
+               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
+         end do
+      endif
       deallocate(conduc_coeff_wtd)
 
       ! Apply some thresholding of small values

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -900,7 +900,7 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: conduc_coeff
       real (kind=RKIND), pointer :: conduc_coeff_drowned
       real (kind=RKIND), pointer :: bedRoughMax
-      real (kind=RKIND) :: conduc_coeff_wtd
+      real (kind=RKIND), dimension(:), allocatable :: conduc_coeff_wtd
       character (len=StrKIND), pointer :: config_SGH_tangent_slope_calculation
       logical, pointer :: config_SGH_allow_terrestrial_outflow
       real (kind=RKIND), pointer :: config_sea_level
@@ -1143,24 +1143,26 @@ module li_subglacial_hydro
       gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 + hydropotentialBaseSlopeTangent**2)
 
       ! calculate effective conductivity on edges
+      allocate(conduc_coeff_wtd(nEdges + 1))
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
          do iEdge = 1, nEdges
-            conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
+            conduc_coeff_wtd(iEdge) = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
                conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
                (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
-
-            effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
-         end do
-      else
-         do iEdge = 1, nEdges
-            ! Just use a single conductivity coeff.
-            effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
-               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
          enddo
+      else
+         conduc_coeff_wtd(:) = conduc_coeff  ! constant value irrespective of water depth
       endif
 
+      ! Calculate effectiveConducEdge now that we have determined the conductivity coefficient
+      do iEdge = 1, nEdges
+         effectiveConducEdge(iEdge) = conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
+            gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
+      end do
+      deallocate(conduc_coeff_wtd)
+
+      ! Apply some thresholding of small values
       do iEdge = 1, nEdges
          if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
             effectiveConducEdge(iEdge) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1163,7 +1163,7 @@ module li_subglacial_hydro
       if (config_sgh_transition_flow) then
          ! Transition flow law from Hill et al. (2024), https://doi.org/10.1017/jog.2023.103
          do iEdge = 1, nEdges
-            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
+            if ((gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) .or. (waterThicknessEdge(iEdge) <= 0.0_RKIND)) then
                effectiveConducEdge(iEdge) = 0.0_RKIND
             else
                effectiveConducEdge(iEdge) = kin_visc_water / (2.0_RKIND * flow_transition_param) * &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1167,9 +1167,8 @@ module li_subglacial_hydro
                effectiveConducEdge(iEdge) = 0.0_RKIND
             else
                effectiveConducEdge(iEdge) = kin_visc_water / (2.0_RKIND * flow_transition_param) * &
-                  (waterThicknessEdge(iEdge) / bedRoughMax)** &
-                  ((-2.0_RKIND + 2.0_RKIND * alpha) / (3.0_RKIND - 2.0_RKIND * alpha)) &
-                  * &
+                  bedRoughMax ** (3.0_RKIND - 2.0_RKIND * alpha) / &
+                  waterThicknessEdge(iEdge) ** (4.0_RKIND - 2.0_RKIND * alpha) * &
                   (-1.0_RKIND + sqrt(1.0_RKIND + 4.0_RKIND * (flow_transition_param / kin_visc_water) * &
                   (waterThicknessEdge(iEdge) / bedRoughMax)**(3.0_RKIND - 2.0_RKIND * alpha) * &
                   conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**3 * gradMagPhiBaseEdge(iEdge))) / &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1140,39 +1140,35 @@ module li_subglacial_hydro
       gradMagPhiEdge = sqrt(hydropotentialSlopeNormal**2 + hydropotentialSlopeTangent**2)
 
       ! calculate magnitude of gradient of hydropotentialBase
-      gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 +&
-      hydropotentialBaseSlopeTangent**2)
+      gradMagPhiBaseEdge = sqrt(hydropotentialBaseSlopeNormal**2 + hydropotentialBaseSlopeTangent**2)
 
       ! calculate effective conductivity on edges
       if (conduc_coeff_drowned > 0.0_RKIND) then
          ! Use a thickness weighted conductivity coeff. when water thickness exceeds bump height
          do iEdge = 1, nEdges
-            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
-               effectiveConducEdge(iEdge) = 0.0_RKIND
-            else
-               conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
-                  conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
-                  (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
+            conduc_coeff_wtd = (conduc_coeff * min(waterThicknessEdge(iEdge), bedRoughMax) + &
+               conduc_coeff_drowned * max(waterThicknessEdge(iEdge) - bedRoughMax, 0.0_RKIND)) / &
+               (waterThicknessEdge(iEdge) + 1.0e-16_RKIND)  ! Regularization only applies where value doesn't matter
 
-               effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-                  gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
-            endif
+            effectiveConducEdge(iEdge) = conduc_coeff_wtd * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
+               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
          end do
       else
          do iEdge = 1, nEdges
             ! Just use a single conductivity coeff.
-            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
-               effectiveConducEdge(iEdge) = 0.0_RKIND
-            else
-               effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
-                  gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
-            endif
+            effectiveConducEdge(iEdge) = conduc_coeff * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) *&
+               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
          enddo
       endif
 
-      where (effectiveConducEdge < SMALL_CONDUC)
-              effectiveConducEdge = 0.0_RKIND
-      end where
+      do iEdge = 1, nEdges
+         if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
+            effectiveConducEdge(iEdge) = 0.0_RKIND
+         endif
+         if (effectiveConducEdge(iEdge) < SMALL_CONDUC) then
+              effectiveConducEdge(iEdge) = 0.0_RKIND
+         endif
+      enddo
 
       ! calculate diffusivity on edges
       diffusivity(:) = rho_water * gravity * effectiveConducEdge(:) * waterThicknessEdge(:)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -1163,29 +1163,34 @@ module li_subglacial_hydro
       if (config_sgh_transition_flow) then
          ! Transition flow law from Hill et al. (2024), https://doi.org/10.1017/jog.2023.103
          do iEdge = 1, nEdges
-            effectiveConducEdge(iEdge) = kin_visc_water / (2.0_RKIND * flow_transition_param) * &
-               (waterThicknessEdge(iEdge) / bedRoughMax)** &
-               ((-2.0_RKIND + 2.0_RKIND * alpha) / (3.0_RKIND - 2.0_RKIND * alpha)) &
-               * &
-               (-1.0_RKIND + sqrt(1.0_RKIND + 4.0_RKIND * (flow_transition_param / kin_visc_water) * &
-               (waterThicknessEdge(iEdge) / bedRoughMax)**(3.0_RKIND - 2.0_RKIND * alpha) * &
-               conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**3 * gradMagPhiBaseEdge(iEdge))) / &
-               gradMagPhiBaseEdge(iEdge)
+            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
+               effectiveConducEdge(iEdge) = 0.0_RKIND
+            else
+               effectiveConducEdge(iEdge) = kin_visc_water / (2.0_RKIND * flow_transition_param) * &
+                  (waterThicknessEdge(iEdge) / bedRoughMax)** &
+                  ((-2.0_RKIND + 2.0_RKIND * alpha) / (3.0_RKIND - 2.0_RKIND * alpha)) &
+                  * &
+                  (-1.0_RKIND + sqrt(1.0_RKIND + 4.0_RKIND * (flow_transition_param / kin_visc_water) * &
+                  (waterThicknessEdge(iEdge) / bedRoughMax)**(3.0_RKIND - 2.0_RKIND * alpha) * &
+                  conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**3 * gradMagPhiBaseEdge(iEdge))) / &
+                  gradMagPhiBaseEdge(iEdge)
+            endif
          end do
       else
          ! Traditional flow law (laminar or turbulent)
          do iEdge = 1, nEdges
-            effectiveConducEdge(iEdge) = conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
-               gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
+            if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
+               effectiveConducEdge(iEdge) = 0.0_RKIND
+            else
+               effectiveConducEdge(iEdge) = conduc_coeff_wtd(iEdge) * waterThicknessEdge(iEdge)**(alpha-1.0_RKIND) * &
+                  gradMagPhiBaseEdge(iEdge)**(beta - 2.0_RKIND)
+            endif
          end do
       endif
       deallocate(conduc_coeff_wtd)
 
       ! Apply some thresholding of small values
       do iEdge = 1, nEdges
-         if (gradMagPhiBaseEdge(iEdge) < SMALL_GRADPHI) then
-            effectiveConducEdge(iEdge) = 0.0_RKIND
-         endif
          if (effectiveConducEdge(iEdge) < SMALL_CONDUC) then
               effectiveConducEdge(iEdge) = 0.0_RKIND
          endif

--- a/components/mpas-albany-landice/src/shared/mpas_li_constants.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_constants.F
@@ -52,7 +52,7 @@ module li_constants
 
 #endif
 
-   real (kind=RKIND), parameter, public :: kin_visc_water = 1.793e-6_RKIND  !< kinematic viscosity of freshwater at 0 deg C (m s^-2)
+   real (kind=RKIND), parameter, public :: kin_visc_water = 1.793e-6_RKIND  !< kinematic viscosity of freshwater at 0 deg C (m^2 s^-1)
    real (kind=RKIND), parameter, public :: idealGasConstant = 8.314_RKIND  !< ideal gas constant (J mol^-1 K^-1)
    real (kind=RKIND), parameter, public :: iceConductivity = 2.1_RKIND  !< thermal conductivity of ice (W m^-1 K^-1)
 

--- a/components/mpas-albany-landice/src/shared/mpas_li_constants.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_constants.F
@@ -52,6 +52,7 @@ module li_constants
 
 #endif
 
+   real (kind=RKIND), parameter, public :: kin_visc_water = 1.793e-6_RKIND  !< kinematic viscosity of freshwater at 0 deg C (m s^-2)
    real (kind=RKIND), parameter, public :: idealGasConstant = 8.314_RKIND  !< ideal gas constant (J mol^-1 K^-1)
    real (kind=RKIND), parameter, public :: iceConductivity = 2.1_RKIND  !< thermal conductivity of ice (W m^-1 K^-1)
 


### PR DESCRIPTION
This PR adds the laminar/turbulent transition flow law described by Hill et al. (2024) (https://doi.org/10.1017/jog.2023.103) to MALI's subglacial hydrology model.  This flow law transitions between laminar and turbulent flow equations based on the Reynolds number of the flow.  It uses Hill et al. Eq. S.7 (from supplemental material) for distributed discharge to redefine the effective conductivity term used in MALI's hydrology model.  Some minor refactoring is also done to make this new option coexist with other flow-related options more easily. 