### PR TITLE
Make melt-based calving multiplier and crevasse water depth spatially varying

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -239,6 +239,10 @@
 			description="the slope used to calculate the strain-rate enhancement multiplier from faceMeltSpeed.  Implied values from Ma and Bassis (2018) range from approximately -0.5 to 10.0. 0.0 yields a factor of 1.0"
 			possible_values="any real value"
 		/>
+		<nml_option name="config_calving_strainrate_scaling_source" type="character" default_value="scalar" units="unitless"
+			description="Source of strain-rate multiplier for iceberg calving. Only currently supported for the crevasse-depth calving law."
+			possible_values-"'data' (read from input file), 'scalar' (specified by config_calving_strainrate_scaling)"
+		/>
 		<nml_option name="config_grounded_von_Mises_threshold_stress" type="real" default_value="1.0e6" units="Pa"
 			    description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on grounded ice. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."
 			    possible_values="Any positive real value"
@@ -819,6 +823,7 @@
                         <var name="eigencalvingParameter"/>
                         <var name="groundedVonMisesThresholdStress"/>
                         <var name="floatingVonMisesThresholdStress"/>
+                        <var name="calvingStrainRateScaling"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <var name="upliftRate"/>
@@ -919,6 +924,7 @@
                         <var name="eigencalvingParameter"/>
                         <var name="groundedVonMisesThresholdStress"/>
                         <var name="floatingVonMisesThresholdStress"/>
+                        <var name="calvingStrainRateScaling"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <!-- calvingCFLdt only needed if calving CFL is being applied, but it is a scalar value so no harm in including it always -->
@@ -1362,6 +1368,9 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="floatingVonMisesThresholdStress" type="real" dimensions="nCells Time" units="Pa" time_levs="1"
                      description="Threshold stress for von Mises calving from floating ice."
+                />
+                <var name="calvingStrainRateScaling" type="real" dimensions="nCells Time" units="per (m/d)" time_levs="1"
+                     description="Scaling factor on crevasse depth based on face-melting rate."
                 />
                 <var name="calvingVelocity" type="real" dimensions="nCells Time" units="m s^-1" time_levs="1"
                      description="rate of calving front retreat due to calving, represented as a velocity normal to the calving front (in the x-y plane)."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -309,7 +309,7 @@
                 />
                 <nml_option name="config_smb_fraction_to_water_depth" type="real" default_value="1.0" units="unitless"
                             description="Fraction of surface mass balance to convert to retain as water depth in crevasses for Nick et al. (2010) crevasse depth calving law."
-                            possible_values="a real value between 0 and 1"
+                            possible_values="any non-negative real value"
                 />
                 <nml_option name="config_ismip6_retreat_k" type="real" default_value="-170.0" units="m (m^3 s^-1)^-0.4 deg. C^-1"
                             description="Coefficient for ISMIP6 retreat parameterization from Slater et al. (2019)"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -828,6 +828,7 @@
                         <var name="groundedVonMisesThresholdStress"/>
                         <var name="floatingVonMisesThresholdStress"/>
                         <var name="calvingStrainRateScaling"/>
+						<var name="crevasseWaterDepth"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <var name="upliftRate"/>
@@ -929,6 +930,7 @@
                         <var name="groundedVonMisesThresholdStress"/>
                         <var name="floatingVonMisesThresholdStress"/>
                         <var name="calvingStrainRateScaling"/>
+						<var name="crevasseWaterDepth"/>
                         <var name="stiffnessFactor"/>
                         <var name="calvingMask"/>
                         <!-- calvingCFLdt only needed if calving CFL is being applied, but it is a scalar value so no harm in including it always -->

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -241,7 +241,7 @@
 		/>
 		<nml_option name="config_calving_strainrate_scaling_source" type="character" default_value="scalar" units="unitless"
 			description="Source of strain-rate multiplier for iceberg calving. Only currently supported for the crevasse-depth calving law."
-			possible_values-"'data' (read from input file), 'scalar' (specified by config_calving_strainrate_scaling)"
+			possible_values="'data' (read from input file), 'scalar' (specified by config_calving_strainrate_scaling)"
 		/>
 		<nml_option name="config_grounded_von_Mises_threshold_stress" type="real" default_value="1.0e6" units="Pa"
 			    description="Threshold von Mises stress value required for calving velocity to exceed ice velocity on grounded ice. sigma_max in Morlighem et al. (2016) eq. 4. 1 MPa default value is from Morlighem et al.'s calibration for Store Glacier."

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -301,11 +301,15 @@
 		/>
                 <nml_option name="config_crevasse_water_depth_source" type="character" default_value="scalar" units="unitless"
                             description="Source of water depth in crevasses for use with crevasse-depth calving law."
-                            possible_values="'data' (read from input file), 'scalar' (specified by config_crevasse_water_depth)"
+                            possible_values="'data' (read from input file), 'scalar' (specified by config_crevasse_water_depth), or 'scaled_smb' (a specific fraction of negative SMB)"
                 />
                 <nml_option name="config_crevasse_water_depth" type="real" default_value="0.0" units="m"
                             description="Water depth in crevasses for Nick et al. (2010) crevasse depth calving law."
                             possible_values="any non-negative real value"
+                />
+                <nml_option name="config_smb_fraction_to_water_depth" type="real" default_value="1.0" units="unitless"
+                            description="Fraction of surface mass balance to convert to retain as water depth in crevasses for Nick et al. (2010) crevasse depth calving law."
+                            possible_values="a real value between 0 and 1"
                 />
                 <nml_option name="config_ismip6_retreat_k" type="real" default_value="-170.0" units="m (m^3 s^-1)^-0.4 deg. C^-1"
                             description="Coefficient for ISMIP6 retreat parameterization from Slater et al. (2019)"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4075,8 +4075,9 @@ module li_calving
          ! Do nothing. This was already retrieved above.
       elseif (trim(config_crevasse_water_depth_source) == "scaled_smb") then
          where (sfcMassBalApplied < 0.0_RKIND)
-             crevasseWaterDepth = crevasseWaterDepth + -1.0_RKIND * config_smb_fraction_to_water_depth * &
-                                  sfcMassBalApplied / config_ice_density * deltat
+             crevasseWaterDepth = crevasseWaterDepth + &
+                 (-1.0_RKIND * config_smb_fraction_to_water_depth * &
+                 sfcMassBalApplied / config_ice_density * deltat)
          elsewhere
              crevasseWaterDepth = 0.0_RKIND
          endwhere
@@ -4760,7 +4761,7 @@ module li_calving
    subroutine calculate_facemelt_strainrate_enhancement(calvingStrainRateScaling, faceMeltSpeed, strainRateEnhancementForCalving)
       real(kind=RKIND), dimension(:), intent(in) :: faceMeltSpeed
       real(kind=RKIND), dimension(:), intent(out) :: strainRateEnhancementForCalving
-      real(kind=RKIND), dimension(:), intent(out) :: calvingStrainRateScaling
+      real(kind=RKIND), dimension(:), intent(inout) :: calvingStrainRateScaling
 
       ! local variables
       logical, pointer :: config_apply_facemelt_strainrate_enhancement

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4005,8 +4005,10 @@ module li_calving
                                                   calvingThickness, &
                                                   strainRateEnhancementForCalving, &
                                                   sfcMassBalApplied
+      real (kind=RKIND), pointer :: deltat  !< time step (s)
       real (kind=RKIND), pointer :: config_flowLawExponent, &
-                                    config_crevasse_water_depth
+                                    config_crevasse_water_depth, &
+                                    config_smb_fraction_to_water_depth
       real (kind=RKIND) :: dryCrevasseDepth, waterAvailable, eEff, &
                            tauMaxForCalving, meanA
 
@@ -4015,6 +4017,7 @@ module li_calving
 
       call mpas_pool_get_config(liConfigs, 'config_crevasse_water_depth', config_crevasse_water_depth)
       call mpas_pool_get_config(liConfigs, 'config_crevasse_water_depth_source', config_crevasse_water_depth_source)
+      call mpas_pool_get_config(liConfigs, 'config_smb_fraction_to_water_depth', config_smb_fraction_to_water_depth)
       call mpas_pool_get_config(liConfigs, 'config_flowParamA_calculation', config_flowParamA_calculation)
       call mpas_pool_get_config(liConfigs, 'config_flowLawExponent', config_flowLawExponent)
       call mpas_pool_get_config(liConfigs, 'config_ice_density', config_ice_density)
@@ -4029,6 +4032,7 @@ module li_calving
       call mpas_pool_get_subpool(domain % blocklist % structs, 'thermal', thermalPool)
 
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
+      call mpas_pool_get_array(meshPool, 'deltat', deltat)
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'layerThickness', layerThickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
@@ -4069,6 +4073,13 @@ module li_calving
          crevasseWaterDepth(:) = config_crevasse_water_depth
       elseif (trim(config_crevasse_water_depth_source) == "data") then
          ! Do nothing. This was already retrieved above.
+      elseif (trim(config_crevasse_water_depth_source) == "scaled_smb") then
+         where (sfcMassBalApplied < 0.0_RKIND)
+             crevasseWaterDepth = crevasseWaterDepth + -1.0_RKIND * config_smb_fraction_to_water_depth * &
+                                  sfcMassBalApplied / config_ice_density * deltat
+         elsewhere
+             crevasseWaterDepth = 0.0_RKIND
+         endwhere
       else
          call mpas_log_write("config_crevasse_water_depth_source must be set to either 'scalar' or 'data'.", MPAS_LOG_ERR)
          err = 1

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -139,7 +139,8 @@ module li_calving
 
       real (kind=RKIND), dimension(:), pointer :: calvingVelocity
       real (kind=RKIND), dimension(:), pointer :: faceMeltSpeed
-      real (kind=RKIND), dimension(:), pointer :: strainRateEnhancementForCalving
+      real (kind=RKIND), dimension(:), pointer :: strainRateEnhancementForCalving, &
+                                                  calvingStrainRateScaling
 
       real (kind=RKIND), dimension(:), pointer :: areaCell
 
@@ -194,7 +195,8 @@ module li_calving
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_array(geometryPool, 'faceMeltSpeed', faceMeltSpeed)
          call mpas_pool_get_array(geometryPool, 'strainRateEnhancementForCalving', strainRateEnhancementForCalving)
-         call calculate_facemelt_strainrate_enhancement(faceMeltSpeed, strainRateEnhancementForCalving)
+         call mpas_pool_get_array(geometryPool, 'calvingStrainRateScaling', calvingStrainRateScaling)
+         call calculate_facemelt_strainrate_enhancement(calvingStrainRateScaling, faceMeltSpeed, strainRateEnhancementForCalving)
 
          block => block % next
       end do
@@ -4744,24 +4746,31 @@ module li_calving
 !> from marine terminating glaciers. Journal of Geophysical Research: Earth Surface
 !-----------------------------------------------------------------------
 
-   subroutine calculate_facemelt_strainrate_enhancement(faceMeltSpeed, strainRateEnhancementForCalving)
+   subroutine calculate_facemelt_strainrate_enhancement(calvingStrainRateScaling, faceMeltSpeed, strainRateEnhancementForCalving)
       real(kind=RKIND), dimension(:), intent(in) :: faceMeltSpeed
       real(kind=RKIND), dimension(:), intent(out) :: strainRateEnhancementForCalving
+      real(kind=RKIND), dimension(:), intent(out) :: calvingStrainRateScaling
 
       ! local variables
       logical, pointer :: config_apply_facemelt_strainrate_enhancement
       real(kind=RKIND), pointer :: config_calving_strainrate_scaling
-
+      character (len=StrKIND), pointer :: config_calving_strainrate_scaling_source
 
       call mpas_pool_get_config(liConfigs, 'config_apply_facemelt_strainrate_enhancement', config_apply_facemelt_strainrate_enhancement)
       call mpas_pool_get_config(liConfigs, 'config_calving_strainrate_scaling', config_calving_strainrate_scaling)
+      call mpas_pool_get_config(liConfigs, 'config_calving_strainrate_scaling_source', config_calving_strainrate_scaling_source)
 
       if (config_apply_facemelt_strainrate_enhancement) then
-         strainRateEnhancementForCalving = 1.0_RKIND + faceMeltSpeed * 86400.0_RKIND * config_calving_strainrate_scaling
+         if (trim(config_calving_strainrate_scaling_source) == 'scalar') then
+            calvingStrainRateScaling(:) = config_calving_strainrate_scaling
+         else
+            ! do nothing
+         endif
+         strainRateEnhancementForCalving(:) = 1.0_RKIND + faceMeltSpeed(:) * 86400.0_RKIND * calvingStrainRateScaling(:)
          ! Don't allow negative multiplier
-         strainRateEnhancementForCalving = max(0.0_RKIND, strainRateEnhancementForCalving)
+         strainRateEnhancementForCalving(:) = max(0.0_RKIND, strainRateEnhancementForCalving(:))
       else
-         strainRateEnhancementForCalving = 1.0_RKIND
+         strainRateEnhancementForCalving(:) = 1.0_RKIND
       endif
 
    end subroutine calculate_facemelt_strainrate_enhancement

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4082,7 +4082,7 @@ module li_calving
              crevasseWaterDepth = 0.0_RKIND
          endwhere
       else
-         call mpas_log_write("config_crevasse_water_depth_source must be set to either 'scalar' or 'data'.", MPAS_LOG_ERR)
+         call mpas_log_write("config_crevasse_water_depth_source must be set to 'scalar', 'data', or 'scaled_smb'.", MPAS_LOG_ERR)
          err = 1
          return
       endif


### PR DESCRIPTION
This merge adds options to make the inputs to the crevasse-depth calving law vary in space and time. First, it allows for a spatially varying scaling parameter for the submarine melt-based multiplier on iceberg calving, which increases the strain rate used to calculate the deviatoric stress. Second, it adds an option to use a specified fraction of the surface mass balance to define the water depth in crevasses.