### PR TITLE
Initialize err variable in subglacial hydro routine

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2643,6 +2643,8 @@ module li_subglacial_hydro
       real (kind=RKIND) :: chnlGroundingLineDischargeEdge
       real (kind=RKIND) :: totalGroundingLineDischargeEdge
 
+      err = 0
+
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
       call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)


### PR DESCRIPTION
This uninitialized error code variable was sometimes causing model failures in optimized builds because it was getting initialized to nonzero values.  This merge fixes that bug.