### PR TITLE
Add constant and data options for flowA in hydrology model

### DIFF
--- a/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
+++ b/components/mpas-albany-landice/src/Registry_subglacial_hydro.xml
@@ -77,12 +77,19 @@
 		            description="notional englacial porosity"
 		            possible_values="positive real number"
 		/>
-		
 		<nml_option name="config_SGH_use_iceThicknessHydro" type="logical" default_value=".false." units="unitless"
 			    description="Option to use an altered ice thickness field called iceThicknessHydro that replaces local maxima/minima in upperSurface with a mean of the cells neighbors. This option has no significant effect on the behavior of the model but makes it more stable.  NOTE: Current implementation causes unrealistic bumps in thickness near the grounding line in many places, which prevents realistic outflow.  Enable this option with care."
 		            possible_values=".true. or .false."
 		/>
-	
+		<nml_option name="config_SGH_flowA_source" type="character" default_value="flowParamA"
+		            description="Source of flow parameter A for subglacial hydrology model.  'constant' is a spatially uniform value taken from option config_SGH_flowA_value.  'data' is the value read into the field 'flowAHydro', 'flowParamA' takes the basal value from the 'flowParamA' variable used in the ice dynamics in MALI."
+		            possible_values="'constant', 'data', 'flowParamA'"
+		/>
+		<nml_option name="config_SGH_flowA_value" type="real" default_value="3.1709792e-24" units="s^-1 Pa^-n"
+		            description="Flow parameter A value used by subglacial hydrology model when config_SGH_flowA_source is set to 'constant'. Defaults to the SI representation of 1.0e-16 yr^-1 Pa^-3."
+		            possible_values="positive real number"
+		/>
+
 	        <!-- channel options -->
                 <nml_option name="config_SGH_chnl_active" type="logical" default_value=".false." units="unitless"
 		            description="activate channels in subglacial hydrology model"
@@ -159,7 +166,9 @@
         <var_struct name="hydro" time_levs="1" packages="hydro">
                 <!-- state vars -->
 		<var name="iceThicknessHydro" type="real" dimensions="nCells Time" units="m"
-			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." /> 
+			description="ice thickness used by the hydrology model. Same as 'thickness' but with potential differences along domain boundaries that inhibit the formation of local hydropotential minima on boundaries." />
+		<var name="flowAHydro" type="real" dimensions="nCells Time" units="s^-1 Pa^-n" default_value="3.1709792e-24"
+                        description="flow parameter A value used by subglacial hydrology model" />
                 <var name="waterThickness" type="real" dimensions="nCells Time" units="m" default_value="0.01"
                      description="water layer thickness in subglacial hydrology system" />
                 <var name="waterThicknessOld" type="real" dimensions="nCells Time" units="m"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -284,6 +284,8 @@ module li_subglacial_hydro
       logical, pointer :: config_ocean_connection_N
       logical, pointer :: config_SGH_chnl_active
       character (len=StrKIND), pointer :: config_SGH_basal_melt
+      character (len=StrKIND), pointer :: config_SGH_flowA_source
+      real(kind=RKIND), pointer :: config_SGH_flowA_value
       type (block_type), pointer :: block
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: hydroPool
@@ -292,6 +294,7 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: velocityPool
       real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:,:), pointer :: temperature, flowParamA
+      real (kind=RKIND), dimension(:), pointer :: flowAHydro
       real (kind=RKIND), dimension(:), pointer :: Wtill, WtillOld
       real (kind=RKIND), dimension(:), pointer :: basalMeltInput
       real (kind=RKIND), dimension(:), pointer :: groundedBasalMassBal
@@ -325,6 +328,7 @@ module li_subglacial_hydro
       real (kind=RKIND), pointer :: tillMax
       integer, pointer :: nCellsSolve
       integer, pointer :: nCells
+      integer, pointer :: nVertLevels
       integer :: iCell, iEdge, iEdgeOnCell
       real (kind=RKIND) :: timeLeft ! subcycling time remaining until master dt is reached
       real (kind=RKIND) :: deltatSGHaccumulated
@@ -351,6 +355,7 @@ module li_subglacial_hydro
       call mpas_pool_get_config(liConfigs, 'config_SGH_till_drainage', Cd)
       call mpas_pool_get_config(liConfigs, 'config_SGH_till_max', tillMax)
       call mpas_pool_get_config(liConfigs, 'config_SGH_basal_melt', config_SGH_basal_melt)
+      call mpas_pool_get_config(liConfigs, 'config_SGH_flowA_source', config_SGH_flowA_source)
 
       block => domain % blocklist
       do while (associated(block))
@@ -358,15 +363,29 @@ module li_subglacial_hydro
          call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-         call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-         call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+         call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
 
          call calc_iceThicknessHydro(block, err_tmp)
          err = ior(err, err_tmp)
 
-         call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
-         err = ior(err, err_tmp)
+         call mpas_pool_get_array(hydroPool, 'flowAHydro', flowAHydro)
+         if (trim(config_SGH_flowA_source) == 'constant') then
+            call mpas_pool_get_config(liConfigs, 'config_SGH_flowA_value', config_SGH_flowA_value)
+            flowAHydro(:) = config_SGH_flowA_value
+         elseif (trim(config_SGH_flowA_source) == 'data') then
+            ! do nothing - use value already in flowAHydro
+         elseif (trim(config_SGH_flowA_source) == 'flowParamA') then
+            call mpas_pool_get_array(thermalPool, 'temperature', temperature)
+            call mpas_pool_get_array(geometryPool, 'thickness', thickness)
+            call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
+            call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
+            call li_calculate_flowParamA(meshPool, temperature, thickness, flowParamA, err_tmp)
+            err = ior(err, err_tmp)
+            flowAHydro(:) = flowParamA(nVertLevels, :)
+         else
+            err = ior(err, 1)
+            call mpas_log_write("Unknown value for 'config_SGH_flowA_source': " // trim(config_SGH_flowA_source), MPAS_LOG_ERR)
+         endif
 
          block => block % next
       end do
@@ -375,7 +394,7 @@ module li_subglacial_hydro
       call mpas_timer_start("halo updates")
       call mpas_dmpar_field_halo_exch(domain, 'iceThicknessHydro')
       call mpas_timer_stop("halo updates")
-      
+
       ! initialize while loop
       call mpas_pool_get_subpool(domain % blocklist % structs, 'mesh', meshPool)  ! can get from any block
       call mpas_pool_get_array(meshPool, 'deltat', masterDeltat)
@@ -384,7 +403,7 @@ module li_subglacial_hydro
 
       block => domain % blocklist
       do while (associated(block))
-        
+
          call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
          call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
          effectivePressure = 0.0_RKIND
@@ -1610,11 +1629,11 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: Wtill, WtillOld
       real (kind=RKIND), dimension(:), pointer :: divergence
       real (kind=RKIND), dimension(:), pointer :: basalSpeed
-      real (kind=RKIND), dimension(:,:), pointer :: flowParamA
+      real (kind=RKIND), dimension(:), pointer :: flowAHydro
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro      
+      real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: cellMask
       integer, dimension(:), pointer :: nEdgesOnCell
@@ -1677,7 +1696,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'channelAreaChangeCell', channelAreaChangeCell)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
-      call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
+      call mpas_pool_get_array(hydroPool, 'flowAHydro', flowAHydro)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)
@@ -1687,7 +1706,7 @@ module li_subglacial_hydro
       !   basalMeltInput(:) / rhoi  ! Hewitt 2011 opening
       openingRate = max(0.0_RKIND, openingRate)
 
-      closingRate(:) = creepCoeff * flowParamA(nVertLevels, :) * &
+      closingRate(:) = creepCoeff * flowAHydro(:) * &
               effectivePressureSGH(:)**3 * waterThickness(:)
 !      closingRate(:) = waterThickness(:) * effectivePressureSGH(:) / 1.0e13_RKIND
 !          ! Hewitt 2011 creep closure form.  Denominator is ice viscosity
@@ -1700,7 +1719,7 @@ module li_subglacial_hydro
       select case (trim(config_SGH_pressure_calc))
       case ('cavity')
 
-         where (li_mask_is_grounded_ice(cellMask))        
+         where (li_mask_is_grounded_ice(cellMask))
             waterPressure = (zeroOrderSum - divergence - divergenceChannel - channelAreaChangeCell) * &
                    rho_water * gravity * deltatSGH / porosity + waterPressureOld
          elsewhere ((.not. (li_mask_is_grounded_ice(cellMask))) .and. (bedTopography > config_sea_level))
@@ -1902,7 +1921,7 @@ module li_subglacial_hydro
       integer, dimension(:), pointer :: waterFluxMask
       integer, dimension(:), pointer :: hydroMarineMarginMask
       integer, dimension(:), pointer :: edgeMask
-      real (kind=RKIND), dimension(:,:), pointer :: flowParamA
+      real (kind=RKIND), dimension(:), pointer :: flowAHydro
       integer, dimension(:,:), pointer :: cellsOnEdge
       integer, pointer :: nVertLevels
       integer, pointer :: nEdgesSolve
@@ -1941,7 +1960,7 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'flowParamAChannel', flowParamAChannel)
       call mpas_pool_get_array(hydroPool, 'channelEffectivePressure', channelEffectivePressure)
       call mpas_pool_get_array(meshPool, 'cellsOnEdge', cellsOnEdge)
-      call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
+      call mpas_pool_get_array(hydroPool, 'flowAHydro', flowAHydro)
       call mpas_pool_get_array(hydroPool, 'effectivePressureSGH', effectivePressureSGH)
       call mpas_pool_get_array(hydroPool, 'waterFluxMask', waterFluxMask)
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
@@ -2012,7 +2031,7 @@ module li_subglacial_hydro
          cell2 = cellsOnEdge(2, iEdge)
 
          ! Not sure if these ought to be upwind average, but using centered
-         flowParamAChannel(iEdge) = 0.5_RKIND * (flowParamA(nVertLevels, cell1) + flowParamA(nVertLevels, cell2) )
+         flowParamAChannel(iEdge) = 0.5_RKIND * (flowAHydro(cell1) + flowAHydro(cell2))
          channelEffectivePressure(iEdge) = 0.5_RKIND * (effectivePressureSGH(cell1) + effectivePressureSGH(cell2))
       end do
       channelClosingRate(:) = creep_coeff * channelArea(:) * flowParamAChannel(:) * channelEffectivePressure(:)**3

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -107,7 +107,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: waterThickness
       real (kind=RKIND), dimension(:), pointer :: tillWaterThickness
       real (kind=RKIND), dimension(:), pointer :: waterPressure
-      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: bedTopography
       real (kind=RKIND), dimension(:), pointer :: iceThicknessHydro
       real (kind=RKIND), dimension(:), pointer :: hydropotential
@@ -185,8 +184,6 @@ module li_subglacial_hydro
          tillWaterThickness = max(0.0_RKIND, tillWaterThickness)
          tillWaterThickness = min(tillMax, tillWaterThickness)
 
-         call mpas_pool_get_array(geometryPool, 'thickness', thickness)
-         call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro) 
          call calc_iceThicknessHydro(block, err_tmp) !adjust ice thickness along boundaries
          err = ior(err,err_tmp)
          block => block % next
@@ -860,7 +857,6 @@ module li_subglacial_hydro
       type (mpas_pool_type), pointer :: geometryPool
       type (mpas_pool_type), pointer :: hydroPool
       real (kind=RKIND), dimension(:), pointer :: bedTopography
-      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBase
       real (kind=RKIND), dimension(:), pointer :: hydropotential
       real (kind=RKIND), dimension(:), pointer :: hydropotentialBaseVertex
@@ -942,7 +938,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydropotentialBase', hydropotentialBase)
       call mpas_pool_get_array(hydroPool, 'hydropotential', hydropotential)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(hydroPool, 'waterThicknessEdge', waterThicknessEdge)
       call mpas_pool_get_array(hydroPool, 'waterThicknessEdgeUpwind', waterThicknessEdgeUpwind)
       call mpas_pool_get_array(hydroPool, 'hydropotentialBaseSlopeNormal', hydropotentialBaseSlopeNormal)
@@ -1616,7 +1611,6 @@ module li_subglacial_hydro
       real (kind=RKIND), dimension(:), pointer :: divergence
       real (kind=RKIND), dimension(:), pointer :: basalSpeed
       real (kind=RKIND), dimension(:,:), pointer :: flowParamA
-      real (kind=RKIND), dimension(:), pointer :: thickness
       real (kind=RKIND), dimension(:), pointer :: divergenceChannel
       real (kind=RKIND), dimension(:), pointer :: channelAreaChangeCell
       real (kind=RKIND), dimension(:), pointer :: bedTopography
@@ -1684,7 +1678,6 @@ module li_subglacial_hydro
       call mpas_pool_get_array(hydroPool, 'hydroMarineMarginMask', hydroMarineMarginMask)
       call mpas_pool_get_array(velocityPool, 'basalSpeed', basalSpeed)
       call mpas_pool_get_array(velocityPool, 'flowParamA', flowParamA)
-      call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(hydroPool, 'iceThicknessHydro', iceThicknessHydro)


### PR DESCRIPTION
This PR adds two new options for the flow parameter A calculation used just by the subglacial hydrology model.  In addition to coming from the basal flowA field used by the ice dynamics part of MALI, it can now also be specified either as a constant scalar value or as data from a file.  There are good reasons to not necessarily want to use the same value of flow A for creep closure of subglacial conduits as for the large-scale deformation of ice.