### PR TITLE
Fix fragile upwind calculation when velocity is low

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -925,9 +925,9 @@ module li_subglacial_hydro
       integer, pointer :: nVertices
       integer :: iEdge, cell1, cell2
       integer :: i, j, iVertex, iCell
-      real (kind=RKIND) :: velSign
       integer :: numGroundedCells
       real(kind=RKIND), parameter :: SMALL_CONDUC = 1.0e-30_RKIND
+      real(kind=RKIND), parameter :: SMALL_VELOCITY = 1.0e-20_RKIND
       integer :: err_tmp
       
       err = 0
@@ -1195,9 +1195,16 @@ module li_subglacial_hydro
          cell1 = cellsOnEdge(1, iEdge)
          cell2 = cellsOnEdge(2, iEdge)
          waterVelocity(iEdge) = -1.0_RKIND * effectiveConducEdge(iEdge) * hydropotentialBaseSlopeNormal(iEdge)
-         velSign = sign(1.0_RKIND, waterVelocity(iEdge))
-         waterThicknessEdgeUpwind(iEdge) = max(velSign * waterThickness(cell1),   &
-                     velSign * (-1.0_RKIND) * waterThickness(cell2))
+
+
+         if (waterVelocity(iEdge) > SMALL_VELOCITY) then
+            waterThicknessEdgeUpwind(iEdge) = waterThickness(cell1)
+         elseif (waterVelocity(iEdge) < -SMALL_VELOCITY) then
+            waterThicknessEdgeUpwind(iEdge) = waterThickness(cell2)
+         else
+            waterThicknessEdgeUpwind(iEdge) = max(waterThickness(cell1), waterThickness(cell2))
+         endif
+
 
          ! advective flux
          waterFluxAdvec(iEdge) = waterVelocity(iEdge) * waterThicknessEdgeUpwind(iEdge)


### PR DESCRIPTION
This fix changes the determination of the upwind water thickness in situations where the velocity field is at or close to 0.  In such cases, the selection of which cell is upwind of an edge becomes arbitrary. This in turn means that the zeroing of flux when waterThicknessEdgeUpwind is zero can become arbitrary.  That leads to a possible grid imprinting related to edge-cell ordering.  This commit fixes this by making the upwind thickness when velocity is very small to be the max of the two thicknesses.  This simply ensures that any zeroing of fluxes is symmetric with respect to cell-edge ordering.  For situations with non-negligble velocity, this has no effect.
Bug identification and solution suggested by Copilot.