### PR TITLE
Debug config_TF_iceberg_melt for cells where icebergFjordMask is 0

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -951,7 +951,7 @@ contains
       
       ! Main difference between TF parameterization is how we collapse into 2d, which happens in mpas_li_ice_shelt_melt.F
       do iCell = 1, nCells
-         if (config_TF_iceberg_melt == 'off') then
+         if ( (config_TF_iceberg_melt == 'off') .or. ( (config_TF_iceberg_melt == 'mask') .and. (icebergFjordMask(iCell) == 0) ) ) then
 
             ! From Jenkins 2011 and Slater 2020
             do iLayer = 1, nISMIP6OceanLayers


### PR DESCRIPTION
This PR is a single commit to debug `config_TF_iceberg_melt = 'mask'`. The commit adds logic to assign TF where icebergFjordMask is 0. Otherwise these cells were zeroed out and TF is only assign for `icebergFjordMask == 1`.

This PR has been tested on the Uummannaq/Disko Bay mesh and works as intended.