### PR TITLE
Ensure all RK stages use the same masks

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -819,7 +819,7 @@ module li_core
       call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
       call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
       albanyVelocityError = 0
-      call li_velocity_solve(domain, solveVelo=solveVelo, err=err_tmp)
+      call li_velocity_solve(domain, solveVelo=solveVelo, updateMask=.true., err=err_tmp)
       err = ior(err, err_tmp)
 
       ! Initial calving solution

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -547,7 +547,7 @@ module li_time_integration_fe_rk
             cellMask(:) = cellMaskPrev(:)
             edgeMask(:) = edgeMaskPrev(:)
             vertexMask(:) = vertexMaskPrev(:)
-            call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+            call li_velocity_solve(domain, solveVelo=.true., updateMask=.false., err=err_tmp)
             err = ior(err, err_tmp)
          endif
 ! *** end RK loop ***
@@ -637,7 +637,7 @@ module li_time_integration_fe_rk
 
 ! === Solve velocity for final state =====================
       if (solveVeloAfterCalving) then
-         call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
+         call li_velocity_solve(domain, solveVelo=.true., updateMask=.true., err=err_tmp)
          err = ior(err, err_tmp)
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -671,6 +671,7 @@ module li_time_integration_fe_rk
       deallocate(groundedBasalMassBalAccum)
       deallocate(floatingBasalMassBalAccum)
       deallocate(fluxAcrossGroundingLineAccum)
+      deallocate(fluxAcrossGroundingLineOnCellsAccum)
       deallocate(calvingThicknessAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -146,7 +146,7 @@ module li_time_integration_fe_rk
                                                       fluxAcrossGroundingLineOnCellsAccum, &
                                                       calvingThicknessAccum
       real (kind=RKIND), dimension(:), pointer :: layerCenterSigma, layerThicknessFractions
-      integer, dimension(:), pointer :: cellMaskPrev  ! cell mask before advection
+      integer, dimension(:), allocatable :: cellMaskPrev, edgeMaskPrev, vertexMaskPrev  ! cell mask before advection
       real (kind=RKIND), dimension(:,:), allocatable :: layerThicknessPrev, &
                                                         layerThicknessTmp, &
                                                         temperaturePrev, &
@@ -156,10 +156,10 @@ module li_time_integration_fe_rk
                                                         damage3d, &
                                                         damage3dPrev
       integer, pointer :: nVertLevels
-      integer, pointer :: nCells, nEdges
+      integer, pointer :: nCells, nEdges, nVertices
       integer, pointer :: albanyVelocityError
       integer :: iCell1, iCell2, iEdge, theGroundedCell
-      integer, dimension(:), pointer :: edgeMask, cellMask
+      integer, dimension(:), pointer :: edgeMask, cellMask, vertexMask
       real (kind=RKIND), pointer :: deltat, config_ice_density
       real (kind=RKIND) :: deltatFull
       real (kind=RKIND), dimension(4) :: rkSubstepWeights
@@ -196,6 +196,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_dimension(meshPool, 'nVertLevels', nVertLevels)
       call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
+      call mpas_pool_get_dimension(meshPool, 'nVertices', nVertices)
 
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
       call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
@@ -220,6 +221,8 @@ module li_time_integration_fe_rk
       allocate(passiveTracer3dPrev(nVertLevels, nCells+1))
       allocate(passiveTracer3d(nVertLevels, nCells+1))
       allocate(cellMaskPrev(nCells+1))
+      allocate(edgeMaskPrev(nEdges+1))
+      allocate(vertexMaskPrev(nVertices+1))
 
       allocate(sfcMassBalAccum(nCells+1))
       allocate(basalMassBalAccum(nCells+1))
@@ -238,6 +241,8 @@ module li_time_integration_fe_rk
       damage3d(:,:) = 0.0_RKIND
       passiveTracer3dPrev(:,:) = 0.0_RKIND
       cellMaskPrev(:) = 0
+      edgeMaskPrev(:) = 0
+      vertexMaskPrev(:) = 0
       passiveTracer3d(:,:) = 0.0_RKIND
 
       sfcMassBalAccum(:) = 0.0_RKIND
@@ -293,6 +298,9 @@ module li_time_integration_fe_rk
       call mpas_pool_get_array(geometryPool, 'passiveTracer2d', passiveTracer2d)
       call mpas_pool_get_array(geometryPool, 'damage', damage)
       call mpas_pool_get_array(geometryPool, 'cellMask', cellMask)
+      call mpas_pool_get_array(geometryPool, 'edgeMask', edgeMask)
+      call mpas_pool_get_array(geometryPool, 'vertexMask', vertexMask, timeLevel=1)
+
 
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
@@ -301,6 +309,8 @@ module li_time_integration_fe_rk
       waterFracPrev(:,:) = waterFrac(:,:)
       layerThicknessPrev(:,:) = layerThickness(:,:)
       cellMaskPrev(:) = cellMask(:)
+      edgeMaskPrev(:) = edgeMask(:)
+      vertexMaskPrev(:) = vertexMask(:)
       do k = 1, nVertLevels
          damage3dPrev(k,:) = damage(:)
          passiveTracer3dPrev(k,:) = passiveTracer2d(:)
@@ -532,7 +542,11 @@ module li_time_integration_fe_rk
             ! This frequently results in icebergs that causes intermediate
             ! RK stage velocity solves to fail.
             call li_remove_icebergs(domain)
+            call mpas_log_write('Resetting masks')
 
+            cellMask(:) = cellMaskPrev(:)
+            edgeMask(:) = edgeMaskPrev(:)
+            vertexMask(:) = vertexMaskPrev(:)
             call li_velocity_solve(domain, solveVelo=.true., err=err_tmp)
             err = ior(err, err_tmp)
          endif
@@ -1281,7 +1295,6 @@ module li_time_integration_fe_rk
 
             call li_calculate_layerThickness(meshPool, thickness, layerThickness)
          endif
-
          call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          call li_update_geometry(geometryPool)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -663,6 +663,8 @@ module li_time_integration_fe_rk
       deallocate(passiveTracer3dPrev)
       deallocate(passiveTracer3d)
       deallocate(cellMaskPrev)
+      deallocate(edgeMaskPrev)
+      deallocate(vertexMaskPrev)
       deallocate(sfcMassBalAccum)
       deallocate(basalMassBalAccum)
       deallocate(groundedSfcMassBalAccum)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -333,7 +333,6 @@ contains
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
 
-         call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -222,7 +222,7 @@ contains
 !>  This routine calls velocity solvers.
 !
 !-----------------------------------------------------------------------
-   subroutine li_velocity_solve(domain, solveVelo, err)
+   subroutine li_velocity_solve(domain, solveVelo, updateMask, err)
 
       use mpas_vector_reconstruction
       use li_mask
@@ -236,6 +236,8 @@ contains
       !< velocity should be solved, or if an existing solution should be
       !< used to calculate the diagnostic fields related to velocty
       !< (e.g. on a restart)
+      logical, intent(in) :: updateMask !< Input: update mask before
+      !< velocity solve only if outside of RK loop.
 
       !-----------------------------------------------------------------
       ! input/output variables
@@ -331,7 +333,10 @@ contains
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-
+         ! Only update mask outside of RK loop
+         if ( updateMask ) then
+             call li_calculate_mask(meshPool, velocityPool, geometryPool, err_tmp)
+         endif
          call li_update_geometry(geometryPool)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -326,7 +326,6 @@ contains
       call mpas_dmpar_field_halo_exch(domain, 'thickness')
       call mpas_timer_stop("halo updates")
 
-      ! Update mask just to be safe (might be redundant)
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -354,7 +354,7 @@ contains
       ! ====
       ! Calculate cellMask values===========================
       ! ====
-      call mpas_log_write("Updating masks")
+      !call mpas_log_write("Updating masks")  ! Disabled to avoid excessive logging from shared routine
       !call mpas_timer_start('calculate mask cell')
       ! Set mask to 0 everywhere, but need to preserve bits the initial ice extent bit
       do i=1, nCells

--- a/components/mpas-albany-landice/src/shared/mpas_li_mask.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_mask.F
@@ -354,7 +354,7 @@ contains
       ! ====
       ! Calculate cellMask values===========================
       ! ====
-
+      call mpas_log_write("Updating masks")
       !call mpas_timer_start('calculate mask cell')
       ! Set mask to 0 everywhere, but need to preserve bits the initial ice extent bit
       do i=1, nCells


### PR DESCRIPTION
This merge removes unwanted intermediate mask updates before the velocity solve between stages when using Runge-Kutta time integration. It also resets masks to pre-advection values just before the velocity solve. This is necessary to preserve accuracy of the integration.