### PR TITLE
Fix error code bug preventing code abort

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -761,6 +761,7 @@ module li_core
       real(kind=RKIND) :: deltatTemp
 
       integer :: err, err_tmp, globalErr
+      integer, pointer :: albanyVelocityError
       logical :: solveVelo
 
       integer, dimension(:), pointer :: vertexMask
@@ -815,6 +816,9 @@ module li_core
       end do
 
       ! Initial velocity solve
+      call mpas_pool_get_subpool(domain % blocklist % structs, 'velocity', velocityPool)
+      call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
+      albanyVelocityError = 0
       call li_velocity_solve(domain, solveVelo=solveVelo, err=err_tmp)
       err = ior(err, err_tmp)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -157,6 +157,7 @@ module li_time_integration_fe_rk
                                                         damage3dPrev
       integer, pointer :: nVertLevels
       integer, pointer :: nCells, nEdges
+      integer, pointer :: albanyVelocityError
       integer :: iCell1, iCell2, iEdge, theGroundedCell
       integer, dimension(:), pointer :: edgeMask, cellMask
       real (kind=RKIND), pointer :: deltat, config_ice_density
@@ -197,6 +198,7 @@ module li_time_integration_fe_rk
       call mpas_pool_get_dimension(meshPool, 'nEdges', nEdges)
 
       call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
+      call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
       call mpas_pool_get_array(geometryPool, 'groundedToFloatingThickness', groundedToFloatingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingThickness', calvingThickness)
       call mpas_pool_get_array(geometryPool, 'calvingThicknessFromThreshold', calvingThicknessFromThreshold)
@@ -207,6 +209,7 @@ module li_time_integration_fe_rk
       calvingThickness(:) = 0.0_RKIND
       calvingThicknessFromThreshold(:) = 0.0_RKIND
       calvingVelocity(:) = 0.0_RKIND
+      albanyVelocityError = 0
 
       allocate(temperaturePrev(nVertLevels, nCells+1))
       allocate(waterFracPrev(nVertLevels, nCells+1))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity.F
@@ -659,7 +659,7 @@ contains
          ! ---
          ! --- Calculate strain rates on cell centers
          ! ---
-         call calculate_strain_rates_and_stresses(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err)
+         call calculate_strain_rates_and_stresses(meshPool, geometryPool, thermalPool, scratchPool, velocityPool, err_tmp)
          err = ior(err, err_tmp)
 
          block => block % next

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -471,6 +471,7 @@ contains
       real (kind=RKIND), dimension(:,:), pointer :: heatDissipation  ! on cells
       integer :: iEdge
       integer :: iCell
+      integer :: albanyVelocityErrorTmp
       real(kind=RKIND), parameter :: secondsInYear = 365.0_RKIND * 24.0_RKIND * 3600.0_RKIND
          !< The value of seconds in a year assumed by external dycores
       integer, pointer :: albanyVelocityError
@@ -521,7 +522,6 @@ contains
       call mpas_pool_get_array(velocityPool, 'dirichletVelocityMask', dirichletVelocityMask, timeLevel = 1)
       call mpas_pool_get_array(velocityPool, 'stiffnessFactor', stiffnessFactor)
       call mpas_pool_get_array(velocityPool, 'albanyVelocityError', albanyVelocityError)
-      albanyVelocityError = 0
 
       ! Hydro variables
       call mpas_pool_get_array(hydroPool, 'effectivePressure', effectivePressure)
@@ -595,19 +595,24 @@ contains
 
 
           call mpas_timer_start("velocity_solver_solve_FO")
+          albanyVelocityErrorTmp = 0
           call velocity_solver_solve_FO(bedTopography, lowerSurface, thickness, &
                 betaSolve, sfcMassBal, temperature, stiffnessFactor, &
                 effectivePressureLimited, muFriction, &
                 uReconstructX, uReconstructY,  &  ! Dirichlet boundary values to apply where dirichletVelocityMask=1
                 normalVelocity, drivingStressVert, dissipationVertexField % array, uReconstructX, uReconstructY, &  ! return values
-                deltat, albanyVelocityError)  ! return values
+                deltat, albanyVelocityErrorTmp)  ! return values
           call mpas_timer_stop("velocity_solver_solve_FO")
 
-          if (albanyVelocityError == 1) then
+          ! this error code is accumulated here because the velocity solver will be called multiple times per time step
+          ! when using the RK time-stepper.
+          albanyVelocityError = albanyVelocityError + albanyVelocityErrorTmp
+
+          if (albanyVelocityErrorTmp >= 1) then
              if (config_nonconvergence_error) then
                 call mpas_log_write("Albany velocity solve failed to converge!  " // &
                    "Check log.albany.0000.out for more information.", MPAS_LOG_ERR)
-                err = ior(err, albanyVelocityError)
+                err = ior(err, albanyVelocityErrorTmp)
              else
                 call mpas_log_write("Albany velocity solve failed to converge!  " // &
                    "Check log.albany.0000.out for more information.", MPAS_LOG_WARN)
@@ -616,7 +621,7 @@ contains
 
 
           ! Now interpolate from vertices to cell centers
-          if (albanyVelocityError == 0) then
+          if (albanyVelocityErrorTmp == 0) then
              ! the dissipationVertexField can have garbage if the solver didn't converge,
              ! so keep previous timestep's field if nonconvergence
              call li_interpolate_vertex_to_cell_2d(meshPool, dissipationVertexField % array, heatDissipation)


### PR DESCRIPTION
An intermediate error code was overwriting previous error codes in the velocity module.  This meant that a convergence error from Albany was not actually killing the model.  This PR fixes that bug.  It also handles the situation where the RK time-stepper is in use and when Albany errors are set to be nonfatal, the albanyVelocityError output variable now reports the number of times during a timestep that a velocity error occurred.