### PR TITLE
Fix uninitialized err code in evolve_channel routine

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_subglacial_hydro.F
@@ -2104,6 +2104,8 @@ module li_subglacial_hydro
       integer, pointer :: nCellsSolve
       integer :: iCell, iEdgeOnCell, iEdge
 
+      err = 0
+
       call mpas_pool_get_subpool(block % structs, 'hydro', hydroPool)
       call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
       call mpas_pool_get_array(hydroPool, 'deltatSGH', deltatSGH)


### PR DESCRIPTION
There was an uninitialized error code in the evolve_channel routine. This could potentially cause a phantom error to be thrown and kill the model.