### PR TITLE
Add SMB & SAT lapse rate feature

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1306,6 +1306,9 @@ is the value of that variable from the *previous* time level!
                 <var name="sfcMassBalApplied" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
                      description="applied surface mass balance"
                 />
+                <var name="sfcMassBalGradientCorrection" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+                     description="correction to surface mass balance based on lapse rate and surface elevation"
+                />
                 <var name="groundedSfcMassBalApplied" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
                      description="applied surface mass balance on grounded ice"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -747,6 +747,8 @@
                 <package name="thermal" description="This package includes variables required for the thermal solver."/>
 
                 <package name="extrapOceanData" description="This package includes variables required for extrapolating ocean data into MALI ice shelf cavities." />
+
+                <package name="smbSatLapseRate" description="This package includes variables needed when config_apply_smb_sat_lapse_rate is true."/>
 	</packages>
 
 
@@ -910,6 +912,7 @@
 			<var name="cellMask"/>
 			<var name="bedTopography"/>
 			<var name="sfcMassBal"/>
+			<var name="surfaceElevationRef" packages="smbSatLapseRate"/>
                         <var name="floatingBasalMassBal"/>
                         <var name="regionCellMasks"/>
                         <var name="regionEdgeMasks"/>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -139,6 +139,10 @@
                     description="Mask to zero out sfcMassBalApplied in regions where there is no ice at the timestep."
                     possible_values=".true. or .false."
         />
+		<nml_option name="config_apply_smb_sat_lapse_rate" type="logical" default_value=".false." units="unitless"
+			    description="If true, apply SMB and SAT elevation-change (lapse-rate) corrections in MALI using ISMIP6 atmospheric forcing guidance (Atmospheric forcing section): https://theghub.org/groups/ismip6/wiki/MainPage/ISMIP6ProjectionsGreenland?version=3"
+			    possible_values=".true. or .false."
+		/>
 <!-- This option to be implemented in the future.
 		<nml_option name="config_allow_additional_advance" type="logical" default_value=".true." units="none"
 		            description="Determines whether ice can advance beyond its initial extent"
@@ -1293,6 +1297,12 @@ is the value of that variable from the *previous* time level!
                 <var name="sfcMassBal" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
                      description="potential surface mass balance"
                 />
+                <var name="sfcMassBalLapseRate" type="real" dimensions="nCells Time" units="kg m^-2 s^-1 m^-1" default_value="0.0"
+                     description="vertical gradient dSMBdz used for SMB elevation-change correction"
+                />
+                <var name="surfaceElevationRef" type="real" dimensions="nCells Time" units="m" default_value="0.0"
+                     description="reference surface elevation h_ref used for SMB and SAT elevation-change corrections"
+                />
                 <var name="sfcMassBalApplied" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
                      description="applied surface mass balance"
                 />
@@ -1746,6 +1756,12 @@ is the value of that variable from the *previous* time level!
                 />
                 <var name="surfaceAirTemperature" type="real" dimensions="nCells Time" units="K" default_value="273.15"
                      description="air temperature at the ice sheet surface"
+                />
+                <var name="surfaceAirTemperatureLapseRate" type="real" dimensions="nCells Time" units="K m^-1" default_value="0.0"
+                     description="vertical gradient dTdz used for SAT elevation-change correction"
+                />
+                <var name="surfaceAirTemperatureApplied" type="real" dimensions="nCells Time" units="K" default_value="273.15"
+                     description="air temperature at the ice sheet surface after model-side lapse-rate adjustment"
                 />
                 <var name="surfaceTemperature" type="real" dimensions="nCells Time" units="K" default_value="273.15"
                      description="temperature at upper ice service"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -339,17 +339,13 @@
 		            possible_values="Any positive real value"
 		/>
 		<nml_option name="config_surface_air_temperature_source" type="character" default_value="file" units="unitless"
-		            description="Selection of the method for setting the surface air temperature. 'constant' uses the value set by config_surface_air_temperature_value.  'file' reads the field from an input or forcing file or ESM coupler. 'lapse' uses the value of config_surface_air_temperature_value at elevation 0 with a lapse rate applied from config_surface_air_temperature_lapse_rate."
-		            possible_values="'constant', 'file', 'lapse'"
+		            description="Selection of the method for setting the surface air temperature. 'constant' uses the value set by config_surface_air_temperature_value.  'file' reads the field from an input or forcing file or ESM coupler."
+		            possible_values="'constant', 'file'"
 		/>
 		<nml_option name="config_surface_air_temperature_value" type="real" default_value="273.15" units="Kelvin"
 		            description="Constant value of the surface air temperature."
 		            possible_values="Any positive real value"
                 />
-                <nml_option name="config_surface_air_temperature_lapse_rate" type="real" default_value="0.01" units="K m^-1"
-		            description="Lapse rate to apply to surface air temperature when config_surface_air_temperature_source='lapse'. Positive values lead to colder temperatures at higher elevations."
-		            possible_values="Any real value"
-		/>
 		<nml_option name="config_basal_heat_flux_source" type="character" default_value="file" units="unitless"
 		            description="Selection of the method for setting the basal heat flux."
 		            possible_values="'constant', 'file'  'constant' uses the value set by config_basal_heat_flux_value.  'file' reads the field from an input or forcing file or ESM coupler."

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1127,7 +1127,6 @@ module li_advection
       logical, pointer :: config_apply_smb_sat_lapse_rate
 
       real (kind=RKIND), dimension(:), pointer :: upperSurface
-      real (kind=RKIND), dimension(:), pointer :: sfcMassBal
       real (kind=RKIND), dimension(:), pointer :: sfcMassBalGradientCorrection
       real (kind=RKIND), dimension(:), pointer :: sfcMassBalLapseRate
       real (kind=RKIND), dimension(:), pointer :: surfaceElevationRef
@@ -1148,7 +1147,6 @@ module li_advection
          call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
 
          call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
-         call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalGradientCorrection', sfcMassBalGradientCorrection)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalLapseRate', sfcMassBalLapseRate)
          call mpas_pool_get_array(geometryPool, 'surfaceElevationRef', surfaceElevationRef)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -146,6 +146,7 @@ module li_advection
            thickness,             & ! ice thickness (updated in this subroutine)
            bedTopography,         & ! bed topography
            sfcMassBal,            & ! surface mass balance (potential forcing)
+           sfcMassBalGradientCorrection, & ! lapse rate correction to sfcMassBal
            sfcMassBalApplied,     & ! surface mass balance (actually applied)
            bareIceAblationApplied, & ! ablation (melting) of bare ice (actually applied)
            groundedSfcMassBalApplied,     & ! surface mass balance on grounded locations (actually applied)
@@ -283,6 +284,7 @@ module li_advection
       call mpas_pool_get_array(geometryPool, 'thickness', thickness)
       call mpas_pool_get_array(geometryPool, 'bedTopography', bedTopography)
       call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
+      call mpas_pool_get_array(geometryPool, 'sfcMassBalGradientCorrection', sfcMassBalGradientCorrection)
       call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
       call mpas_pool_get_array(geometryPool, 'bareIceAblationApplied', bareIceAblationApplied)
       call mpas_pool_get_array(geometryPool, 'groundedSfcMassBalApplied', groundedSfcMassBalApplied)
@@ -608,6 +610,7 @@ module li_advection
               cellMask,            &
               bedTopography,       &
               sfcMassBal,          &
+              sfcMassBalGradientCorrection, &
               sfcMassBalApplied,   &
               bareIceAblationApplied,      &
               groundedSfcMassBalApplied,   &
@@ -862,6 +865,7 @@ module li_advection
               cellMask,            &
               bedTopography,       &
               sfcMassBal,          &
+              sfcMassBalGradientCorrection, &
               sfcMassBalApplied,   &
               bareIceAblationApplied,      &
               groundedSfcMassBalApplied,   &
@@ -887,6 +891,7 @@ module li_advection
       real (kind=RKIND), dimension(:), intent(in) ::  &
            bedTopography,      & !< Input: bed elevation (m)
            sfcMassBal,         & !< Input: surface mass balance (kg/m^2/s)
+           sfcMassBalGradientCorrection, & !< Input: lapse rate correction to sfcMassBal (kg/m^2/s)
            basalMassBal          !< Input: basal mass balance (kg/m^2/s)
 
       real(kind=RKIND), dimension(:,:), intent(in) :: &
@@ -952,7 +957,8 @@ module li_advection
       ! If positive, then add the SMB to the top layer, conserving mass*tracer products
       ! If negative, then melt from the top down until the melting term is used up or the ice is gone
 
-      ! Initialize applied BMB field
+      ! Initialize applied SMB and BMB fields
+      sfcMassBalApplied(:) = sfcMassBal(:) + sfcMassBalGradientCorrection(:)
       basalMassBalApplied(:) = basalMassBal(:)
 
       do iCell = 1, nCells
@@ -1122,7 +1128,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:), pointer :: upperSurface
       real (kind=RKIND), dimension(:), pointer :: sfcMassBal
-      real (kind=RKIND), dimension(:), pointer :: sfcMassBalApplied
+      real (kind=RKIND), dimension(:), pointer :: sfcMassBalGradientCorrection
       real (kind=RKIND), dimension(:), pointer :: sfcMassBalLapseRate
       real (kind=RKIND), dimension(:), pointer :: surfaceElevationRef
 
@@ -1143,7 +1149,7 @@ module li_advection
 
          call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
          call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
-         call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
+         call mpas_pool_get_array(geometryPool, 'sfcMassBalGradientCorrection', sfcMassBalGradientCorrection)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalLapseRate', sfcMassBalLapseRate)
          call mpas_pool_get_array(geometryPool, 'surfaceElevationRef', surfaceElevationRef)
 
@@ -1152,12 +1158,11 @@ module li_advection
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureLapseRate', surfaceAirTemperatureLapseRate)
 
          ! Always initialize applied fields from raw forcing fields.
-         sfcMassBalApplied(:) = sfcMassBal(:)
+         sfcMassBalGradientCorrection(:) = 0.0_RKIND
          surfaceAirTemperatureApplied(:) = surfaceAirTemperature(:)
 
          if (config_apply_smb_sat_lapse_rate) then
-            sfcMassBalApplied(:) = sfcMassBalApplied(:) + &
-                                   sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+            sfcMassBalGradientCorrection(:) = sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
 
             surfaceAirTemperatureApplied(:) = surfaceAirTemperatureApplied(:) + &
                                               surfaceAirTemperatureLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -47,7 +47,8 @@ module li_advection
    public :: li_advection_thickness_tracers, &
              li_layer_normal_velocity, &
              li_update_geometry, &
-             li_grounded_to_floating
+             li_grounded_to_floating, &
+             li_apply_ismip6_atmosphere_forcing
 
    !--------------------------------------------------------------------
    !
@@ -1097,6 +1098,72 @@ module li_advection
 
     end subroutine apply_mass_balance
 
+
+!***********************************************************************
+!
+!  routine li_apply_ismip6_atmosphere_forcing
+!
+!> \brief   Build effective SMB and applied SAT from ISMIP6-style fields.
+!> \details
+!>  If config_apply_smb_sat_lapse_rate is enabled, compute
+!>  elevation-change corrections only.
+!>  Incoming sfcMassBal and surfaceAirTemperature are assumed to already
+!>  include any anomaly correction from preprocessing.
+!
+!-----------------------------------------------------------------------
+   subroutine li_apply_ismip6_atmosphere_forcing(domain, err)
+
+      type (domain_type), intent(inout) :: domain
+      integer, intent(out) :: err
+
+      type (block_type), pointer :: block
+      type (mpas_pool_type), pointer :: geometryPool, thermalPool
+
+      logical, pointer :: config_apply_smb_sat_lapse_rate
+
+      real (kind=RKIND), dimension(:), pointer :: upperSurface
+      real (kind=RKIND), dimension(:), pointer :: sfcMassBal
+      real (kind=RKIND), dimension(:), pointer :: sfcMassBalLapseRate
+      real (kind=RKIND), dimension(:), pointer :: surfaceElevationRef
+
+      real (kind=RKIND), dimension(:), pointer :: surfaceAirTemperature
+      real (kind=RKIND), dimension(:), pointer :: surfaceAirTemperatureApplied
+      real (kind=RKIND), dimension(:), pointer :: surfaceAirTemperatureLapseRate
+
+      err = 0
+
+      call mpas_pool_get_config(liConfigs, 'config_apply_smb_sat_lapse_rate', &
+                    config_apply_smb_sat_lapse_rate)
+      if (.not. config_apply_smb_sat_lapse_rate) then
+         return
+      endif
+
+      block => domain % blocklist
+      do while (associated(block))
+
+         call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+         call mpas_pool_get_subpool(block % structs, 'thermal', thermalPool)
+
+         call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
+         call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
+         call mpas_pool_get_array(geometryPool, 'sfcMassBalLapseRate', sfcMassBalLapseRate)
+         call mpas_pool_get_array(geometryPool, 'surfaceElevationRef', surfaceElevationRef)
+
+         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperatureApplied)
+         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureLapseRate', surfaceAirTemperatureLapseRate)
+
+         sfcMassBal(:) = sfcMassBal(:) + &
+                         sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+
+         surfaceAirTemperatureApplied(:) = surfaceAirTemperature(:) + &
+                                           surfaceAirTemperatureLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+
+         block => block % next
+      end do
+
+   end subroutine li_apply_ismip6_atmosphere_forcing
+
 !***********************************************************************
 !
 !  subroutine tracer_setup
@@ -1179,7 +1246,7 @@ module li_advection
            layerThickness
 
       real (kind=RKIND), dimension(:), pointer :: &
-           surfaceAirTemperature,   & ! surface air temperature
+            surfaceAirTemperatureApplied,   & ! surface air temperature used by physics
            basalTemperature           ! basal ice temperature
 
       real (kind=RKIND), dimension(:), pointer :: &
@@ -1216,7 +1283,7 @@ module li_advection
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
       call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
       call mpas_pool_get_array(thermalPool, 'enthalpy', enthalpy)
-      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperatureApplied)
       call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
 
       ! get config variables
@@ -1235,10 +1302,10 @@ module li_advection
       !     before calling this subroutine.
       ! (3) Surface and basal temperature (or enthalpy) are not transported, but their
       !     values are applied to new accumulation at either surface.
-      ! (4) In most cases the surface temperature is equal to min(surfaceAirTemperature, 273.15),
+      ! (4) In most cases the surface temperature is equal to min(surfaceAirTemperatureApplied, 273.15),
       !     so we could set surfaceTracers to surfaceTemperature.  But if a positive SMB
       !     is applied to a previously ice-free cell, then surfaceTemperature has not yet been
-      !     initialized to the correct value, so we explicitly use min(surfaceAirTemperature, 273.15).
+      !     initialized to the correct value, so we explicitly use min(surfaceAirTemperatureApplied, 273.15).
 
       iTracer = 0    ! initialize the tracer index
 
@@ -1265,7 +1332,7 @@ module li_advection
 
          ! set enthalpy of new ice at upper and lower surfaces
          ! convert temperature to enthalpy assuming waterFrac = 0 for new ice
-         surfaceTracers(iTracer,:) = min(surfaceAirTemperature(:), kelvin_to_celsius) * config_ice_density*cp_ice
+         surfaceTracers(iTracer,:) = min(surfaceAirTemperatureApplied(:), kelvin_to_celsius) * config_ice_density*cp_ice
          basalTracers(iTracer,:) = basalTemperature(:) * config_ice_density*cp_ice
 
       elseif (trim(config_thermal_solver) == 'temperature') then  ! advect temperature
@@ -1277,7 +1344,7 @@ module li_advection
          advectedTracers(iTracer,:,:) = temperature(:,:)
 
          ! set enthalpy of new ice at upper and lower surfaces
-         surfaceTracers(iTracer,:) = min(surfaceAirTemperature(:), kelvin_to_celsius)
+         surfaceTracers(iTracer,:) = min(surfaceAirTemperatureApplied(:), kelvin_to_celsius)
          basalTracers(iTracer,:) = basalTemperature(:)
 
       endif

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -48,7 +48,7 @@ module li_advection
              li_layer_normal_velocity, &
              li_update_geometry, &
              li_grounded_to_floating, &
-             li_apply_ismip6_atmosphere_forcing
+             li_apply_atm_lapse_rate
 
    !--------------------------------------------------------------------
    !
@@ -952,8 +952,7 @@ module li_advection
       ! If positive, then add the SMB to the top layer, conserving mass*tracer products
       ! If negative, then melt from the top down until the melting term is used up or the ice is gone
 
-      ! Initialize applied SMB and BMB fields
-      sfcMassBalApplied(:) = sfcMassBal(:)
+      ! Initialize applied BMB field
       basalMassBalApplied(:) = basalMassBal(:)
 
       do iCell = 1, nCells
@@ -1101,7 +1100,7 @@ module li_advection
 
 !***********************************************************************
 !
-!  routine li_apply_ismip6_atmosphere_forcing
+!  routine li_apply_atm_lapse_rate
 !
 !> \brief   Build effective SMB and applied SAT from ISMIP6-style fields.
 !> \details
@@ -1111,7 +1110,7 @@ module li_advection
 !>  include any anomaly correction from preprocessing.
 !
 !-----------------------------------------------------------------------
-   subroutine li_apply_ismip6_atmosphere_forcing(domain, err)
+   subroutine li_apply_atm_lapse_rate(domain, err)
 
       type (domain_type), intent(inout) :: domain
       integer, intent(out) :: err
@@ -1123,6 +1122,7 @@ module li_advection
 
       real (kind=RKIND), dimension(:), pointer :: upperSurface
       real (kind=RKIND), dimension(:), pointer :: sfcMassBal
+      real (kind=RKIND), dimension(:), pointer :: sfcMassBalApplied
       real (kind=RKIND), dimension(:), pointer :: sfcMassBalLapseRate
       real (kind=RKIND), dimension(:), pointer :: surfaceElevationRef
 
@@ -1134,9 +1134,6 @@ module li_advection
 
       call mpas_pool_get_config(liConfigs, 'config_apply_smb_sat_lapse_rate', &
                     config_apply_smb_sat_lapse_rate)
-      if (.not. config_apply_smb_sat_lapse_rate) then
-         return
-      endif
 
       block => domain % blocklist
       do while (associated(block))
@@ -1146,6 +1143,7 @@ module li_advection
 
          call mpas_pool_get_array(geometryPool, 'upperSurface', upperSurface)
          call mpas_pool_get_array(geometryPool, 'sfcMassBal', sfcMassBal)
+         call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
          call mpas_pool_get_array(geometryPool, 'sfcMassBalLapseRate', sfcMassBalLapseRate)
          call mpas_pool_get_array(geometryPool, 'surfaceElevationRef', surfaceElevationRef)
 
@@ -1153,16 +1151,22 @@ module li_advection
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperatureApplied)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureLapseRate', surfaceAirTemperatureLapseRate)
 
-         sfcMassBal(:) = sfcMassBal(:) + &
-                         sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+         ! Always initialize applied fields from raw forcing fields.
+         sfcMassBalApplied(:) = sfcMassBal(:)
+         surfaceAirTemperatureApplied(:) = surfaceAirTemperature(:)
 
-         surfaceAirTemperatureApplied(:) = surfaceAirTemperature(:) + &
-                                           surfaceAirTemperatureLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+         if (config_apply_smb_sat_lapse_rate) then
+            sfcMassBalApplied(:) = sfcMassBalApplied(:) + &
+                                   sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+
+            surfaceAirTemperatureApplied(:) = surfaceAirTemperatureApplied(:) + &
+                                              surfaceAirTemperatureLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
+         endif
 
          block => block % next
       end do
 
-   end subroutine li_apply_ismip6_atmosphere_forcing
+   end subroutine li_apply_atm_lapse_rate
 
 !***********************************************************************
 !

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -544,7 +544,7 @@ module li_calving
          ! get required fields from the thermal pool
          call mpas_pool_get_array(thermalPool, 'temperature', temperature)
          call mpas_pool_get_array(thermalPool, 'waterFrac', waterFrac)
-         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature', basalTemperature)
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
@@ -109,6 +109,7 @@ module li_core_interface
       logical, pointer :: config_adaptive_timestep_include_DCFL
       logical, pointer :: config_write_albany_ascii_mesh
       logical, pointer :: config_ocean_data_extrapolation
+      logical, pointer :: config_apply_smb_sat_lapse_rate
 
       logical, pointer :: higherOrderVelocityActive
       logical, pointer :: SIAvelocityActive
@@ -118,6 +119,7 @@ module li_core_interface
       logical, pointer :: ismip6GroundedFaceMeltActive
       logical, pointer :: thermalActive
       logical, pointer :: extrapOceanDataActive
+      logical, pointer :: smbSatLapseRateActive
 
       ierr = 0
 
@@ -130,6 +132,7 @@ module li_core_interface
       call mpas_pool_get_config(configPool, 'config_use_3d_thermal_forcing_for_face_melt', config_use_3d_thermal_forcing_for_face_melt)
       call mpas_pool_get_config(configPool, 'config_ocean_data_extrapolation', config_ocean_data_extrapolation)
       call mpas_pool_get_config(configPool, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(configPool, 'config_apply_smb_sat_lapse_rate', config_apply_smb_sat_lapse_rate)
 
       call mpas_pool_get_package(packagePool, 'SIAvelocityActive', SIAvelocityActive)
       call mpas_pool_get_package(packagePool, 'higherOrderVelocityActive', higherOrderVelocityActive)
@@ -139,6 +142,7 @@ module li_core_interface
       call mpas_pool_get_package(packagePool, 'ismip6GroundedFaceMeltActive', ismip6GroundedFaceMeltActive)
       call mpas_pool_get_package(packagePool, 'thermalActive', thermalActive)
       call mpas_pool_get_package(packagePool, 'extrapOceanDataActive', extrapOceanDataActive)
+      call mpas_pool_get_package(packagePool, 'smbSatLapseRateActive', smbSatLapseRateActive)
 
       if (trim(config_velocity_solver) == 'sia') then
          SIAvelocityActive = .true.
@@ -165,6 +169,12 @@ module li_core_interface
          extrapOceanDataActive = .true.
          call mpas_log_write("The 'extrapOceanDataActive' package and assocated variables have been enabled because " // &
               "'config_ocean_data_extrapolation' is set to .true.")
+      endif
+
+      if (config_apply_smb_sat_lapse_rate) then
+         smbSatLapseRateActive = .true.
+         call mpas_log_write("The 'smbSatLapseRate' package and associated variables have been enabled because " // &
+              "'config_apply_smb_sat_lapse_rate' is set to .true.")
       endif
 
       if ( (trim(config_basal_mass_bal_float) == 'ismip6') .or. &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -117,7 +117,7 @@ module li_thermal
 
       logical, pointer :: &
            config_print_thermal_info,  &
-          config_do_restart
+           config_do_restart
 
       character(len=StrKIND), pointer :: &
            config_thermal_solver,                 & ! solver option ('temperature' or 'enthalpy')
@@ -413,7 +413,7 @@ module li_thermal
                     nVertLevels,                   &
                     layerCenterSigma,              &
                     thickness(iCell),              &
-                  surfaceAirTemperature(iCell),  &
+                    surfaceAirTemperature(iCell),  &
                     temperature(:,iCell),          &
                     waterFrac(:,iCell),            &
                     surfaceTemperature(iCell),     &
@@ -658,7 +658,7 @@ module li_thermal
            nVertLevels                 ! number of vertical layers
 
       logical, pointer :: &
-          config_print_thermal_info   ! if true, print debug info
+           config_print_thermal_info   ! if true, print debug info
 
       character(len=StrKIND), pointer :: &
            config_thermal_solver       ! option for thermal solver
@@ -694,7 +694,6 @@ module li_thermal
       real (kind=RKIND), dimension(:), pointer :: &
            surfaceTemperature,       & ! surface ice temperature (K)
            basalTemperature,         & ! basal ice temperature (K)
-           surfaceAirTemperature,    & ! raw/input surface air temperature (K)
            surfaceAirTemperatureApplied,    & ! surface air temperature used by physics (K)
            basalHeatFlux,            & ! basal heat flux into the ice (W m^{-2}, positive upward)
            basalFrictionFlux,        & ! basal frictional flux into the ice (W m^{-2})
@@ -817,7 +816,6 @@ module li_thermal
          call mpas_pool_get_array(thermalPool, 'drainedInternalMeltRate', drainedInternalMeltRate)
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature',   basalTemperature)
-         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperatureApplied)
          call mpas_pool_get_array(thermalPool, 'surfaceConductiveFlux', surfaceConductiveFlux)
          call mpas_pool_get_array(thermalPool, 'basalConductiveFlux', basalConductiveFlux)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -123,7 +123,7 @@ module li_thermal
            config_thermal_solver,                 & ! solver option ('temperature' or 'enthalpy')
            config_temperature_init,               & ! temperature initialization option ('linear' or 'file')
            config_surface_air_temperature_source, & ! surface air temperature initialization option
-                                                    ! ('constant' or 'file' or 'lapse')
+                                   ! ('constant' or 'file')
            config_basal_heat_flux_source            ! basal heat flux initialization option ('constant' or 'file')
 
       real (kind=RKIND), pointer ::  &
@@ -132,7 +132,6 @@ module li_thermal
 
       real (kind=RKIND), pointer ::  &
            config_surface_air_temperature_value, & ! constant value of surface air temperature
-           config_surface_air_temperature_lapse_rate, & ! optional lapse rate to apply to constant value of surface air temperature
            config_basal_heat_flux_value            ! constant value of basal heat flux
 
       integer, pointer :: &
@@ -204,7 +203,6 @@ module li_thermal
       call mpas_pool_get_config(liConfigs, 'config_temperature_init', config_temperature_init)
       call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_source', config_surface_air_temperature_source)
       call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_value', config_surface_air_temperature_value)
-      call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_lapse_rate', config_surface_air_temperature_lapse_rate)
       call mpas_pool_get_config(liConfigs, 'config_basal_heat_flux_source', config_basal_heat_flux_source)
       call mpas_pool_get_config(liConfigs, 'config_basal_heat_flux_value', config_basal_heat_flux_value)
       call mpas_pool_get_config(liConfigs, 'config_print_thermal_info', config_print_thermal_info)
@@ -260,12 +258,6 @@ module li_thermal
             surfaceAirTemperature(:) = config_surface_air_temperature_value
             if (config_print_thermal_info) &
                call mpas_log_write('Initialize sfc air temp: $r', realArgs=(/config_surface_air_temperature_value/))
-         elseif (trim(config_surface_air_temperature_source) == 'lapse') then
-            surfaceAirTemperature(:) = config_surface_air_temperature_value - config_surface_air_temperature_lapse_rate &
-               * upperSurface(:)
-            if (config_print_thermal_info) &
-               call mpas_log_write('Initialize sfc air temp to $r with lapse rate of $r', &
-                  realArgs=(/config_surface_air_temperature_value, config_surface_air_temperature_lapse_rate/))
          endif
 
          ! init for basalHeatFlux
@@ -673,16 +665,9 @@ module li_thermal
 
       character (len=StrKIND), pointer :: config_velocity_solver
 
-      character(len=StrKIND), pointer :: &
-           config_surface_air_temperature_source ! surface air temperature initialization option
-
       real(kind=RKIND), pointer :: &
            config_thermal_thickness, & ! minimum thickness (m) for temperature calculations
            config_sea_level            ! sea level (m) relative to z = 0
-
-      real (kind=RKIND), pointer ::  &
-           config_surface_air_temperature_value, & ! constant value of surface air temperature
-           config_surface_air_temperature_lapse_rate ! optional lapse rate to apply to constant value of surface air temperature
 
       integer, pointer :: &
            config_stats_cell_ID        ! global ID for diagnostic cell
@@ -772,9 +757,6 @@ module li_thermal
       call mpas_pool_get_config(liConfigs, 'config_sea_level', config_sea_level)
       call mpas_pool_get_config(liConfigs, 'config_stats_cell_ID', config_stats_cell_ID)
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
-      call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_value', config_surface_air_temperature_value)
-      call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_lapse_rate', config_surface_air_temperature_lapse_rate)
-      call mpas_pool_get_config(liConfigs, 'config_surface_air_temperature_source', config_surface_air_temperature_source)
 
 
       if (config_print_thermal_info) then
@@ -874,13 +856,6 @@ module li_thermal
          ! === mechanical heating terms now calculated in li_velocity_solve ===
          ! (this makes restarts easier because just heatDissipation and basalFrictionFlux
          !  need to be restart variables, rather than all of their inputs.)
-
-
-         ! === Update surfaceTemperature if using a lapse rate ===
-         if (trim(config_surface_air_temperature_source) == 'lapse') then
-            surfaceAirTemperature(:) = config_surface_air_temperature_value - config_surface_air_temperature_lapse_rate &
-               * upperSurface(:)
-         endif
 
          ! ================================
          select case(config_thermal_solver)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_thermal.F
@@ -117,7 +117,7 @@ module li_thermal
 
       logical, pointer :: &
            config_print_thermal_info,  &
-           config_do_restart
+          config_do_restart
 
       character(len=StrKIND), pointer :: &
            config_thermal_solver,                 & ! solver option ('temperature' or 'enthalpy')
@@ -159,7 +159,7 @@ module li_thermal
            enthalpy                    ! interior ice enthalpy (J m^{-3})
 
       real (kind=RKIND), dimension(:), pointer :: &
-           surfaceAirTemperature,    & ! surface air temperature (K)
+           surfaceAirTemperature,    & ! raw/input surface air temperature (K)
            surfaceTemperature,       & ! surface ice temperature (K)
            basalTemperature            ! basal ice temperature (K)
 
@@ -413,7 +413,7 @@ module li_thermal
                     nVertLevels,                   &
                     layerCenterSigma,              &
                     thickness(iCell),              &
-                    surfaceAirTemperature(iCell),  &
+                  surfaceAirTemperature(iCell),  &
                     temperature(:,iCell),          &
                     waterFrac(:,iCell),            &
                     surfaceTemperature(iCell),     &
@@ -658,7 +658,7 @@ module li_thermal
            nVertLevels                 ! number of vertical layers
 
       logical, pointer :: &
-           config_print_thermal_info   ! if true, print debug info
+          config_print_thermal_info   ! if true, print debug info
 
       character(len=StrKIND), pointer :: &
            config_thermal_solver       ! option for thermal solver
@@ -694,7 +694,8 @@ module li_thermal
       real (kind=RKIND), dimension(:), pointer :: &
            surfaceTemperature,       & ! surface ice temperature (K)
            basalTemperature,         & ! basal ice temperature (K)
-           surfaceAirTemperature,    & ! surface air temperature (K)
+           surfaceAirTemperature,    & ! raw/input surface air temperature (K)
+           surfaceAirTemperatureApplied,    & ! surface air temperature used by physics (K)
            basalHeatFlux,            & ! basal heat flux into the ice (W m^{-2}, positive upward)
            basalFrictionFlux,        & ! basal frictional flux into the ice (W m^{-2})
            surfaceConductiveFlux,    & ! conductive heat flux at the upper surface (W m^{-2}, positive down)
@@ -817,6 +818,7 @@ module li_thermal
          call mpas_pool_get_array(thermalPool, 'surfaceTemperature', surfaceTemperature)
          call mpas_pool_get_array(thermalPool, 'basalTemperature',   basalTemperature)
          call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+         call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperatureApplied)
          call mpas_pool_get_array(thermalPool, 'surfaceConductiveFlux', surfaceConductiveFlux)
          call mpas_pool_get_array(thermalPool, 'basalConductiveFlux', basalConductiveFlux)
          call mpas_pool_get_array(thermalPool, 'basalHeatFlux', basalHeatFlux)
@@ -856,7 +858,6 @@ module li_thermal
          ! === mechanical heating terms now calculated in li_velocity_solve ===
          ! (this makes restarts easier because just heatDissipation and basalFrictionFlux
          !  need to be restart variables, rather than all of their inputs.)
-
          ! ================================
          select case(config_thermal_solver)
          ! ================================
@@ -874,7 +875,7 @@ module li_thermal
             ! Convert temperature from Kelvin to Celsius to avoid repeated use of kelvin_to_celsius below
             ! (Convert back at the end.)
             temperature(:,:) = temperature(:,:) - kelvin_to_celsius
-            surfaceAirTemperature(:) = surfaceAirTemperature(:) - kelvin_to_celsius
+            surfaceAirTemperatureApplied(:) = surfaceAirTemperatureApplied(:) - kelvin_to_celsius
             surfaceTemperature(:) = surfaceTemperature(:) - kelvin_to_celsius
             basalTemperature(:) = basalTemperature(:) - kelvin_to_celsius
 
@@ -891,7 +892,7 @@ module li_thermal
                do iCell = 1, nCellsSolve
                   if (indexToCellID(iCell) == config_stats_cell_ID) then
                      call mpas_log_write('thickness = $r', realArgs=(/thickness(iCell)/))
-                     call mpas_log_write('surfaceAirTemperature = $r', realArgs=(/surfaceAirTemperature(iCell)/))
+                     call mpas_log_write('surfaceAirTemperatureApplied = $r', realArgs=(/surfaceAirTemperatureApplied(iCell)/))
                      call mpas_log_write(' ')
                      call mpas_log_write('Initial column temperatures, indexToCellID = $i', intArgs=(/indexToCellID(iCell)/))
                      call mpas_log_write("0 $r", realArgs=(/surfaceTemperature(iCell)/))
@@ -917,7 +918,7 @@ module li_thermal
 
                   ! Set surface temperature (Celsius)
 
-                  surfaceTemperature(iCell) = min(0.0_RKIND, surfaceAirTemperature(iCell))
+                  surfaceTemperature(iCell) = min(0.0_RKIND, surfaceAirTemperatureApplied(iCell))
 
                   ! For floating ice, set the basal temperature to the freezing temperature of seawater.
                   ! Values based on Ocean Water Freezing Point Calculator with S = 35 PSU
@@ -1268,7 +1269,7 @@ module li_thermal
 
             ! Convert temperatures from Celsius back to Kelvin
             temperature(:,:) = temperature(:,:) + kelvin_to_celsius
-            surfaceAirTemperature(:) = surfaceAirTemperature(:) + kelvin_to_celsius
+            surfaceAirTemperatureApplied(:) = surfaceAirTemperatureApplied(:) + kelvin_to_celsius
             surfaceTemperature(:) = surfaceTemperature(:) + kelvin_to_celsius
             basalTemperature(:) = basalTemperature(:) + kelvin_to_celsius
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -251,7 +251,7 @@ module li_time_integration_fe_rk
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
-      call li_apply_ismip6_atmosphere_forcing(domain, err_tmp)
+      call li_apply_atm_lapse_rate(domain, err_tmp)
       err = ior(err, err_tmp)
 
       call mpas_timer_start("advection prep")

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration_fe_rk.F
@@ -251,6 +251,9 @@ module li_time_integration_fe_rk
 
 ! === Prepare for advection (including CFL checks) ===========
 ! This has to come first currently, because it sets the time step!
+      call li_apply_ismip6_atmosphere_forcing(domain, err_tmp)
+      err = ior(err, err_tmp)
+
       call mpas_timer_start("advection prep")
       call prepare_advection(domain, err_tmp)
       err = ior(err, err_tmp)
@@ -658,7 +661,6 @@ module li_time_integration_fe_rk
       deallocate(calvingThicknessAccum)
    !--------------------------------------------------------------------
    end subroutine li_time_integrator_forwardeuler_rungekutta
-
 
 
 !***********************************************************************

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -858,7 +858,7 @@ subroutine li_velocity_external_write_albany_mesh(domain)
 
       ! Thermal variables
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperature)
+      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
       call mpas_pool_get_array(thermalPool, 'basalHeatFlux', basalHeatFlux)
 
       ! hydro variables

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_velocity_external.F
@@ -858,7 +858,7 @@ subroutine li_velocity_external_write_albany_mesh(domain)
 
       ! Thermal variables
       call mpas_pool_get_array(thermalPool, 'temperature', temperature)
-      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperature', surfaceAirTemperature)
+      call mpas_pool_get_array(thermalPool, 'surfaceAirTemperatureApplied', surfaceAirTemperature)
       call mpas_pool_get_array(thermalPool, 'basalHeatFlux', basalHeatFlux)
 
       ! hydro variables


### PR DESCRIPTION
This PR implements a version of the ISMIP6 lapse rate adjustment for SMB and surface air temperature described here:
https://theghub.org/groups/ismip6/wiki/MainPage/ISMIP6ProjectionsGreenland?version=3
It is applied on every timestep (in contrast with ISMIP6 method to be applied once per year).

It also removes the config_surface_air_temperature_source='lapse' option, which has never been used.  The new feature offers the same functionality and it would be unnecessarily complicated to support both ways of doing it.