### PR TITLE
Avoid divide-by-zero in FCT and damage calculation code

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -2097,7 +2097,11 @@ module li_advection
 
             do k = 1, nVertLevels
                do nt = 1, nTracers
-                  tracers(nt,k,iCell) = hTsum(nt,k) / (layerThickness(k, iCell))
+                  if (layerThickness(k, iCell) > 0.0_RKIND) then
+                     tracers(nt,k,iCell) = hTsum(nt,k) / (layerThickness(k, iCell))
+                  else
+                     tracers(nt,k,iCell) = 0.0_RKIND
+                  endif
                enddo         ! nt
             enddo            ! k
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -125,7 +125,6 @@ module li_tracer_advection_fct
          tracerCur,     &! reordered current tracer
          tracerMax,     &! max tracer in neighbors for limiting
          tracerMin,     &! min tracer in neighbors for limiting
-         hNewInv,       &! inverse of new layer thickness
          hProv,         &! provisional layer thickness
          hProvInv,      &! inverse of provisional layer thickness
          flxIn,         &! flux coming into each cell
@@ -152,7 +151,6 @@ module li_tracer_advection_fct
                tracerCur   (nVertLevels  ,nCells+1), &
                tracerMin   (nVertLevels  ,nCells), &
                tracerMax   (nVertLevels  ,nCells), &
-               hNewInv     (nVertLevels  ,nCells), &
                hProv       (nVertLevels  ,nCells), &
                hProvInv    (nVertLevels  ,nCells), &
                flxIn       (nVertLevels  ,nCells+1), &
@@ -168,7 +166,6 @@ module li_tracer_advection_fct
       tracerCur(:,:) = 0.0_RKIND
       tracerMin(:,:) = 0.0_RKIND
       tracerMax(:,:) = 0.0_RKIND
-      hNewInv(:,:) = 0.0_RKIND
       hProv(:,:) = 0.0_RKIND
       hProvInv(:,:) = 0.0_RKIND
       flxIn(:,:) = 0.0_RKIND
@@ -210,12 +207,9 @@ module li_tracer_advection_fct
          ! thickness flux
          do k = kmin, kmax
             if (hProv(k, iCell) > 0.0_RKIND) then
-               hProvInv(k,iCell) = 1.0_RKIND/ hProv(k,iCell)
-               hNewInv (k,iCell) = 1.0_RKIND/(hProv(k,iCell) - &
-                                   dt*w(k,iCell) + dt*w(k+1, iCell))
+               hProvInv(k, iCell) = 1.0_RKIND / hProv(k, iCell)
             else
                hProvInv(k, iCell) = 0.0_RKIND
-               hNewInv(k, iCell)  = 0.0_RKIND
             endif
          end do
       end do
@@ -530,7 +524,6 @@ module li_tracer_advection_fct
                  tracerCur,    &
                  tracerMin,    &
                  tracerMax,    &
-                 hNewInv,      &
                  hProv,        &
                  hProvInv,     &
                  flxIn,        &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection_fct.F
@@ -206,7 +206,7 @@ module li_tracer_advection_fct
          ! New layer thickness is after horizontal and vertical
          ! thickness flux
          do k = kmin, kmax
-            if (hProv(k, iCell) > 0.0_RKIND) then
+            if (hProv(k, iCell) > eps) then
                hProvInv(k, iCell) = 1.0_RKIND / hProv(k, iCell)
             else
                hProvInv(k, iCell) = 0.0_RKIND

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3568,6 +3568,7 @@ module li_calving
       integer, pointer :: nCells
       integer :: iCell, jCell, iNeighbor, n_damage_downstream
       real(kind=RKIND) :: damage_downstream
+      real(kind=RKIND), parameter :: eps = 1.0e-10_RKIND  ! small threshold to avoid divide-by-zero
       real(kind=RKIND), dimension(:,:), pointer :: uReconstructX, uReconstructY
       real(kind=RKIND), dimension(6) :: localMinInfo, localMaxInfo, globalMinInfo, globalMaxInfo
 
@@ -3612,7 +3613,7 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'tauMin', tauMin)
          call mpas_pool_get_array(velocityPool, 'principalStrainRateRatio', principalStrainRateRatio)
 
-         where ( thickness == 0.0_RKIND .or. tauMax == 0.0_RKIND )
+         where ( thickness <= eps .or. tauMax <= eps )
              principalStrainRateRatio = 0.0_RKIND
              s0 = 0.0_RKIND
              nstar = 0.0_RKIND
@@ -3634,7 +3635,7 @@ module li_calving
 
 
          do iCell = 1, nCells
-         if (thickness(iCell) == 0.0_RKIND) then
+         if (thickness(iCell) <= eps) then
              damageSource(iCell) = 0.0_RKIND
          else
              damageSource(iCell) = nstar(iCell) * (1.0_RKIND - s0(iCell)) * eMax(iCell) - floatingBasalMassBal(iCell) &
@@ -3656,7 +3657,7 @@ module li_calving
          damage(:) = damage(:) + ddamagedt(:) * deltat
 
          do iCell = 1, nCells
-             if (thickness(iCell) == 0.0_RKIND) then
+             if (thickness(iCell) <= eps) then
                  damageNye(iCell) = 0.0_RKIND
              else
                  damageNye(iCell) = (2.0_RKIND + principalStrainRateRatio(iCell)) * tauMax(iCell) / &

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -3613,7 +3613,7 @@ module li_calving
          call mpas_pool_get_array(velocityPool, 'tauMin', tauMin)
          call mpas_pool_get_array(velocityPool, 'principalStrainRateRatio', principalStrainRateRatio)
 
-         where ( thickness <= eps .or. tauMax <= eps )
+         where ( thickness <= eps .or. abs(tauMax) <= eps )
              principalStrainRateRatio = 0.0_RKIND
              s0 = 0.0_RKIND
              nstar = 0.0_RKIND


### PR DESCRIPTION
Avoid divide-by-zero issues in FCT and damage calculation code that were causing occasional floating-point exceptions when compiled in debug mode.