### PR TITLE
Fix invalid memory reference in mpas_li_ocean_extrap.F

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_ocean_extrap.F
@@ -530,12 +530,16 @@ contains
             ! Assign 'applied' ocean t/s, otherwise original fields will be
             ! clobbered by input file each time step
 
-            oceanSalinityApplied = oceanSalinity
-            oceanTemperatureApplied = oceanTemperature
+            if (config_calculate_thermal_forcing) then
+               oceanSalinityApplied = oceanSalinity
+               oceanTemperatureApplied = oceanTemperature
+            endif
 
             call mpas_timer_start("halo_updates")
-            call mpas_dmpar_field_halo_exch(domain,'oceanSalinityApplied')
-            call mpas_dmpar_field_halo_exch(domain,'oceanTemperatureApplied')
+            if (config_calculate_thermal_forcing) then
+               call mpas_dmpar_field_halo_exch(domain,'oceanSalinityApplied')
+               call mpas_dmpar_field_halo_exch(domain,'oceanTemperatureApplied')
+            endif
             call mpas_dmpar_field_halo_exch(domain,'ismip6shelfMelt_3dThermalForcing')
             call mpas_dmpar_field_halo_exch(domain,'growMask')
             call mpas_timer_stop("halo_updates")


### PR DESCRIPTION
This merge fixes an invalid memory reference in mpas_li_ocean_extrap.F by consistently protecting oceanSalinity code with `if (config_calculate_thermal_forcing)`.