### PR TITLE
Add option for crevasse water depth to be proportional to melt rate

### DIFF
--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -301,14 +301,14 @@
 		/>
                 <nml_option name="config_crevasse_water_depth_source" type="character" default_value="scalar" units="unitless"
                             description="Source of water depth in crevasses for use with crevasse-depth calving law."
-                            possible_values="'data' (read from input file), 'scalar' (specified by config_crevasse_water_depth), or 'scaled_smb' (a specific fraction of negative SMB)"
+                            possible_values="'data' (read from input file), 'scalar' (specified by config_crevasse_water_depth), 'scaled_smb_cumulative' (accmulates a specific fraction of negative SMB until SMB is no longer negative, at which point it resets), or 'scaled_smb_instantaneous' (proportional to instantaneous negative SMB)."
                 />
                 <nml_option name="config_crevasse_water_depth" type="real" default_value="0.0" units="m"
                             description="Water depth in crevasses for Nick et al. (2010) crevasse depth calving law."
                             possible_values="any non-negative real value"
                 />
                 <nml_option name="config_smb_fraction_to_water_depth" type="real" default_value="1.0" units="unitless"
-                            description="Fraction of surface mass balance to convert to retain as water depth in crevasses for Nick et al. (2010) crevasse depth calving law."
+                        description="Fraction of surface mass balance to convert to retain as water depth in crevasses for Nick et al. (2010) crevasse depth calving law.  When 'config_crevasse_water_depth_source'='scaled_smb_cumulative', this is a scaling of the melt volume on each time step.  When 'config_crevasse_water_depth_source' = 'scaled_smb_instantaneous', this is a direct proportionality between the negative SMB and crevasse water depth.  For example, a value of 4.7472e4 would convert a melt rate of 0.001053 kg/m2/s (10 cm/day, a representative Greenland ablation zone melt rate) to a 50 m crevasse water depth (a representative crevasse depth).  This option is meant to be used for situations like monthly mean melt rates."
                             possible_values="any non-negative real value"
                 />
                 <nml_option name="config_ismip6_retreat_k" type="real" default_value="-170.0" units="m (m^3 s^-1)^-0.4 deg. C^-1"

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_calving.F
@@ -4074,7 +4074,7 @@ module li_calving
          crevasseWaterDepth(:) = config_crevasse_water_depth
       elseif (trim(config_crevasse_water_depth_source) == "data") then
          ! Do nothing. This was already retrieved above.
-      elseif (trim(config_crevasse_water_depth_source) == "scaled_smb") then
+      elseif (trim(config_crevasse_water_depth_source) == "scaled_smb_cumulative") then
          where (sfcMassBalApplied < 0.0_RKIND)
              crevasseWaterDepth = crevasseWaterDepth + &
                  (-1.0_RKIND * config_smb_fraction_to_water_depth * &
@@ -4082,8 +4082,11 @@ module li_calving
          elsewhere
              crevasseWaterDepth = 0.0_RKIND
          endwhere
+      elseif (trim(config_crevasse_water_depth_source) == "scaled_smb_instantaneous") then
+         crevasseWaterDepth = config_smb_fraction_to_water_depth * max(0.0_RKIND, -1.0_RKIND * sfcMassBalApplied)
       else
-         call mpas_log_write("config_crevasse_water_depth_source must be set to 'scalar', 'data', or 'scaled_smb'.", MPAS_LOG_ERR)
+         call mpas_log_write("config_crevasse_water_depth_source must be set to 'scalar', 'data', 'scaled_smb_cumulative', " // &
+                             "or 'scaled_smb_instantaneous'.", MPAS_LOG_ERR)
          err = 1
          return
       endif


### PR DESCRIPTION
This merge adds a new possible value for config_crevasse_water_depth_source that allows the crevasse water depth to be directly proportional to the instantaneous local SMB melt rate. This is meant to be used as a very crude parameterization that provides water to crevasses when and where melting occurs, without any consideration of crevasse water mass balance.  It could be used for something like monthly mean SMB to provide water to crevasses in the melt season and not otherwise.