### PR TITLE
Add ISMIP flux fields to time averaging

### DIFF
--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -660,6 +660,7 @@ add_default($nl, 'config_adaptive_timestep_include_DCFL');
 add_default($nl, 'config_adaptive_timestep_include_calving');
 add_default($nl, 'config_adaptive_timestep_include_face_melting');
 add_default($nl, 'config_adaptive_timestep_force_interval');
+add_default($nl, 'config_timeaveraging_interval');
 
 ###################################
 # Namelist group: time_management #

--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -661,6 +661,7 @@ add_default($nl, 'config_adaptive_timestep_include_calving');
 add_default($nl, 'config_adaptive_timestep_include_face_melting');
 add_default($nl, 'config_adaptive_timestep_force_interval');
 add_default($nl, 'config_timeaveraging_interval');
+add_default($nl, 'config_enable_timeAvgRestarts');
 
 ###################################
 # Namelist group: time_management #

--- a/components/mpas-albany-landice/bld/build-namelist-section
+++ b/components/mpas-albany-landice/bld/build-namelist-section
@@ -166,6 +166,7 @@ add_default($nl, 'config_adaptive_timestep_include_calving');
 add_default($nl, 'config_adaptive_timestep_include_face_melting');
 add_default($nl, 'config_adaptive_timestep_force_interval');
 add_default($nl, 'config_timeaveraging_interval');
+add_default($nl, 'config_enable_timeAvgRestarts');
 
 ###################################
 # Namelist group: time_management #

--- a/components/mpas-albany-landice/bld/build-namelist-section
+++ b/components/mpas-albany-landice/bld/build-namelist-section
@@ -165,6 +165,7 @@ add_default($nl, 'config_adaptive_timestep_include_DCFL');
 add_default($nl, 'config_adaptive_timestep_include_calving');
 add_default($nl, 'config_adaptive_timestep_include_face_melting');
 add_default($nl, 'config_adaptive_timestep_force_interval');
+add_default($nl, 'config_timeaveraging_interval');
 
 ###################################
 # Namelist group: time_management #

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -144,6 +144,7 @@
 <config_adaptive_timestep_include_calving>.true.</config_adaptive_timestep_include_calving>
 <config_adaptive_timestep_include_face_melting>.true.</config_adaptive_timestep_include_face_melting>
 <config_adaptive_timestep_force_interval>'0000-00-01_00:00:00'</config_adaptive_timestep_force_interval>
+<config_timeaveraging_interval>'0000-00-00_00:00:00'</config_timeaveraging_interval>
 
 <!-- time_management -->
 <config_do_restart>.false.</config_do_restart>

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -145,6 +145,7 @@
 <config_adaptive_timestep_include_face_melting>.true.</config_adaptive_timestep_include_face_melting>
 <config_adaptive_timestep_force_interval>'0000-00-01_00:00:00'</config_adaptive_timestep_force_interval>
 <config_timeaveraging_interval>'0000-00-00_00:00:00'</config_timeaveraging_interval>
+<config_enable_timeAvgRestarts>.false.</config_enable_timeAvgRestarts>
 
 <!-- time_management -->
 <config_do_restart>.false.</config_do_restart>

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
@@ -1073,6 +1073,14 @@ Valid values: Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'. (items in t
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_timeaveraging_interval" type="char*1024"
+	category="time_integration" group="time_integration">
+Interval at which time-averaging accumulators are reset.  If set to a zero interval, then time-averaging accumulators are never reset.  When running in E3SM, the zero interval should be used, because the GLC driver resets the accumulators every coupling interval.
+
+Valid values: Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- time_management -->
 

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_definition_mali.xml
@@ -1081,6 +1081,14 @@ Valid values: Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_enable_timeAvgRestarts" type="logical"
+	category="time_integration" group="time_integration">
+Determines if restart files include time-averaging accumulator state. This should be enabled when the restart stream output_interval is longer than config_timeaveraging_interval.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- time_management -->
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -607,6 +607,10 @@
 		            description="If adaptive timestep is enabled, the model will ensure a timestep ends at multiples of this interval.  This is useful for ensuring that model output is written at a specific desired interval (rather than the closest time after) or when running coupled to an earth system model that expects a certain interval."
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'. (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
 		/>
+		<nml_option name="config_timeaveraging_interval" type="character" default_value="0001-00-00_00:00:00" units="unitless"
+		            description="Interval at which time-averaging accumulators are reset.  If set to a zero interval, then time-averaging accumulators are never reset.  When running in E3SM, the zero interval should be used, because the GLC driver resets the accumulators every coupling interval."
+		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'"
+		/>
 	</nml_record>
 
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -607,7 +607,7 @@
 		            description="If adaptive timestep is enabled, the model will ensure a timestep ends at multiples of this interval.  This is useful for ensuring that model output is written at a specific desired interval (rather than the closest time after) or when running coupled to an earth system model that expects a certain interval."
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'. (items in the format string may be dropped from the left if not needed, and the components on either side of the underscore may be replaced with a single integer representing the rightmost unit)"
 		/>
-		<nml_option name="config_timeaveraging_interval" type="character" default_value="0001-00-00_00:00:00" units="unitless"
+		<nml_option name="config_timeaveraging_interval" type="character" default_value="0000-00-00_00:00:00" units="unitless"
 		            description="Interval at which time-averaging accumulators are reset.  If set to a zero interval, then time-averaging accumulators are never reset.  When running in E3SM, the zero interval should be used, because the GLC driver resets the accumulators every coupling interval."
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'"
 		/>

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1596,7 +1596,7 @@ is the value of that variable from the *previous* time level!
                      description="time averaged negative surface mass balance applied to melting of bare ice (using appliedBareIceAblation from 'geometry' pool)"
                 />
 				<!-- fields for ISMIP reporting not included in the above -->
-				<var name="avgSfcMassBal" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+				<var name="avgSMBFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
 					 description="time averaged applied surface mass balance"
 				/>
 				<var name="avgGroundedBMBFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -611,6 +611,10 @@
 		            description="Interval at which time-averaging accumulators are reset.  If set to a zero interval, then time-averaging accumulators are never reset.  When running in E3SM, the zero interval should be used, because the GLC driver resets the accumulators every coupling interval."
 		            possible_values="Any time interval of the format 'YYYY-MM-DD_HH:MM:SS'"
 		/>
+		<nml_option name="config_enable_timeAvgRestarts" type="logical" default_value=".false." units="unitless"
+		            description="Determines if restart files include time-averaging accumulator state. This should be enabled when the restart stream output_interval is longer than config_timeaveraging_interval."
+		            possible_values=".true. or .false."
+		/>
 	</nml_record>
 
 
@@ -759,6 +763,8 @@
                 <package name="thermal" description="This package includes variables required for the thermal solver."/>
 
                 <package name="extrapOceanData" description="This package includes variables required for extrapolating ocean data into MALI ice shelf cavities." />
+
+		<package name="timeAvgRestarts" description="Variables needed to be included in restart files for time averaging to work correctly"/>
 	</packages>
 
 
@@ -1570,7 +1576,7 @@ is the value of that variable from the *previous* time level!
 <!-- ================ -->
 
         <!-- Variables related to time averaging of fluxes -->
-        <var_struct name="timeAveraging" time_levs="1">
+        <var_struct name="timeAveraging" time_levs="1" packages="timeAvgRestarts">
                 <var name="timeAccumulatedCoupled" type="real" dimensions="Time" units="s"
                      description="accumulated time for use in averaging of coupler fields"
                 />

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -995,16 +995,7 @@
                         <var name="oceanTemperature" packages="extrapOceanData"/>
                         <var name="oceanSalinity" packages="extrapOceanData"/>
                         <!-- time averaging fields for restart -->
-                        <var name="timeAccumulatedCoupled" packages="timeAvgRestarts"/>
-                        <var name="avgCalvingFlux" packages="timeAvgRestarts"/>
-                        <var name="avgFaceMeltFlux" packages="timeAvgRestarts"/>
-                        <var name="avgFloatingBMBFlux" packages="timeAvgRestarts"/>
-                        <var name="avgBareIceAblation" packages="timeAvgRestarts"/>
-                        <var name="avgBareIceAblationApplied" packages="timeAvgRestarts"/>
-                        <var name="avgSMBFlux" packages="timeAvgRestarts"/>
-                        <var name="avgGroundedBMBFlux" packages="timeAvgRestarts"/>
-                        <var name="avgGroundingLineFlux" packages="timeAvgRestarts"/>
-                        <var name="avgDhdt" packages="timeAvgRestarts"/>
+                        <var_struct name="timeAveraging"/>
 		</stream>
 
 

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -1585,6 +1585,19 @@ is the value of that variable from the *previous* time level!
                 <var name="avgBareIceAblationApplied" type="real" dimensions="nCells Time" units="kg m^-2 s^-1" 
                      description="time averaged negative surface mass balance applied to melting of bare ice (using appliedBareIceAblation from 'geometry' pool)"
                 />
+				<!-- fields for ISMIP reporting not included in the above -->
+				<var name="avgSfcMassBal" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+					 description="time averaged applied surface mass balance"
+				/>
+				<var name="avgGroundedBMBFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+					 description="time averaged applied grounded basal mass balance"
+				/>
+				<var name="avgGroundingLineFlux" type="real" dimensions="nCells Time" units="kg m^-2 s^-1"
+					 description="time averaged applied flux across the grounding line"
+				/>
+				<var name="avgDhdt" type="real" dimensions="nCells Time" units="m s^-1"
+					 description="time averaged rate of change of ice thickness"
+				/>
         </var_struct>
 
 <!-- ================ -->

--- a/components/mpas-albany-landice/src/Registry.xml
+++ b/components/mpas-albany-landice/src/Registry.xml
@@ -994,6 +994,17 @@
                         <var name="icebergFjordMask" packages="extrapOceanData"/>
                         <var name="oceanTemperature" packages="extrapOceanData"/>
                         <var name="oceanSalinity" packages="extrapOceanData"/>
+                        <!-- time averaging fields for restart -->
+                        <var name="timeAccumulatedCoupled" packages="timeAvgRestarts"/>
+                        <var name="avgCalvingFlux" packages="timeAvgRestarts"/>
+                        <var name="avgFaceMeltFlux" packages="timeAvgRestarts"/>
+                        <var name="avgFloatingBMBFlux" packages="timeAvgRestarts"/>
+                        <var name="avgBareIceAblation" packages="timeAvgRestarts"/>
+                        <var name="avgBareIceAblationApplied" packages="timeAvgRestarts"/>
+                        <var name="avgSMBFlux" packages="timeAvgRestarts"/>
+                        <var name="avgGroundedBMBFlux" packages="timeAvgRestarts"/>
+                        <var name="avgGroundingLineFlux" packages="timeAvgRestarts"/>
+                        <var name="avgDhdt" packages="timeAvgRestarts"/>
 		</stream>
 
 
@@ -1576,7 +1587,7 @@ is the value of that variable from the *previous* time level!
 <!-- ================ -->
 
         <!-- Variables related to time averaging of fluxes -->
-        <var_struct name="timeAveraging" time_levs="1" packages="timeAvgRestarts">
+        <var_struct name="timeAveraging" time_levs="1">
                 <var name="timeAccumulatedCoupled" type="real" dimensions="Time" units="s"
                      description="accumulated time for use in averaging of coupler fields"
                 />

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -109,17 +109,20 @@ module li_core
       type (MPAS_Time_Type) :: startTime
       integer :: i, err, err_tmp, globalErr
       logical, pointer :: config_do_restart
+      logical, pointer :: config_enable_timeAvgRestarts
       real (kind=RKIND), pointer :: deltat  ! variable in each block
       real (kind=RKIND) :: dtSeconds ! local variable
       type (MPAS_Pool_type), pointer :: meshPool, geometryPool, velocityPool, timeAveragingPool
-      type (MPAS_TimeInterval_type) :: timeStepInterval
+      type (MPAS_TimeInterval_type) :: timeStepInterval, timeAveragingInterval, restartInterval, zeroInterval
       character (len=StrKIND), pointer :: xtime, simulationStartTime
+      character (len=StrKIND), pointer :: config_timeaveraging_interval
       real (kind=RKIND), pointer :: daysSinceStart
       integer, dimension(:), pointer :: cellProcID
       type (MPAS_Time_type) :: xtime_timeType, simulationStartTime_timeType
       type (MPAS_stream_list_type), pointer :: stream_cursor
       type (MPAS_Alarm_type), pointer :: alarm_cursor
       character (len=StrKIND) :: actualWhen
+      integer :: streamErr
 
       err = 0
       err_tmp = 0
@@ -127,12 +130,32 @@ module li_core
 
       call li_config_init(domain % configs)
       call mpas_pool_get_config(domain % configs, 'config_do_restart', config_do_restart)
+      call mpas_pool_get_config(domain % configs, 'config_timeaveraging_interval', config_timeaveraging_interval)
+      call mpas_pool_get_config(domain % configs, 'config_enable_timeAvgRestarts', config_enable_timeAvgRestarts)
 
       !
       ! Initialize config option settings as needed
       !
       call li_setup_config_options( domain, err_tmp )
       err = ior(err, err_tmp)
+
+      ! Validate time-averaging cadence against the runtime restart stream interval.
+      call mpas_set_timeInterval(zeroInterval, dt = 0.0_RKIND, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      call mpas_set_timeInterval(timeAveragingInterval, timeString=config_timeaveraging_interval, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      if (timeAveragingInterval .gt. zeroInterval) then
+         restartInterval = MPAS_stream_mgr_get_stream_interval(domain % streamManager, 'restart', MPAS_STREAM_OUTPUT, streamErr)
+         err = ior(err, streamErr)
+         if (streamErr /= MPAS_STREAM_MGR_NOERR) then
+            call mpas_log_write("Unable to determine restart stream output_interval for time-averaging consistency check.", MPAS_LOG_CRIT)
+            err = ior(err, 1)
+         else if ((restartInterval .gt. timeAveragingInterval) .and. (.not. config_enable_timeAvgRestarts)) then
+            call mpas_log_write("Restart stream output_interval is longer than config_timeaveraging_interval. " // &
+                 "Enable config_enable_timeAvgRestarts=.true. to include time-averaging restart state.", MPAS_LOG_CRIT)
+            err = ior(err, 1)
+         endif
+      endif
 
       if (config_do_restart) then
          call mpas_log_write("This is a restart: read stream 'restart'.")
@@ -1121,7 +1144,7 @@ module li_core
       type (MPAS_TimeInterval_type) :: timeAveragingInterval
       type (MPAS_TimeInterval_type) :: zeroInterval
       character (len=StrKIND), pointer :: config_start_time, config_run_duration, config_stop_time, &
-         config_output_interval, config_restart_interval ! MPAS standard configs
+         config_output_interval ! MPAS standard configs
       character (len=StrKIND), pointer :: config_dt  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_timeaveraging_interval  ! MPAS LI-specific config option
@@ -1217,7 +1240,6 @@ module li_core
       ierr = ior(ierr,err_tmp)
       ! Only set up the alarm if the interval is greater than zero (i.e., if the user specified an interval for this)
       if (timeAveragingInterval .gt. zeroInterval) then
-
          call mpas_add_clock_alarm(core_clock, 'timeAveragingInterval', alarmTime=startTime, &
                  alarmTimeInterval=timeAveragingInterval, ierr=err_tmp)
          ierr = ior(ierr,err_tmp)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -1118,10 +1118,13 @@ module li_core
       type (MPAS_Time_Type) :: startTime, stopTime, alarmStartTime
       type (MPAS_TimeInterval_type) :: runDuration, timeStep, alarmTimeStep
       type (MPAS_TimeInterval_type) :: adaptDtForceInterval
+      type (MPAS_TimeInterval_type) :: timeAveragingInterval
+      type (MPAS_TimeInterval_type) :: zeroInterval
       character (len=StrKIND), pointer :: config_start_time, config_run_duration, config_stop_time, &
          config_output_interval, config_restart_interval ! MPAS standard configs
       character (len=StrKIND), pointer :: config_dt  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_adaptive_timestep_force_interval  ! MPAS LI-specific config option
+      character (len=StrKIND), pointer :: config_timeaveraging_interval  ! MPAS LI-specific config option
       character (len=StrKIND), pointer :: config_restart_timestamp_name
       integer, pointer :: config_slm_coupling_interval
       character (len=StrKIND) :: restartTimeStamp !< string to be read from file
@@ -1142,6 +1145,7 @@ module li_core
       call mpas_pool_get_config(configs, 'config_stop_time', config_stop_time)
       call mpas_pool_get_config(configs, 'config_restart_timestamp_name', config_restart_timestamp_name)
       call mpas_pool_get_config(configs, 'config_adaptive_timestep_force_interval', config_adaptive_timestep_force_interval)
+      call mpas_pool_get_config(configs, 'config_timeaveraging_interval', config_timeaveraging_interval)
       call mpas_pool_get_config(configs, 'config_slm_coupling_interval', config_slm_coupling_interval)
 
 
@@ -1205,6 +1209,25 @@ module li_core
          ierr = ior(ierr, err_tmp)
       endif
       ierr = ior(ierr, err_tmp)
+
+      ! Set up the timeAveragingInterval alarm.
+      call mpas_set_timeInterval(zeroInterval, dt = 0.0_RKIND, ierr=err_tmp)
+      ierr = ior(ierr,err_tmp)
+      call mpas_set_timeInterval(timeAveragingInterval, timeString=config_timeaveraging_interval, ierr=err_tmp)
+      ierr = ior(ierr,err_tmp)
+      ! Only set up the alarm if the interval is greater than zero (i.e., if the user specified an interval for this)
+      if (timeAveragingInterval .gt. zeroInterval) then
+
+         call mpas_add_clock_alarm(core_clock, 'timeAveragingInterval', alarmTime=startTime, &
+                 alarmTimeInterval=timeAveragingInterval, ierr=err_tmp)
+         ierr = ior(ierr,err_tmp)
+         if (mpas_is_alarm_ringing(core_clock, 'timeAveragingInterval', ierr=err_tmp)) then
+            ierr = ior(ierr, err_tmp)
+            call mpas_reset_clock_alarm(core_clock, 'timeAveragingInterval', ierr=err_tmp)
+            ierr = ior(ierr, err_tmp)
+         endif
+         ierr = ior(ierr, err_tmp)
+      endif
 
       ! === error check
       if (ierr /= 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -413,6 +413,7 @@ module li_core
       use li_setup
       use li_statistics
       use li_time_integration
+      use li_time_average_coupled, only: li_time_average_coupled_init
 
       implicit none
 
@@ -442,12 +443,14 @@ module li_core
       !-----------------------------------------------------------------
       integer, pointer :: timestepNumber
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: geometryPool, meshPool
+      type (mpas_pool_type), pointer :: geometryPool, meshPool, timeAveragingPool
       integer, pointer :: config_stats_interval   !< interval (number of timesteps) for writing stats
       character(len=StrKIND), pointer :: config_restart_timestamp_name
       character(len=StrKIND), pointer :: config_velocity_solver
+      character(len=StrKIND), pointer :: config_timeaveraging_interval
       ! Variables needed for printing timestamps
       type (MPAS_Time_Type) :: currTime
+      type (MPAS_TimeInterval_type) :: timeAveragingInterval
       character(len=StrKIND) :: timeStamp
       logical :: isRinging
       integer :: restartTimestampUnit
@@ -463,6 +466,7 @@ module li_core
       call mpas_pool_get_config(liConfigs, 'config_restart_timestamp_name', config_restart_timestamp_name)
       call mpas_pool_get_config(liConfigs, 'config_stats_interval', config_stats_interval)
       call mpas_pool_get_config(liConfigs, 'config_velocity_solver', config_velocity_solver)
+      call mpas_pool_get_config(liConfigs, 'config_timeaveraging_interval', config_timeaveraging_interval)
 
       call mpas_timer_start("land ice core run")
 
@@ -609,6 +613,24 @@ module li_core
          endif
          err = ior(err, err_tmp)
          call mpas_timer_stop("write streams")
+
+         ! === reset time-averaging accmulation if necessary
+         call mpas_set_timeInterval(timeAveragingInterval, timeString=config_timeaveraging_interval, ierr=err_tmp)
+         err = ior(err, err_tmp)
+         if (mpas_is_alarm_ringing(domain % clock, 'timeAveragingInterval', ierr=err_tmp)) then
+            err = ior(err, err_tmp)
+            call mpas_log_write('Resetting coupled time averaging accumulation.')
+            block => domain % blocklist
+            do while (associated(block))
+               call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
+               call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)
+               call li_time_average_coupled_init(meshPool, timeAveragingPool)
+               block => block % next
+            end do
+            call mpas_reset_clock_alarm(domain % clock, 'timeAveragingInterval', ierr=err_tmp)
+            err = ior(err, err_tmp)
+         endif
+         err = ior(err, err_tmp)
 
 
          ! === (end of output section) ===

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core.F
@@ -123,6 +123,8 @@ module li_core
       type (MPAS_Alarm_type), pointer :: alarm_cursor
       character (len=StrKIND) :: actualWhen
       integer :: streamErr
+      integer (kind=I8KIND) :: nIntervals
+      type (MPAS_TimeInterval_type) :: remainder
 
       err = 0
       err_tmp = 0
@@ -154,6 +156,16 @@ module li_core
             call mpas_log_write("Restart stream output_interval is longer than config_timeaveraging_interval. " // &
                  "Enable config_enable_timeAvgRestarts=.true. to include time-averaging restart state.", MPAS_LOG_CRIT)
             err = ior(err, 1)
+         else if (restartInterval .gt. timeAveragingInterval) then
+            startTime = mpas_get_clock_time(domain % clock, MPAS_START_TIME, err_tmp)
+            err = ior(err, err_tmp)
+            call mpas_interval_division(startTime, restartInterval, timeAveragingInterval, nIntervals, remainder)
+            if ((remainder .ne. zeroInterval) .and. (.not. config_enable_timeAvgRestarts)) then
+               call mpas_log_write("Restart stream output_interval is not an even multiple of " // &
+                    "config_timeaveraging_interval. Enable config_enable_timeAvgRestarts=.true. " // &
+                    "to include time-averaging restart state.", MPAS_LOG_CRIT)
+               err = ior(err, 1)
+            endif
          endif
       endif
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_core_interface.F
@@ -109,6 +109,7 @@ module li_core_interface
       logical, pointer :: config_adaptive_timestep_include_DCFL
       logical, pointer :: config_write_albany_ascii_mesh
       logical, pointer :: config_ocean_data_extrapolation
+      logical, pointer :: config_enable_timeAvgRestarts
 
       logical, pointer :: higherOrderVelocityActive
       logical, pointer :: SIAvelocityActive
@@ -118,6 +119,7 @@ module li_core_interface
       logical, pointer :: ismip6GroundedFaceMeltActive
       logical, pointer :: thermalActive
       logical, pointer :: extrapOceanDataActive
+      logical, pointer :: timeAvgRestartsActive
 
       ierr = 0
 
@@ -130,6 +132,7 @@ module li_core_interface
       call mpas_pool_get_config(configPool, 'config_use_3d_thermal_forcing_for_face_melt', config_use_3d_thermal_forcing_for_face_melt)
       call mpas_pool_get_config(configPool, 'config_ocean_data_extrapolation', config_ocean_data_extrapolation)
       call mpas_pool_get_config(configPool, 'config_thermal_solver', config_thermal_solver)
+      call mpas_pool_get_config(configPool, 'config_enable_timeAvgRestarts', config_enable_timeAvgRestarts)
 
       call mpas_pool_get_package(packagePool, 'SIAvelocityActive', SIAvelocityActive)
       call mpas_pool_get_package(packagePool, 'higherOrderVelocityActive', higherOrderVelocityActive)
@@ -139,6 +142,7 @@ module li_core_interface
       call mpas_pool_get_package(packagePool, 'ismip6GroundedFaceMeltActive', ismip6GroundedFaceMeltActive)
       call mpas_pool_get_package(packagePool, 'thermalActive', thermalActive)
       call mpas_pool_get_package(packagePool, 'extrapOceanDataActive', extrapOceanDataActive)
+      call mpas_pool_get_package(packagePool, 'timeAvgRestartsActive', timeAvgRestartsActive)
 
       if (trim(config_velocity_solver) == 'sia') then
          SIAvelocityActive = .true.
@@ -188,6 +192,16 @@ module li_core_interface
          thermalActive = .true.
          call mpas_log_write("The 'thermal' package and assocated variables have been enabled because " // &
               "'config_thermal_solver' is set to either 'temperature' or 'enthalpy'.")
+      endif
+
+      if (config_enable_timeAvgRestarts) then
+         timeAvgRestartsActive = .true.
+         call mpas_log_write("The 'timeAvgRestarts' package and associated variables have been enabled because " // &
+              "'config_enable_timeAvgRestarts' is set to .true.")
+      else
+         timeAvgRestartsActive = .false.
+         call mpas_log_write("The 'timeAvgRestarts' package and associated variables have been disabled because " // &
+              "'config_enable_timeAvgRestarts' is set to .false.")
       endif
 
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -101,7 +101,7 @@ module li_time_integration
       !-----------------------------------------------------------------
       ! Pools pointers
       type (block_type), pointer :: block
-      type (mpas_pool_type), pointer :: meshPool, timeAveragingPool, geometryPool 
+      type (mpas_pool_type), pointer :: meshPool, timeAveragingPool, geometryPool, velocityPool 
       character (len=StrKIND), pointer :: xtime
       real (kind=RKIND), pointer :: daysSinceStart
       character (len=StrKIND), pointer :: simulationStartTime
@@ -183,7 +183,8 @@ module li_time_integration
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-         call li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool)
+         call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
+         call li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool, velocityPool)
          block => block % next
       end do
 

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -175,7 +175,7 @@ module li_time_integration
       end select
       err = ior(err,err_tmp)
 
-      ! === accumulate fluxes for time averaging of fields sent to coupler
+      ! === accumulate fluxes for time averaging of fields sent to coupler or for ismip
       block => domain % blocklist
       do while (associated(block))
          call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -106,13 +106,11 @@ module li_time_integration
       real (kind=RKIND), pointer :: daysSinceStart
       character (len=StrKIND), pointer :: simulationStartTime
       character (len=StrKIND), pointer :: config_time_integration
-      character (len=StrKIND), pointer :: config_timeaveraging_interval
       logical, pointer :: config_adaptive_timestep
       real (kind=RKIND), pointer :: deltat !< the current time step in seconds, on each block
 
       ! Other local variables
       type (MPAS_TimeInterval_type) :: timeStepInterval !< the current time step as an interval
-      type (MPAS_TimeInterval_type) :: timeAveragingInterval
       real (kind=RKIND) :: dtSeconds !< the current time step in seconds, local variable
       type (MPAS_Time_Type) :: currTime  !< current time as time type
       character(len=StrKIND) :: timeStamp !< current time as a string
@@ -125,7 +123,6 @@ module li_time_integration
 
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep', config_adaptive_timestep)
-      call mpas_pool_get_config(liConfigs, 'config_timeaveraging_interval', config_timeaveraging_interval)
 
       currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, err_tmp)
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
@@ -181,29 +178,13 @@ module li_time_integration
       ! === accumulate fluxes for time averaging of fields sent to coupler or for ismip
       block => domain % blocklist
       do while (associated(block))
+         call mpas_pool_get_subpool(block % structs, 'mesh', meshPool)
          call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)
          call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
          call mpas_pool_get_subpool(block % structs, 'velocity', velocityPool)
          call li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool, velocityPool)
          block => block % next
       end do
-
-      ! === reset time-averaging accmulation if necessary
-      call mpas_set_timeInterval(timeAveragingInterval, timeString=config_timeaveraging_interval, ierr=err_tmp)
-      err = ior(err, err_tmp)
-      if (mpas_is_alarm_ringing(domain % clock, 'timeAveragingInterval', ierr=err_tmp)) then
-         err = ior(err, err_tmp)
-         block => domain % blocklist
-         do while (associated(block))
-            call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)
-            call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
-            call li_time_average_coupled_init(meshPool, timeAveragingPool)
-            block => block % next
-         end do
-         call mpas_reset_clock_alarm(domain % clock, 'timeAveragingInterval', ierr=err_tmp)
-         err = ior(err, err_tmp)
-      endif
-      err = ior(err, err_tmp)
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_time_integration.F
@@ -106,11 +106,13 @@ module li_time_integration
       real (kind=RKIND), pointer :: daysSinceStart
       character (len=StrKIND), pointer :: simulationStartTime
       character (len=StrKIND), pointer :: config_time_integration
+      character (len=StrKIND), pointer :: config_timeaveraging_interval
       logical, pointer :: config_adaptive_timestep
       real (kind=RKIND), pointer :: deltat !< the current time step in seconds, on each block
 
       ! Other local variables
       type (MPAS_TimeInterval_type) :: timeStepInterval !< the current time step as an interval
+      type (MPAS_TimeInterval_type) :: timeAveragingInterval
       real (kind=RKIND) :: dtSeconds !< the current time step in seconds, local variable
       type (MPAS_Time_Type) :: currTime  !< current time as time type
       character(len=StrKIND) :: timeStamp !< current time as a string
@@ -123,6 +125,7 @@ module li_time_integration
 
       call mpas_pool_get_config(liConfigs, 'config_time_integration', config_time_integration)
       call mpas_pool_get_config(liConfigs, 'config_adaptive_timestep', config_adaptive_timestep)
+      call mpas_pool_get_config(liConfigs, 'config_timeaveraging_interval', config_timeaveraging_interval)
 
       currTime = mpas_get_clock_time(domain % clock, MPAS_NOW, err_tmp)
       call mpas_get_time(curr_time=currTime, dateTimeString=timeStamp, ierr=err_tmp)
@@ -183,6 +186,23 @@ module li_time_integration
          call li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool)
          block => block % next
       end do
+
+      ! === reset time-averaging accmulation if necessary
+      call mpas_set_timeInterval(timeAveragingInterval, timeString=config_timeaveraging_interval, ierr=err_tmp)
+      err = ior(err, err_tmp)
+      if (mpas_is_alarm_ringing(domain % clock, 'timeAveragingInterval', ierr=err_tmp)) then
+         err = ior(err, err_tmp)
+         block => domain % blocklist
+         do while (associated(block))
+            call mpas_pool_get_subpool(block % structs, 'timeAveraging', timeAveragingPool)
+            call mpas_pool_get_subpool(block % structs, 'geometry', geometryPool)
+            call li_time_average_coupled_init(meshPool, timeAveragingPool)
+            block => block % next
+         end do
+         call mpas_reset_clock_alarm(domain % clock, 'timeAveragingInterval', ierr=err_tmp)
+         err = ior(err, err_tmp)
+      endif
+      err = ior(err, err_tmp)
 
       ! === error check
       if (err > 0) then

--- a/components/mpas-albany-landice/src/shared/mpas_li_time_average_coupled.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_time_average_coupled.F
@@ -53,6 +53,8 @@ module li_time_average_coupled
 
         real (kind=RKIND), dimension(:), pointer :: avgBareIceAblationApplied, avgCalvingFlux, &
                 avgFaceMeltFlux, avgFloatingBMBFlux
+        ! fields for ISMIP reporting not included in the above
+        real (kind=RKIND), dimension(:), pointer :: avgSMBFlux, avgGroundedBMBFlux, avgGroundingLineFlux, avgDhdt
 
         integer, pointer :: nCells
 
@@ -63,16 +65,27 @@ module li_time_average_coupled
         call mpas_pool_get_dimension(meshPool, 'nCells', nCells)
 
         call mpas_pool_get_array(timeAveragingPool, 'timeAccumulatedCoupled', timeAccumulatedCoupled)
+        ! fields for E3SM coupling
         call mpas_pool_get_array(timeAveragingPool, 'avgBareIceAblationApplied', avgBareIceAblationApplied)
         call mpas_pool_get_array(timeAveragingPool, 'avgCalvingFlux', avgCalvingFlux)
         call mpas_pool_get_array(timeAveragingPool, 'avgFaceMeltFlux', avgFaceMeltFlux)
         call mpas_pool_get_array(timeAveragingPool, 'avgFloatingBMBFlux', avgFloatingBMBFlux)
+        ! fields for ISMIP reporting not included in the above
+        call mpas_pool_get_array(timeAveragingPool, 'avgSMBFlux', avgSMBFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgGroundedBMBFlux', avgGroundedBMBFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgGroundingLineFlux', avgGroundingLineFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgDhdt', avgDhdt)
 
         do iCell = 1, nCells
            avgBareIceAblationApplied(iCell) = 0.0_RKIND
            avgCalvingFlux(iCell) = 0.0_RKIND
            avgFaceMeltFlux(iCell) = 0.0_RKIND
            avgFloatingBMBFlux(iCell) = 0.0_RKIND
+           ! fields for ISMIP reporting not included in the above
+           avgSMBFlux(iCell) = 0.0_RKIND
+           avgGroundedBMBFlux(iCell) = 0.0_RKIND
+           avgGroundingLineFlux(iCell) = 0.0_RKIND
+           avgDhdt(iCell) = 0.0_RKIND
         end do
 
         timeAccumulatedCoupled = 0.0_RKIND
@@ -102,6 +115,10 @@ module li_time_average_coupled
                                                     calvingThickness, avgCalvingFlux, &
                                                     faceMeltingThickness, avgFaceMeltFlux, avgFloatingBMBFlux, &
                                                     floatingBasalMassBalApplied
+        ! fields for ISMIP reporting not included in the above
+        real (kind=RKIND), dimension(:), pointer :: avgSMBFlux, avgGroundedBMBFlux, avgGroundingLineFlux, avgDhdt
+        real (kind=RKIND), dimension(:), pointer :: sfcMassBalApplied, groundedBasalMassBalApplied, &
+                                                    fluxAcrossGroundingLineOnCells, dHdt
         integer, pointer :: nCells
 
         real (kind=RKIND), pointer :: timeAccumulatedCoupled, rhoi, deltat
@@ -120,6 +137,15 @@ module li_time_average_coupled
         call mpas_pool_get_array(timeAveragingPool, 'avgCalvingFlux', avgCalvingFlux)
         call mpas_pool_get_array(timeAveragingPool, 'avgFaceMeltFlux', avgFaceMeltFlux)
         call mpas_pool_get_array(timeAveragingPool, 'avgFloatingBMBFlux', avgFloatingBMBFlux)
+        ! fields for ISMIP reporting not included in the above
+        call mpas_pool_get_array(timeAveragingPool, 'avgSMBFlux', avgSMBFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgGroundedBMBFlux', avgGroundedBMBFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgGroundingLineFlux', avgGroundingLineFlux)
+        call mpas_pool_get_array(timeAveragingPool, 'avgDhdt', avgDhdt)
+        call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
+        call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
+        call mpas_pool_get_array(geometryPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
+        call mpas_pool_get_array(geometryPool, 'dHdt', dHdt)
 
         do iCell = 1, nCells
 
@@ -134,6 +160,20 @@ module li_time_average_coupled
                                         
            avgFloatingBMBFlux(iCell) = ( avgFloatingBMBFlux(iCell) * timeAccumulatedCoupled &
                                                 + floatingBasalMassBalApplied(iCell) * deltat) / ( timeAccumulatedCoupled + deltat )
+
+           ! fields for ISMIP reporting not included in the above
+           avgSMBFlux(iCell) = ( avgSMBFlux(iCell) * timeAccumulatedCoupled &
+                                                + sfcMassBalApplied(iCell) * deltat) / ( timeAccumulatedCoupled + deltat )
+
+           avgGroundedBMBFlux(iCell) = ( avgGroundedBMBFlux(iCell) * timeAccumulatedCoupled &
+                                                + groundedBasalMassBalApplied(iCell) * deltat) / ( timeAccumulatedCoupled + deltat )
+
+           avgGroundingLineFlux(iCell) = ( avgGroundingLineFlux(iCell) * timeAccumulatedCoupled &
+                                                + fluxAcrossGroundingLineOnCells(iCell) * deltat) / ( timeAccumulatedCoupled + deltat )
+
+           avgDhdt(iCell) = ( avgDhdt(iCell) * timeAccumulatedCoupled &
+                                                + dHdt(iCell) * deltat) / ( timeAccumulatedCoupled + deltat )
+
         end do
 
         timeAccumulatedCoupled = timeAccumulatedCoupled + deltat

--- a/components/mpas-albany-landice/src/shared/mpas_li_time_average_coupled.F
+++ b/components/mpas-albany-landice/src/shared/mpas_li_time_average_coupled.F
@@ -103,13 +103,14 @@ module li_time_average_coupled
 !>  This routine accumulates the coupled time averaging fields
 !
 !-----------------------------------------------------------------------
-    subroutine li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool)
+    subroutine li_time_average_coupled_accumulate(timeAveragingPool, geometryPool, meshPool, velocityPool)
             
         use li_setup 
 
         type (mpas_pool_type), intent(inout) :: timeAveragingPool
         type (mpas_pool_type), intent(in) :: geometryPool
         type (mpas_pool_type), intent(in) :: meshPool
+        type (mpas_pool_type), intent(in) :: velocityPool
 
         real (kind=RKIND), dimension(:), pointer :: bareIceAblationApplied, avgBareIceAblationApplied, &
                                                     calvingThickness, avgCalvingFlux, &
@@ -144,7 +145,7 @@ module li_time_average_coupled
         call mpas_pool_get_array(timeAveragingPool, 'avgDhdt', avgDhdt)
         call mpas_pool_get_array(geometryPool, 'sfcMassBalApplied', sfcMassBalApplied)
         call mpas_pool_get_array(geometryPool, 'groundedBasalMassBalApplied', groundedBasalMassBalApplied)
-        call mpas_pool_get_array(geometryPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
+        call mpas_pool_get_array(velocityPool, 'fluxAcrossGroundingLineOnCells', fluxAcrossGroundingLineOnCells)
         call mpas_pool_get_array(geometryPool, 'dHdt', dHdt)
 
         do iCell = 1, nCells


### PR DESCRIPTION
This merge adds the additional time-averaged flux fields required by ISMIP by utilizing the existing time averaging machinery for coupler fields.  There is an option to control the time-averaging period.  And a check if the time-averaging fields need to be included as restart variables, and a way to manually enable that (not possible to automate).

Usage cases:
* In E3SM, the coupler handles the resetting of the time averaging interval.  Set `config_timeaveraging_interval='0000-00-00_00:00:00'`, and the time averaging will be done per coupling interval by the GLC driver, as before.
* In standalone MALI, for ISMIP7, config_timeaveraging_interval would be set to 1 year.  If the restart output interval is shorter than 1 year, the time-averaging fields need to be added to the restart stream.  Because that is a lot of additional fields, and they are not always needed, the time-averaging fields are not in the restart stream by default.  They can be added with `config_enable_timeAvgRestarts=.true.`.  There was not an easy way to make this logic be handled automatically.  But if a run is attempted where this needs to be true and it isn't, the run will die with a helpful error.
* In standalone MALI, if time-averaged flux fields are desired at intervals of less than the restart output interval, and the time-averaging interval divides evenly into the restart output interval, it is not necessary to include the time-averaging fields in the restart stream (but it's ok if they are included anyway).
* Because the restart stream issue could potentially abort a run, the config_timeaveraging_interval is set to the zero interval by default, meaning the accumulators are never reset.

A few areas ways that the current implementation could be improved, but was beyond the time constraints of this PR:
* The time-averaging fields are modified every time step as part of accumulation and therefore have misleading values at times prior to the full time-averaging interval.  (They will be the ongoing time average since the last reset.)  There is not a check or control that they are only written out at the full interval, so the user needs to understand how to set the stream and the time-averaging interval consistently.
* Time-averaging calculations are always happening even when the time averaging interval is set to 0 - there is no way to turn it off.  This was the case prior to this PR but was not fixed in this PR.
* The additional ISMIP-required variables are always calculated even in coupled E3SM applications, and the E3SM coupling variables are always calculated, even in standalone applications.  There is significant overlap between the two, and I considered adding flags to handle the two cases more cleanly, but decided that was unnecessary complexity.  The additional calculations are not much expense.  And truly handling both cases cleanly and more flexibly should probably be done with a more robust time-averaging system like the ocean has (where time-averaging can be occurring over multiple time periods at once, restarts are handled gracefully, etc.).  Given the current implementation is not going to be full featured, I opted to keep it as simple as necessary for immediate needs only.