### PR TITLE
Check for negative values in `surfaceElevationRef`

### DIFF
--- a/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
+++ b/components/mpas-albany-landice/src/mode_forward/mpas_li_advection.F
@@ -1160,6 +1160,12 @@ module li_advection
          surfaceAirTemperatureApplied(:) = surfaceAirTemperature(:)
 
          if (config_apply_smb_sat_lapse_rate) then
+            if (minval(surfaceElevationRef(:)) < 0.0_RKIND) then
+               call mpas_log_write('surfaceElevationRef contains negative values. ' // &
+                  'All values must be >= 0.', MPAS_LOG_CRIT)
+               err = 1
+               return
+            endif
             sfcMassBalGradientCorrection(:) = sfcMassBalLapseRate(:) * (upperSurface(:) - surfaceElevationRef(:))
 
             surfaceAirTemperatureApplied(:) = surfaceAirTemperatureApplied(:) + &


### PR DESCRIPTION
Throw an error if `surfaceElevationRef < 0` anywhere. If that field is created incorrectly — for instance by taking upperSurface from a previous MALI run, which would include seafloor elevations outside the ice mask — it could lead to enormous errors in surface mass balance when applying the lapse rate.